### PR TITLE
Fixes for using system libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,13 +40,13 @@ set(libswiftnav_SRCS
 
 add_library(swiftnav-static STATIC ${libswiftnav_SRCS})
 target_link_libraries(swiftnav-static cblas)
-target_link_libraries(swiftnav-static lapacke)
+target_link_libraries(swiftnav-static lapacke lapack)
 install(TARGETS swiftnav-static DESTINATION lib${LIB_SUFFIX})
 
 if(BUILD_SHARED_LIBS)
   add_library(swiftnav SHARED ${libswiftnav_SRCS})
   target_link_libraries(swiftnav cblas)
-  target_link_libraries(swiftnav lapacke)
+  target_link_libraries(swiftnav lapacke lapack)
   install(TARGETS swiftnav DESTINATION lib${LIB_SUFFIX})
 else(BUILD_SHARED_LIBS)
   message(STATUS "Not building shared libraries")

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <cblas.h>
 #include <clapack.h>
+#include <f2c.h>
 // #include <lapacke.h>
 #include <math.h>
 #include <linear_algebra.h>

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -12,6 +12,7 @@
 
 #include <clapack.h>
 #include <cblas.h>
+#include <f2c.h>
 #include <stdio.h>
 #include <string.h>
 #include "ambiguity_test.h"

--- a/src/float_kf.c
+++ b/src/float_kf.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <cblas.h>
 #include <clapack.h>
+#include <f2c.h>
 #include <math.h>
 #include <linear_algebra.h>
 #include "constants.h"


### PR DESCRIPTION
I found these errors while compiling `libswiftnav` against my system libraries instead of the bundled ones.

First, both `libswiftnav.so` and `liblapacke.so` reference symbols from `liblapack.so`, it just doesn't cause an error until you try to link an executable against `libswiftnav.so`.

Second, `f2c.h` is not necessarily included by `clapack`, so explicitly including `f2c.h` whenever using definitions from it (ie the `integer` type) is necessary.

Thanks!