### PR TITLE
Increase the size of nav message subframe bit buffer and check for overrun.

### DIFF
--- a/include/libswiftnav/common.h
+++ b/include/libswiftnav/common.h
@@ -18,6 +18,7 @@
  * Common definitions used throughout the library.
  * \{ */
 
+#define ABS(x) ((x) < 0 ? -(x) : (x))
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #define MAX(x, y) (((x) > (y)) ? (x) : (y))
 #define CLAMP_DIFF(a,b) (MAX((a),(b)) - (b))

--- a/include/libswiftnav/nav_msg.h
+++ b/include/libswiftnav/nav_msg.h
@@ -16,11 +16,12 @@
 #include "common.h"
 #include "ephemeris.h"
 
-#define NAV_MSG_SUBFRAME_BITS_LEN 12 /* Buffer 384 nav bits. */
+#define NAV_MSG_SUBFRAME_BITS_LEN 14 /* Buffer 448 nav bits. */
 
 typedef struct {
   u32 subframe_bits[NAV_MSG_SUBFRAME_BITS_LEN];
   u16 subframe_bit_index;
+  bool overrun;
   /** Foo
    * - 0 = no preamble found
    * - +x = preamble begins at bit index (x-1)

--- a/src/nav_msg.c
+++ b/src/nav_msg.c
@@ -114,8 +114,11 @@ s32 nav_msg_update(nav_msg_t *n, s32 corr_prompt_real, u8 ms)
   /* Dump the nav bit, i.e. determine the sign of the correlation over the
    * nav bit period. */
 
-#define abs(x) ((x) < 0 ? -(x) : (x))
-  u16 last_subframe_bit_index = abs(n->subframe_start_index) + 27;
+  /* The following is offset by 27 to allow the handover word to be
+   * overwritten.  This is not a problem as it's handled below and
+   * isn't needed by the ephemeris decoder.
+   */
+  u16 last_subframe_bit_index = ABS(n->subframe_start_index) + 27;
   last_subframe_bit_index %= NAV_MSG_SUBFRAME_BITS_LEN * 32;
   if (n->subframe_start_index &&
       (n->subframe_bit_index == last_subframe_bit_index)) {


### PR DESCRIPTION
This fixes a lot of 'subframe parity error' messages when the CPU load increases and the nav msg thread is unable to process the subframe in time.  This should also fix the problem of occasionally getting a bad ephemeris.