### PR TITLE
Switched a log back to old behavior

### DIFF
--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -585,8 +585,8 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
  * to date, this will make a set of sdiffs and DD measurements that correspond
  * to the resolved sats.
  *
- * Returns 0 if the input sdiff sats are a superset of the resolved IAR sats.
- * Returns -1 otherwise.
+ * \todo If the input sdiffs are a subset of the resolved IAR sats, but still
+ *       enough to compute a solution, do it.
  *
  * \param amb_test                  The local amb_test struct. Must have a
  *                                  current amb_check.

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -390,7 +390,9 @@ s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
   /* At this point, sdiffs should be valid due to dgnss_update
    * Return code not equal to 0 signals an error. */
   if (valid_sdiffs != 0) {
-    log_error("dgnss_fixed_baseline: invalid sdiffs.\n");
+    if (valid_sdiffs != -1) {
+      log_error("dgnss_fixed_baseline: Invalid sdiffs.");
+    }
     return 0;
   }
 
@@ -524,7 +526,9 @@ s8 _dgnss_low_latency_IAR_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
       &ambiguity_test, num_sdiffs, sdiffs, dd_meas, ambiguity_sdiffs);
 
   if (valid_sdiffs != 0) {
-    log_error("_dgnss_low_latency_IAR_baseline: invalid sdiffs\n");
+    if (valid_sdiffs != -1) {
+      log_error("_dgnss_low_latency_IAR_baseline: Invalid sdiffs.");
+    }
     DEBUG_EXIT();
     return -1;
   }


### PR DESCRIPTION
Switched a log back to old behavior to only print when sdiffs are disordered. This was a log_error where there shouldn't be one.

We have two situations where we can't compute a baseline:

- In one situation, the sats have changed, but we haven't updated the filters yet to take this into account. If the new sat set isn't a superset of the old sat set, we just don't compute a baseline and wait for the filters to update

- In the other situation, we try to use a disordered set of satellites. This shouldn't happen, so when we detect it, we print a log_error.