### PR TITLE
No longer trying to add sats when there aren't enough to get 4 DDs minimum

### DIFF
--- a/include/libswiftnav/single_diff.h
+++ b/include/libswiftnav/single_diff.h
@@ -49,7 +49,7 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
 
 void almanacs_to_single_diffs(u8 n, almanac_t *alms, gps_time_t timestamp, sdiff_t *sdiffs);
 
-s8 copy_sdiffs_put_ref_first(u8 ref_prn, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
+s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 
 u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop, u8 *sats_to_drop);
 

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -1235,8 +1235,10 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
                            const sats_management_t *float_sats, const double *float_mean,
                            const double *float_cov_U, const double *float_cov_D)
 {
-  if (float_sats->num_sats <= num_dds_in_intersection + 1 || float_sats->num_sats < 2) {
-    /* Nothing added. */
+  if (float_sats->num_sats <= num_dds_in_intersection + 1 || float_sats->num_sats < 5) {
+    /* Nothing added if we alread have all the sats or the KF has too few sats
+     * such that we couldn't test anyways. Changing the < 5 can allow code to
+     * run below that needs to add to no less than 4 DD's.  */
     return 0;
   }
 
@@ -1300,6 +1302,10 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
   assert(state_dim == num_old_dds + num_addible_dds);
 
   u8 min_dds_to_add = MAX(1, 4 - num_current_dds);
+
+  if (min_dds_to_add > num_addible_dds) {
+    return 0;
+  }
 
   /* Reorder the covariance matrix basis so that old sats come first: */
   /* [ old_sats | new_sats ] */

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -751,6 +751,20 @@ void rebase_hypothesis(void *arg, element_t *elem) //TODO make it so it doesn't 
   memcpy(hypothesis->N, new_N, (num_sats-1) * sizeof(s32));
 }
 
+/** Update an ambiguity test's reference satellite.
+ * Given a set of sdiffs, choose a new reference that is hopefully already
+ * tracked. If that's impossible, just choose a reference.
+ * If the ambiguity test has the new reference, rebase the old hypotheses.
+ * Otherwise trash the test and start over.
+ * On return, the reference sat should be in the sdiffs.
+ *
+ * \param amb_test              The ambiguity test to update
+ * \param num_sdiffs            The length of the sdiffs array.
+ * \param sdiffs                sdiffs, sorted by PRN.
+ * \param sdiffs_with_ref_first sdiffs, sorted by PRN after the first element,
+ *                              which is the reference.
+ * \return Whether the reference sat has changed.
+ */
 u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   if (DEBUG_AMBIGUITY_TEST) {

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -875,6 +875,7 @@ u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_inte
                        &intersection, sizeof(intersection),
                        &projection_aggregator);
   printf("IAR: updates to %"PRIu32"\n", memory_pool_n_allocated(amb_test->pool));
+  printf("After projection, num_sats = %d", num_dds_in_intersection + 1);
   u8 work_prns[MAX_CHANNELS];
   memcpy(work_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
   for (u8 i=0; i<num_dds_in_intersection; i++) {

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -782,13 +782,18 @@ u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, c
       printf("updating iar reference sat\n");
     }
     changed_ref = 1;
-    u8 new_prns[amb_test->sats.num_sats];
-    memcpy(new_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
+    if (sats_management_code == NEW_REF_START_OVER) {
+      create_ambiguity_test(amb_test);
+    }
+    else {
+      u8 new_prns[amb_test->sats.num_sats];
+      memcpy(new_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
 
-    rebase_prns_t prns = {.num_sats = amb_test->sats.num_sats};
-    memcpy(prns.old_prns, old_prns, amb_test->sats.num_sats * sizeof(u8));
-    memcpy(prns.new_prns, new_prns, amb_test->sats.num_sats * sizeof(u8));
-    memory_pool_map(amb_test->pool, &prns, &rebase_hypothesis);
+      rebase_prns_t prns = {.num_sats = amb_test->sats.num_sats};
+      memcpy(prns.old_prns, old_prns, amb_test->sats.num_sats * sizeof(u8));
+      memcpy(prns.new_prns, new_prns, amb_test->sats.num_sats * sizeof(u8));
+      memory_pool_map(amb_test->pool, &prns, &rebase_hypothesis);
+    }
   }
   if (DEBUG_AMBIGUITY_TEST) {
     printf("</AMBIGUITY_UPDATE_REFERENCE>\n");

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -257,6 +257,7 @@ void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3])
     if (num_sats == 1) {
       sats_management.prns[0] = sdiffs[0].prn;
     }
+    create_ambiguity_test(&ambiguity_test);
     DEBUG_EXIT(DEBUG_DGNSS_MANAGEMENT);
     return;
   }

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -183,6 +183,6 @@ u8 ephemeris_good(ephemeris_t *eph, gps_time_t t)
 
   /* TODO: this doesn't exclude ephemerides older than a week so could be made
    * better. */
-  return (eph->valid && fabs(dt) < 4*3600);
+  return (eph->valid  && eph->healthy && fabs(dt) < 4*3600);
 }
 

--- a/src/single_diff.c
+++ b/src/single_diff.c
@@ -260,7 +260,7 @@ void double_diff(u8 n, sdiff_t *sds, sdiff_t *dds, u8 ref_idx)
   }
 }
 
-s8 copy_sdiffs_put_ref_first(u8 ref_prn, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   s8 not_found = -1;
   u8 j = 1;


### PR DESCRIPTION
We used to try to add satellites to get up to at least 4 DDs and at most the number the KF is tracking. However, sometimes the KF was tracking less than 5 sats (4 DDs). So counting up from 4 to less than 4 got us into trouble. Now, we properly return "can't add sats."

Also:
- Changed a bunch of functions that should have const arguments so they do now.
- Changed the ephemeris test to also check the healthy flag.
- Resetting the ambiguity test when we are forced to reset the KF.
- Resetting the ambiguity test when we can't rebase the reference satellite.