### PR TITLE
Minor fixes required for compiling on MinGW-w64.

### DIFF
--- a/clapack-3.2.1-CMAKE/CMakeLists.txt
+++ b/clapack-3.2.1-CMAKE/CMakeLists.txt
@@ -8,6 +8,11 @@ if (NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
+if( WIN32 )
+  set(CMAKE_C_FLAGS "-DUSE_CLOCK")
+  # So USE_CLOCK is defined and headers Windows doesn't have aren't included.
+endif ()
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/INCLUDE)
 # Oh dear, f2c what are you doing?
 set(F2C_FAIL_FLAGS "-Wno-parentheses -Wno-unused-parameter -Wno-sign-compare -Wno-implicit-function-declaration -Wno-strict-prototypes -Wno-unused-but-set-variable -Wno-unused-variable -Wno-format -Wno-format-security -Wno-uninitialized -Wno-self-assign")

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -21,6 +21,10 @@
 #include <assert.h>
 #include <cblas.h>
 #include <clapack.h>
+#ifdef __WIN32
+  /*Avoid error of this being redefined in math.h*/
+  #undef abs
+#endif
 #include <math.h>
 #include <linear_algebra.h>
 #include "constants.h"

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -12,6 +12,10 @@
 
 #include <assert.h>
 #include <clapack.h>
+#ifdef __WIN32
+  /*Avoid error of this being redefined in math.h*/
+  #undef abs
+#endif
 #include <inttypes.h>
 #include <cblas.h>
 #include <stdio.h>


### PR DESCRIPTION
Hi,

My arm was twisted to try and get our project on Windows, part of it is libswiftnav, which I see can only be compiled with MinGW (well it had to be MinGW-w64 as much was already compiled 64bit), but I found I had to do some minor fixes. Here's the patch.

Joe