### PR TITLE
Changed the sign on the carrier phase + code observations, and some cleanup

### DIFF
--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -35,6 +35,7 @@ typedef struct {
   double state_cov_D[MAX_STATE_DIM];
 } nkf_t;
 
+double simple_amb_measurement(double carrier, double code);
 // void predict_forward(nkf_t *kf);
 void nkf_update(nkf_t *kf, double *measurements);
 

--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -46,7 +46,7 @@ void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var,
             u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double *dd_measurements, double ref_ecef[3]);
 void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
                      u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double ref_ecef[3]);
-s32 find_index_of_element_in_u8s(u32 num_elements, u8 x, u8 *list);
+s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list);
 void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns);
 
 void nkf_state_projection(nkf_t *kf,
@@ -67,8 +67,8 @@ void least_squares_solve_b_external_ambs(u8 num_dds, const double *ambs,
          const sdiff_t *sdiffs_with_ref_first, const double *dd_measurements,
          const double ref_ecef[3], double b[3]);
 
-void rebase_mean_N(double *mean, u8 num_sats, u8 *old_prns, u8 *new_prns);
-void rebase_covariance_sigma(double *state_cov, u8 num_sats, u8 *old_prns, u8 *new_prns);
+void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
+void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
 
 #endif /* LIBSWIFTNAV_AMBFLOAT_KF_H */
 

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -79,8 +79,8 @@ void create_empty_ambiguity_test(ambiguity_test_t *amb_test);
 void create_ambiguity_test(ambiguity_test_t *amb_test);
 void reset_ambiguity_test(ambiguity_test_t *amb_test);
 void destroy_ambiguity_test(ambiguity_test_t *amb_test);
-s8 sats_match(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs);
-u8 ambiguity_update_reference(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
+s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs);
+u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 void update_ambiguity_test(double ref_ecef[3], double phase_var, double code_var,
                            ambiguity_test_t *amb_test, u8 state_dim, sdiff_t *sdiffs,
                            u8 changed_sats);
@@ -89,9 +89,13 @@ u32 ambiguity_test_n_hypotheses(ambiguity_test_t *amb_test);
 u8 ambiguity_test_pool_contains(ambiguity_test_t *amb_test, double *ambs);
 void ambiguity_test_MLE_ambs(ambiguity_test_t *amb_test, s32 *ambs);
 void test_ambiguities(ambiguity_test_t *amb_test, double *ambiguity_dd_measurements);
-u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
-                         sats_management_t *float_sats, double *float_mean, double *float_cov_U, double *float_cov_D);
-u8 find_indices_of_intersection_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs);
+u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
+                         const sdiff_t *sdiffs, const sats_management_t *float_sats,
+                         const double *float_mean, const double *float_cov_U,
+                         const double *float_cov_D);
+// u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
+//                          sats_management_t *float_sats, double *float_mean, double *float_cov_U, double *float_cov_D);
+u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs);
 u8 ambiguity_iar_can_solve(ambiguity_test_t *ambiguity_test);
 s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
                                    u8 num_sdiffs, sdiff_t *sdiffs,
@@ -104,14 +108,14 @@ s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_
 s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
                                    u8 num_sdiffs, sdiff_t *sdiffs,
                                    double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs);
-u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, u8 num_dds_in_intersection, u8 *dd_intersection_ndxs);
+u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection, const u8 *dd_intersection_ndxs);
 // TODO(dsk) delete
 u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_intersection,
                                sats_management_t *float_sats, double *float_mean,
                                double *float_cov_U, double *float_cov_D);
-u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, u8 num_dds_in_intersection,
-                            sats_management_t *float_sats, double *float_mean,
-                            double *float_cov_U, double *float_cov_D);
+u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection,
+                            const sats_management_t *float_sats, const double *float_mean,
+                            const double *float_cov_U, const double *float_cov_D);
 u32 float_to_decor(const double *addible_float_cov,
                    const double *addible_float_mean,
                    u8 num_addible_dds,

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -93,8 +93,6 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
                          const sdiff_t *sdiffs, const sats_management_t *float_sats,
                          const double *float_mean, const double *float_cov_U,
                          const double *float_cov_D);
-// u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
-//                          sats_management_t *float_sats, double *float_mean, double *float_cov_U, double *float_cov_D);
 u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs);
 u8 ambiguity_iar_can_solve(ambiguity_test_t *ambiguity_test);
 s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,

--- a/include/libswiftnav/linear_algebra.h
+++ b/include/libswiftnav/linear_algebra.h
@@ -53,7 +53,7 @@ void matrix_multiply_i(u32 n, u32 m, u32 p, const s32 *a,
 void matrix_triu(u32 n, double *M);
 void matrix_eye(u32 n, double *M);
 void matrix_udu(u32 n, double *M, double *U, double *D);
-void matrix_reconstruct_udu(u32 n, double *U, double *D, double *M);
+void matrix_reconstruct_udu(const u32 n, const double *U, const double *D, double *M);
 void matrix_add_sc(u32 n, u32 m, const double *a,
                    const double *b, double gamma, double *c);
 void matrix_transpose(u32 n, u32 m, const double *a, double *b);

--- a/include/libswiftnav/sats_management.h
+++ b/include/libswiftnav/sats_management.h
@@ -31,11 +31,11 @@ typedef struct {
 } sats_management_t;
 
 void init_sats_management(sats_management_t *sats_management,
-                          u8 num_sats, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
+                          const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 void print_sats_management(sats_management_t *sats_management);
 void print_sats_management_short(sats_management_t *sats_management);
 s8 rebase_sats_management(sats_management_t *sats_management,
-                          u8 num_sats, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
+                          const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, sdiff_t *non_ref_sdiffs);
 
 void set_reference_sat_of_prns(u8 ref_prn, u8 num_sats, u8 *prns);

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -199,7 +199,7 @@ void make_residual_measurements(nkf_t *kf, double *measurements, double *resid_m
                measurements, 1, /*  X, incX. */
                0, resid_measurements, 1); /*  beta, Y, incY. */
   for (u8 i=0; i< kf->state_dim; i++) {
-    resid_measurements[i+constraint_dim] = measurements[i] - measurements[i+kf->state_dim] / GPS_L1_LAMBDA_NO_VAC;
+    resid_measurements[i+constraint_dim] = measurements[i] + measurements[i+kf->state_dim] / GPS_L1_LAMBDA_NO_VAC;
   }
 }
 
@@ -445,8 +445,8 @@ void initialize_state(nkf_t *kf, double *dd_measurements, double init_var)
 {
   u8 num_dds = kf->state_dim;
   for (u32 i=0; i<num_dds; i++) {
-    /*  N = Expectation of [phi - rho / lambda]. */
-    kf->state_mean[i] = dd_measurements[i] - dd_measurements[i + num_dds] / GPS_L1_LAMBDA_NO_VAC;
+    /*  N = Expectation of [ phi + rho / lambda]. */
+    kf->state_mean[i] = dd_measurements[i] + dd_measurements[i + num_dds] / GPS_L1_LAMBDA_NO_VAC;
     /*  Sigma begins as a diagonal. */
     kf->state_cov_D[i] = init_var;
   }

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -710,7 +710,7 @@ void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
                   kf->decor_obs_mtx);
 }
 
-s32 find_index_of_element_in_u8s(u32 num_elements, u8 x, u8 *list)
+s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list)
 {
   for (u32 i=0; i<num_elements; i++) {
     if (x == list[i]) {
@@ -721,7 +721,7 @@ s32 find_index_of_element_in_u8s(u32 num_elements, u8 x, u8 *list)
 }
 
 /* REQUIRES num_sats > 1 */
-void rebase_mean_N(double *mean, u8 num_sats, u8 *old_prns, u8 *new_prns)
+void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
@@ -746,7 +746,7 @@ void rebase_mean_N(double *mean, u8 num_sats, u8 *old_prns, u8 *new_prns)
 }
 
 /* REQUIRES num_sats > 1 */
-void assign_state_rebase_mtx(u8 num_sats, u8 *old_prns, u8 *new_prns, double *rebase_mtx)
+void assign_state_rebase_mtx(const u8 num_sats, const u8 *old_prns, const u8 *new_prns, double *rebase_mtx)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
@@ -767,7 +767,7 @@ void assign_state_rebase_mtx(u8 num_sats, u8 *old_prns, u8 *new_prns, double *re
 }
 
 /* REQUIRES num_sats > 1 */
-void rebase_covariance_sigma(double *state_cov, u8 num_sats, u8 *old_prns, u8 *new_prns)
+void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -1619,6 +1619,7 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
                 float_sats, float_mean, float_cov_U, float_cov_D);
     if (incl == 2) {
       create_ambiguity_test(amb_test);
+      changed_sats = 1;
     } else if (incl == 1) {
       changed_sats = 1;
     }

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -668,7 +668,7 @@ s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_
 }
 
 
-s8 sats_match(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs)
+s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs)
 {
   if (DEBUG_AMBIGUITY_TEST) {
     printf("<SATS_MATCH>\namb_test.sats.prns = {");
@@ -687,8 +687,8 @@ s8 sats_match(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs)
     }
     return 0;
   }
-  u8 *prns = amb_test->sats.prns;
-  u8 amb_ref = amb_test->sats.prns[0];
+  const u8 *prns = amb_test->sats.prns;
+  const u8 amb_ref = amb_test->sats.prns[0];
   u8 j=0;
   for (u8 i = 1; i<amb_test->sats.num_sats; i++) { //TODO will not having a j condition cause le fault du seg?
     if (j >= num_sdiffs) {
@@ -751,7 +751,7 @@ void rebase_hypothesis(void *arg, element_t *elem) //TODO make it so it doesn't 
   memcpy(hypothesis->N, new_N, (num_sats-1) * sizeof(s32));
 }
 
-u8 ambiguity_update_reference(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   if (DEBUG_AMBIGUITY_TEST) {
     printf("<AMBIGUITY_UPDATE_REFERENCE>\n");
@@ -833,7 +833,7 @@ void projection_aggregator(element_t *new_, void *x_, u32 n, element_t *elem_)
 
 }
 
-u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, u8 num_dds_in_intersection, u8 *dd_intersection_ndxs)
+u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection, const u8 *dd_intersection_ndxs)
 {
   if (DEBUG_AMBIGUITY_TEST) {
     printf("<AMBIGUITY_SAT_PROJECTION>\n");
@@ -1198,9 +1198,9 @@ static u8 inclusion_loop_body(
   return 0;
 }
 
-u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, u8 num_dds_in_intersection,
-                           sats_management_t *float_sats, double *float_mean,
-                           double *float_cov_U, double *float_cov_D)
+u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection,
+                           const sats_management_t *float_sats, const double *float_mean,
+                           const double *float_cov_U, const double *float_cov_D)
 {
   if (float_sats->num_sats <= num_dds_in_intersection + 1 || float_sats->num_sats < 2) {
     /* Nothing added. */
@@ -1550,9 +1550,23 @@ s8 determine_sats_addition(ambiguity_test_t *amb_test,
  * INVALIDATES unanimous ambiguities
  * ^ TODO record this in the amb_test state?
  */
-u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
-                         sats_management_t *float_sats, double *float_mean,
-                         double *float_cov_U, double *float_cov_D)
+/** Add/drop satellites from the ambiguity test, changing reference if needed.
+ * INVALIDATES unanimous ambiguities
+ * \param amb_test    An ambiguity test whose tests to update.
+ * \param num_sdiffs  The length of the sdiffs array.
+ * \param sdiffs      The single differenced observations. Sorted by PRN.
+ * \param float_sats  The satellites to correspond to the KF mean and cov.
+ * \param float_mean  The KF state estimate.
+ * \param float_cov_U The KF state estimate covariance U in UDU decomposiiton.
+ * \param float_cov_D The KF state estimate covariance D in UDU decomposiiton.
+ * \return  0 if we didn't change the sats
+ *          1 if we did change the sats
+ *          2 if we need to reset IAR TODO maybe do that in here?
+ */
+u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
+                         const sdiff_t *sdiffs, const sats_management_t *float_sats,
+                         const double *float_mean, const double *float_cov_U,
+                         const double *float_cov_D)
 {
   if (DEBUG_AMBIGUITY_TEST) {
     printf("<AMBIGUITY_UPDATE_SATS>\n");
@@ -1600,7 +1614,7 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdi
   /* TODO: Should we order by 'goodness'? Perhaps by volume of hyps? */
 }
 
-u8 find_indices_of_intersection_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs)
+u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs)
 {
   if (DEBUG_AMBIGUITY_TEST) {
     printf("<FIND_INDICES_OF_INTERSECTION_SATS>\n");

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -2035,7 +2035,9 @@ void assign_r_vec(residual_mtxs_t *res_mtxs, u8 num_dds, double *dd_measurements
               dd_measurements, 1,
               0, r_vec, 1);
   for (u8 i=0; i< num_dds; i++) {
-    r_vec[i + res_mtxs->null_space_dim] = dd_measurements[i] + dd_measurements[i+num_dds] / GPS_L1_LAMBDA_NO_VAC;
+    r_vec[i + res_mtxs->null_space_dim] =
+      simple_amb_measurement(dd_measurements[i],
+                             dd_measurements[i+num_dds]);
   }
 }
 

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -311,7 +311,7 @@ s8 update_and_get_max_ll(void *x_, element_t *elem) {
   double q = get_quadratic_term(x->res_mtxs, x->num_dds, hypothesis_N, x->r_vec);
   hyp->ll += q;
   x->max_ll = MAX(x->max_ll, hyp->ll);
-  return (abs(q) < SINGLE_OBS_CHISQ_THRESHOLD); 
+  return (abs(q) < SINGLE_OBS_CHISQ_THRESHOLD);
   /* Doesn't appear to need a dependence on d.o.f. to be effective.
    * We should revisit SINGLE_OBS_CHISQ_THRESHOLD when our noise model is tighter. */
 }
@@ -532,12 +532,12 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
     }
     else if (non_ref_prns[i] > sdiffs[j].prn) {
       /* If both sets are ordered, and we increase j (and possibly i), and the
-       * i prn is higher than the j one, it means that the i one might be in the 
+       * i prn is higher than the j one, it means that the i one might be in the
        * j set for higher j, and that the current j prn isn't in the i set. */
       j++;
     } else {
       /* if both sets are ordered, and we increase j (and possibly i), and the
-       * j prn is higher than the i one, it means that the j one might be in the 
+       * j prn is higher than the i one, it means that the j one might be in the
        * i set for higher i, and that the current i prn isn't in the j set.
        * This means a sat in the IAR's sdiffs isn't in the sdiffs.
        * */
@@ -1106,7 +1106,7 @@ void add_sats(ambiguity_test_t *amb_test,
 }
 
 
-/* 
+/*
  * The satellite inclusion algorithm considers three important vector spaces:
  *  - The correlated space of integer ambiguities considered by the float filter (V0)
  *  - The decorrelated space of all integer ambiguities (V1)
@@ -1558,7 +1558,6 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdi
     printf("<AMBIGUITY_UPDATE_SATS>\n");
   }
   if (num_sdiffs < 2) {
-    printf("3\n");
     create_ambiguity_test(amb_test);
     if (DEBUG_AMBIGUITY_TEST) {
       printf("< 2 sdiffs, starting over\n</AMBIGUITY_UPDATE_SATS>\n");
@@ -1581,8 +1580,7 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdi
     u8 num_dds_in_intersection = find_indices_of_intersection_sats(amb_test, num_sdiffs, sdiffs_with_ref_first, intersection_ndxs);
 
     if (amb_test->sats.num_sats > 1 && num_dds_in_intersection == 0) {
-      printf("1\n");
-      create_ambiguity_test(amb_test); 
+      create_ambiguity_test(amb_test);
     }
 
     // u8 num_dds_in_intersection = ambiguity_order_sdiffs_with_intersection(amb_test, sdiffs, float_cov, intersection_ndxs);

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -1540,18 +1540,9 @@ s8 determine_sats_addition(ambiguity_test_t *amb_test,
   return -1;
 }
 
-/* input/output: amb_test
- * input:        num_sdiffs
- * input:        sdiffs
- * input:        float_sats
- * input:        float_mean
- * input:        float_cov_U
- * input:        float_cov_D
- * INVALIDATES unanimous ambiguities
- * ^ TODO record this in the amb_test state?
- */
 /** Add/drop satellites from the ambiguity test, changing reference if needed.
  * INVALIDATES unanimous ambiguities
+ * ^ TODO record this in the amb_test state?
  * \param amb_test    An ambiguity test whose tests to update.
  * \param num_sdiffs  The length of the sdiffs array.
  * \param sdiffs      The single differenced observations. Sorted by PRN.

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -2006,7 +2006,7 @@ void assign_r_vec(residual_mtxs_t *res_mtxs, u8 num_dds, double *dd_measurements
               dd_measurements, 1,
               0, r_vec, 1);
   for (u8 i=0; i< num_dds; i++) {
-    r_vec[i + res_mtxs->null_space_dim] = dd_measurements[i] - dd_measurements[i+num_dds] / GPS_L1_LAMBDA_NO_VAC;
+    r_vec[i + res_mtxs->null_space_dim] = dd_measurements[i] + dd_measurements[i+num_dds] / GPS_L1_LAMBDA_NO_VAC;
   }
 }
 

--- a/src/linear_algebra.c
+++ b/src/linear_algebra.c
@@ -899,7 +899,7 @@ void matrix_udu(u32 n, double *M, double *U, double *D)
  * \param D Pointer to the diagonal vector.
  * \param M Pointer to the output matrix.
  */
-void matrix_reconstruct_udu(u32 n, double *U, double *D, double *M)
+void matrix_reconstruct_udu(const u32 n, const double *U, const double *D, double *M)
 {
   memset(M, 0, n * n * sizeof(double));
   /* TODO: M will be symmetric, only need to bother populating part of it */

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -19,7 +19,7 @@
 
 #define DEBUG_SATS_MAN 0
 
-u8 choose_reference_sat(u8 num_sats, sdiff_t *sats)
+u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats)
 {
   double best_snr=sats[0].snr;
   u8 best_prn=sats[0].prn;
@@ -44,7 +44,7 @@ u8 choose_reference_sat(u8 num_sats, sdiff_t *sats)
 // }
 
 //assumes both sets are ordered
-u8 intersect_sats(u8 num_sats1, u8 num_sdiffs, u8 *sats1, sdiff_t *sdiffs,
+u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats1, const sdiff_t *sdiffs,
                   sdiff_t *intersection_sats)
 {
   u8 i, j, n = 0;
@@ -118,7 +118,7 @@ u8 intersect_sats(u8 num_sats1, u8 num_sdiffs, u8 *sats1, sdiff_t *sdiffs,
 
 /** Puts sdiffs into sdiffs_with_ref_first with the sdiff for ref_prn first
  */
-void set_reference_sat_of_prns(u8 ref_prn, u8 num_sats, u8 *prns)
+void set_reference_sat_of_prns(const u8 ref_prn, const u8 num_sats, u8 *prns)
 {
   u8 old_ref = prns[0];
   u8 j;
@@ -151,9 +151,9 @@ void set_reference_sat_of_prns(u8 ref_prn, u8 num_sats, u8 *prns)
 
 /** Puts sdiffs into sdiffs_with_ref_first with the sdiff for ref_prn first, while updating sats_management
  */
-void set_reference_sat(u8 ref_prn, sats_management_t *sats_management,
-                          u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
-{  
+void set_reference_sat(const u8 ref_prn, sats_management_t *sats_management,
+                       const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+{
   u8 old_ref = sats_management->prns[0];
   if (DEBUG_SATS_MAN) {
     printf("<SET_REFERENCE_SAT>\n");
@@ -205,8 +205,8 @@ void set_reference_sat(u8 ref_prn, sats_management_t *sats_management,
   }
 }
 
-void set_reference_sat_and_prns(u8 ref_prn, sats_management_t *sats_management,
-                                u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+void set_reference_sat_and_prns(const u8 ref_prn, sats_management_t *sats_management,
+                                const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   sats_management->num_sats = num_sdiffs;
   sats_management->prns[0] = ref_prn;
@@ -227,7 +227,7 @@ void set_reference_sat_and_prns(u8 ref_prn, sats_management_t *sats_management,
 }
 
 void init_sats_management(sats_management_t *sats_management,
-                          u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+                          const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   if (DEBUG_SATS_MAN) {
     printf("<INIT_SATS_MANAGEMENT>\n");
@@ -269,7 +269,7 @@ void print_sats_management_short(sats_management_t *sats_man) {
 /** Updates sats to the new measurements' sat set
  */
 s8 rebase_sats_management(sats_management_t *sats_management,
-                          u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+                          const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   s8 return_code;
   u8 ref_prn;
@@ -309,7 +309,6 @@ s8 rebase_sats_management(sats_management_t *sats_management,
           printf("%u, ", sats_management->prns[so_fetch]);
         }
         printf("}\n");
-        
         printf("num intersect_sats= %u\nintersection= {", num_intersection);
         for (u8 bork=0; bork<num_intersection; bork++) {
           printf("%u, ", intersection_sats[bork].prn);


### PR DESCRIPTION
We were thinking that E[code - carrier] == N. We were wrong about the sign on the carrier phase, so now we're using E[code + carrier] == N. It works much better.

With a new accurate Kalman filter, we have trouble when it's state estimates drift away from the hypotheses generated for the ambiguity test. The KF and amb test may disagree. I made the ambiguity test restart when they disagree too much (when they have a null intersection).

I also did some code cleanup, documentation, and made stuff const that should be const.