### PR TITLE
swig interface files for libswiftnav.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 build*/
 plover/dist/
 *.pyc
-sbp_generate/sbp_out.*
 clapack-3.2.1-CMAKE/F2CLIBS/libf2c/arith*
+swig/*.c
+swig/*.py

--- a/include/libswiftnav/dgnss_management.h
+++ b/include/libswiftnav/dgnss_management.h
@@ -71,7 +71,6 @@ u32 dgnss_iar_num_sats(void);
 s8 dgnss_iar_get_single_hyp(double *hyp);
 void dgnss_reset_iar(void);
 void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3], double b[3]);
-void dgnss_float_baseline(u8 *num_used, double b[3]);
 void dgnss_new_float_baseline(u8 num_sats, sdiff_t *sdiffs, double ref_ecef[3], u8 *num_used, double b[3]);
 s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
                         u8 *num_used, double b[3]);

--- a/include/libswiftnav/linear_algebra.h
+++ b/include/libswiftnav/linear_algebra.h
@@ -34,8 +34,6 @@
     printf(">\n");                                 \
   }
 
-void dmtx_printf(double *mtx, u32 m, u32 n);
-void dmtx_printi(s32 *mtx, u32 m, u32 n);
 void submatrix(u32 new_rows, u32 new_cols, u32 old_cols, const double *old,
                const u32 *new_row_to_old, const u32 *new_col_to_old,
                double *new);

--- a/include/libswiftnav/printing_utils.h
+++ b/include/libswiftnav/printing_utils.h
@@ -13,6 +13,10 @@
 #ifndef LIBSWIFTNAV_PRINTING_UTILS_H
 #define LIBSWIFTNAV_PRINTING_UTILS_H
 
+#include "ambiguity_test.h"
+#include "common.h"
+#include "memory_pool.h"
+
 void print_s32_mtx_diff(u32 m, u32 n, s32 *Z_inv1, s32 *Z_inv2);
 void print_hyp(void *arg, element_t *elem);
 void print_double_mtx(double *m, u32 _r, u32 _c);

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,17 @@
+include *.cfg
+include *.md
+include *.rst
+include *.py
+include *.sh
+include *.txt
+include .coveragerc
+include .gitignore
+include LICENSE
+include LICENSE.GPLv3
+include tox.ini
+recursive-include libswiftnav/ *
+prune libswiftnav/build/
+recursive-include swiftnav/ *.py
+recursive-include swiftnav/ *.pyx
+recursive-include swiftnav/ *.pyd
+prune docs/_build

--- a/python/README.rst
+++ b/python/README.rst
@@ -1,0 +1,47 @@
+==================
+libswiftnav-python
+==================
+
+Python bindings to the `libswiftnav
+<http://github.com/swift-nav/libswiftnav>`_ GNSS library. Full
+documentation is available online at
+http://docs.swift-nav.com/libswiftnav-python.
+
+Installation
+============
+
+Obtaining the source
+--------------------
+
+The libswiftnav-python source and release tarballs are available from
+GitHub, https://github.com/swift-nav/libswiftnav-python. The latest
+development version of libswiftnav-python can be cloned from github
+using this command::
+
+   $ git clone git://github.com/swift-nav/libswiftnav-python.git
+
+Requirements
+--------------------
+
+libswiftnav-python requires libswiftnav C libary available at
+`libswiftnav <https://github.com/swift-nav/libswiftnav>`_. If you've
+checkout this repository, get this as a submodule::
+
+    $ git submodule init
+    $ git submodule update
+
+The Python dependencies are included in ``requirements.txt``, which
+you can install via::
+
+    $ (sudo) pip install -r requirements
+
+Building and Installing
+-----------------------
+
+This library uses `Swig <https://github.com/swig/swig>`_ to generate
+Python bindings. You can install Swig from source or using your
+platform's package manager of choice. To install libswiftnav-python
+(from the root of the source tree)::
+
+    $ python setup.py build
+    $ (sudo) python setup.py install

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,7 @@
+numpy>=1.9
+flake8==2.3.0
+pep8==1.5.7
+pytest==2.6.4
+pyyaml==3.11
+tox==1.8.1
+virtualenv==1.11.6

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,0 +1,7 @@
+[build_ext]
+
+[metadata]
+description-file=README.rst
+
+[wheel]
+universal = 1

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+try:
+  from setuptools import Command, Extension, setup
+  from setuptools.command.install import install
+  from distutils.command.build import build
+  from distutils.command.build_py import build_py
+  from distutils.command.clean import clean
+except ImportError as exc_info:
+  print "Fucking shit! %s." % exc_info.message
+  sys.exit(1)
+
+# Package version and platform info for Pyi
+VERSION = "0.13"
+PLATFORMS = ['linux', 'osx']
+
+# Get the README and requirements
+CWD = os.path.abspath(os.path.dirname(__file__))
+with open(CWD + '/README.rst') as f:
+  readme = f.read()
+
+with open(CWD + '/requirements.txt') as f:
+  INSTALL_REQUIRES = [i.strip() for i in f.readlines()]
+
+
+# Swig and build flags.
+SWIG_INCLUDE_PATH = '../include/libswiftnav/'
+SWIG_OPTS = ['-modern', '-Wall', '-O', '-I%s' % SWIG_INCLUDE_PATH, '-castmode']
+EXTRA_COMPILE_ARGS = ['-O3', '-g', '-Wno-unused-function']
+SWIG_PATH = '../swig/'
+LIBRARY_DIRS = ['build/lib/']
+
+
+def get_extensions(path=SWIG_PATH):
+  """Create a C extension for Python, given an extension name.
+
+  """
+  exts = []
+  modules = []
+  fs = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+  print "Copying c and py files from %s." % path
+  for file_name in fs:
+    name, ftype = file_name.split('.')
+    if ftype != 'i' or name == "numpy" or name == "swiftnav_ext":
+      print "Skipping file %s." % file_name
+      continue
+    modules.append(name)
+    args = EXTRA_COMPILE_ARGS
+    exts.append(Extension('_%s' % name,
+                          [path + file_name],
+                          extra_compile_args=args,
+                          swig_opts=SWIG_OPTS,
+                          include_dirs=[SWIG_INCLUDE_PATH, '.'],
+                          library_dirs=LIBRARY_DIRS,
+                          extra_link_args=['-g'],
+                          libraries=['m', 'swiftnav']))
+  return (modules, exts)
+
+
+class SwiftPyBuild(build_py):
+  """Copies over swig-generated files.
+
+  """
+
+  def run(self):
+    if not self.dry_run:
+      path = SWIG_PATH
+      fs = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+      for target in fs:
+        name, ftype = target.split(".")
+        self.copy_file(SWIG_PATH + target, 'swiftnav/')
+      build_py.run(self)
+
+
+class SwiftClean(clean):
+  """Cleans swig-generated files.
+
+  """
+
+  def run(self):
+    if not self.dry_run:
+      paths = ['swiftnav/', SWIG_PATH]
+      for path in paths:
+        fs = [f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+        for target in fs:
+          name, ftype = target.split(".")
+          if name == '__init__' or ftype == 'i':
+            continue
+          else:
+            os.remove(path + target)
+      clean.run(self)
+
+
+class SwiftCInstall(build):
+  """Compile and install libswiftnav C bindings. Why does someone have
+  to write something like this from scratch?
+
+  """
+
+  def run(self):
+    """Before building extensions, build and copy libswiftnav.
+
+    """
+    print "Building libswiftnav C library!"
+    path = os.path.join(CWD, '../')
+    cmd = ['mkdir -v -p %s/build' % path,
+           'cd %s/build/' % path,
+           'cmake ../',
+           'make',
+           'cd %s' % path]
+    target_files = [os.path.join(path, 'build/src/libswiftnav-static.a')]
+    print "Produced...%s\n" % target_files
+    def compile():
+      print '*' * 80
+      os.system(";\n".join(cmd))
+      print '*' * 80
+    self.execute(compile, [], '\nCompiling libswiftnav C!\n')
+    # copy resulting tool to library build folder
+    self.build_lib = 'build/lib'
+    self.mkpath(self.build_lib)
+    if not self.dry_run:
+      for target in target_files:
+        print "\nCopying %s to %s.\n" % (target, self.build_lib)
+        if os.path.isfile(target):
+          self.copy_file(target, self.build_lib)
+        else:
+          assert False, "Expected library at %s" % target
+    build.run(self)
+    print("\n\n\n\nSuccessfully built libswiftnav C libraries!\n\n\n\n")
+
+SETUP_ARGS = dict(name='swiftnav',
+                  version=VERSION,
+                  description='Python bindings to the libswiftnav library',
+                  long_description=readme,
+                  license='LGPLv3',
+                  url='https://github.com/swift-nav/libswiftnav-python',
+                  author='Swift Navigation',
+                  author_email='dev@swiftnav.com',
+                  maintainer='Swift Navigation',
+                  maintainer_email='dev@swiftnav.com',
+                  install_requires=INSTALL_REQUIRES,
+                  platforms=PLATFORMS,
+                  use_2to3=False,
+                  zip_safe=False,
+                  packages=['swiftnav'],
+                  py_modules=['swiftnav'])
+
+
+def setup_package():
+  """Setup the package and required Cython extensions.
+
+  """
+  # Override ARCHFLAGS to build native, not universal on OS X.
+  os.environ['ARCHFLAGS'] = ""
+  modules, extensions = get_extensions()
+  SETUP_ARGS['ext_modules'] = extensions
+  SETUP_ARGS['py_modules'] = modules
+  SETUP_ARGS['cmdclass'] = {'build': SwiftCInstall,
+                            'build_py': SwiftPyBuild,
+                            'clean': SwiftClean}
+  setup(**SETUP_ARGS)
+
+if __name__ == "__main__":
+  setup_package()

--- a/python/tests/test_almanac.py
+++ b/python/tests/test_almanac.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.almanac
+
+def test_basic():
+  pass

--- a/python/tests/test_amb_kf.py
+++ b/python/tests/test_amb_kf.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.amb_kf
+
+
+def test_basic():
+  pass

--- a/python/tests/test_ambiguity_test.py
+++ b/python/tests/test_ambiguity_test.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.ambiguity_test
+
+def test_basic():
+  pass

--- a/python/tests/test_baseline.py
+++ b/python/tests/test_baseline.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.baseline as base
+
+def test_basic():
+  num_dds = 4
+  N = base.carray_double(4)
+  DE = base.carray_double(12)
+  b = base.carray_double(3)
+  dd_obs = base.carray_double(3)
+  base.predict_carrier_obs(num_dds, N, DE, b, dd_obs)
+  return dd_obs[0], dd_obs[1], dd_obs[2]

--- a/python/tests/test_bits.py
+++ b/python/tests/test_bits.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.bits
+
+def test_basic():
+  pass

--- a/python/tests/test_constants.py
+++ b/python/tests/test_constants.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.constants
+
+def test_basic():
+  pass

--- a/python/tests/test_coord_system.py
+++ b/python/tests/test_coord_system.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.constants
+
+def test_basic():
+  pass

--- a/python/tests/test_edc.py
+++ b/python/tests/test_edc.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.edc
+
+def test_basic():
+  pass

--- a/python/tests/test_ephemeris.py
+++ b/python/tests/test_ephemeris.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.ephemeris
+
+def test_basic():
+  pass

--- a/python/tests/test_gpstime.py
+++ b/python/tests/test_gpstime.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.gpstime
+
+def test_basic():
+  pass

--- a/python/tests/test_lambda.py
+++ b/python/tests/test_lambda.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.lambda_py
+
+def test_basic():
+  pass

--- a/python/tests/test_linear_algebra.py
+++ b/python/tests/test_linear_algebra.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.linear_algebra
+
+def test_basic():
+  pass

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.logging
+
+def test_basic():
+  pass

--- a/python/tests/test_memory_pool.py
+++ b/python/tests/test_memory_pool.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.memory_pool
+
+def test_basic():
+  pass

--- a/python/tests/test_nav_msg.py
+++ b/python/tests/test_nav_msg.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.nav_msg as n
+
+def test_basic():
+  msg = n.nav_msg_t()
+  assert msg.bit_phase == 0
+  msg.bit_phase = 1
+  msg.subframe_start_index = 1
+  x = n.carray_u32(n.NAV_MSG_SUBFRAME_BITS_LEN)
+  msg.subframe_bits = n.carray_u32(n.NAV_MSG_SUBFRAME_BITS_LEN)
+  assert msg.bit_phase == 1
+  #msg.hist = [1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.,1.]
+  msg.hist = n.carray_float(20)

--- a/python/tests/test_printing_utils.py
+++ b/python/tests/test_printing_utils.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.printing_utils
+
+def test_basic():
+  pass

--- a/python/tests/test_prns.py
+++ b/python/tests/test_prns.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.prns
+
+def test_basic():
+  pass

--- a/python/tests/test_pvt.py
+++ b/python/tests/test_pvt.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.pvt
+
+def test_basic():
+  pass

--- a/python/tests/test_rtcm3.py
+++ b/python/tests/test_rtcm3.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.rtcm3
+
+def test_basic():
+  pass

--- a/python/tests/test_sats_management.py
+++ b/python/tests/test_sats_management.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.sats_management_py
+
+def test_basic():
+  pass

--- a/python/tests/test_single_diff.py
+++ b/python/tests/test_single_diff.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.single_diff
+
+def test_basic():
+  pass

--- a/python/tests/test_swiftnav.py
+++ b/python/tests/test_swiftnav.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+def test_imports():
+  """Verify that distributed packages survive setuptools installation.
+
+  """
+  import swiftnav.almanac
+  import swiftnav.amb_kf
+  import swiftnav.ambiguity_test
+  import swiftnav.baseline
+  import swiftnav.bits
+  import swiftnav.constants
+  import swiftnav.coord_system
+  import swiftnav.correlate
+  import swiftnav.dgnss_management
+  import swiftnav.edc
+  import swiftnav.ephemeris
+  import swiftnav.gpstime
+  import swiftnav.lambda_py
+  import swiftnav.linear_algebra
+  import swiftnav.logging
+  import swiftnav.memory_pool
+  import swiftnav.nav_msg
+  import swiftnav.printing_utils
+  import swiftnav.prns
+  import swiftnav.pvt
+  import swiftnav.rtcm3
+  import swiftnav.sats_management_py
+  import swiftnav.single_diff
+  import swiftnav.track
+  import swiftnav.tropo

--- a/python/tests/test_track.py
+++ b/python/tests/test_track.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.track
+
+def test_basic():
+  pass

--- a/python/tests/test_tropo.py
+++ b/python/tests/test_tropo.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import swiftnav.tropo
+
+def test_basic():
+  pass

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+commands =
+         python setup.py build
+         python setup.py install
+         py.test -v tests/
+sitepackages = False
+usedevelop = True
+
+[flake8]
+ignore = E126,E127,E111
+max-line-length = 100
+exclude = tests/*,limbo/*
+max-complexity = 10

--- a/swig/almanac.i
+++ b/swig/almanac.i
@@ -1,0 +1,8 @@
+%module almanac
+
+%{
+#include "almanac.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "almanac.h"

--- a/swig/amb_kf.i
+++ b/swig/amb_kf.i
@@ -1,0 +1,8 @@
+%module amb_kf
+
+%{
+#include "amb_kf.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "amb_kf.h"

--- a/swig/ambiguity_test.i
+++ b/swig/ambiguity_test.i
@@ -1,0 +1,8 @@
+%module ambiguity_test
+
+%{
+#include "ambiguity_test.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "ambiguity_test.h"

--- a/swig/baseline.i
+++ b/swig/baseline.i
@@ -1,0 +1,9 @@
+%module baseline
+
+%{
+#include "baseline.h"
+%}
+
+#define __attribute__(x)
+%include "swiftnav_ext.i"
+%include "baseline.h"

--- a/swig/bits.i
+++ b/swig/bits.i
@@ -1,0 +1,8 @@
+%module bits
+
+%{
+#include "bits.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "bits.h"

--- a/swig/common.i
+++ b/swig/common.i
@@ -1,0 +1,8 @@
+%module common
+
+%{
+#include "common.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "common.h"

--- a/swig/constants.i
+++ b/swig/constants.i
@@ -1,0 +1,7 @@
+%module constants
+
+%{
+#include "constants.h"
+%}
+
+%include "constants.h"

--- a/swig/coord_system.i
+++ b/swig/coord_system.i
@@ -1,0 +1,7 @@
+%module coord_system
+
+%{
+#include "coord_system.h"
+%}
+
+%include "coord_system.h"

--- a/swig/correlate.i
+++ b/swig/correlate.i
@@ -1,0 +1,8 @@
+%module correlate
+
+%{
+#include "correlate.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "correlate.h"

--- a/swig/dgnss_management.i
+++ b/swig/dgnss_management.i
@@ -1,0 +1,8 @@
+%module dgnss_management
+
+%{
+#include "dgnss_management.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "dgnss_management.h"

--- a/swig/edc.i
+++ b/swig/edc.i
@@ -1,0 +1,8 @@
+%module edc
+
+%{
+#include "edc.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "edc.h"

--- a/swig/ephemeris.i
+++ b/swig/ephemeris.i
@@ -1,0 +1,8 @@
+%module ephemeris
+
+%{
+#include "ephemeris.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "ephemeris.h"

--- a/swig/gpstime.i
+++ b/swig/gpstime.i
@@ -1,0 +1,9 @@
+%module gpstime
+
+%{
+#include "gpstime.h"
+%}
+
+%include "swiftnav_ext.i"
+#define __attribute__(x)
+%include "gpstime.h"

--- a/swig/lambda_py.i
+++ b/swig/lambda_py.i
@@ -1,0 +1,8 @@
+%module lambda_py
+
+%{
+#include "lambda.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "lambda.h"

--- a/swig/linear_algebra.i
+++ b/swig/linear_algebra.i
@@ -1,0 +1,8 @@
+%module linear_algebra
+
+%{
+#include "linear_algebra.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "linear_algebra.h"

--- a/swig/logging.i
+++ b/swig/logging.i
@@ -1,0 +1,7 @@
+%module logging
+
+%{
+#include "logging.h"
+%}
+
+%include "logging.h"

--- a/swig/memory_pool.i
+++ b/swig/memory_pool.i
@@ -1,0 +1,8 @@
+%module memory_pool
+
+%{
+#include "memory_pool.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "memory_pool.h"

--- a/swig/nav_msg.i
+++ b/swig/nav_msg.i
@@ -1,0 +1,8 @@
+%module nav_msg
+
+%{
+#include "nav_msg.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "nav_msg.h"

--- a/swig/printing_utils.i
+++ b/swig/printing_utils.i
@@ -1,0 +1,8 @@
+%module printing_utils
+
+%{
+#include "printing_utils.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "printing_utils.h"

--- a/swig/prns.i
+++ b/swig/prns.i
@@ -1,0 +1,8 @@
+%module prns
+
+%{
+#include "prns.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "prns.h"

--- a/swig/pvt.i
+++ b/swig/pvt.i
@@ -1,0 +1,9 @@
+%module pvt
+
+%{
+#include "pvt.h"
+%}
+
+%include "swiftnav_ext.i"
+#define __attribute__(x)
+%include "pvt.h"

--- a/swig/rtcm3.i
+++ b/swig/rtcm3.i
@@ -1,0 +1,8 @@
+%module rtcm3
+
+%{
+#include "rtcm3.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "rtcm3.h"

--- a/swig/sats_management_py.i
+++ b/swig/sats_management_py.i
@@ -1,0 +1,8 @@
+%module sats_management_py
+
+%{
+#include "sats_management.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "sats_management.h"

--- a/swig/single_diff.i
+++ b/swig/single_diff.i
@@ -1,0 +1,8 @@
+%module single_diff
+
+%{
+#include "single_diff.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "single_diff.h"

--- a/swig/swiftnav_ext.i
+++ b/swig/swiftnav_ext.i
@@ -1,0 +1,33 @@
+/* -*- C -*-  (not really, but good for syntax highlighting) */
+
+%typemap(in) s8, s16, s32, s64 {
+    $1 = ($1_type)PyInt_AsLong($input);
+}
+
+%typemap(out) s8, s16, s32, s64 {
+    $result = PyInt_FromLong($1);
+}
+
+%typemap(in) u8, u16, u32, u64 {
+    $1 = ($1_type)PyLong_AsUnsignedLong($input);
+}
+
+%typemap(out) u8, u16, u32, u64  {
+    $result = PyLong_FromUnsignedLong($1);
+}
+
+%include "carrays.i"
+%include "cpointer.i"
+
+%array_class(s8, carray_s8)
+%array_class(s16, carray_s16)
+%array_class(s32, carray_s32)
+%array_class(s64, carray_s64)
+
+%array_class(u8, carray_u8)
+%array_class(u16, carray_u16)
+%array_class(u32, carray_u32)
+%array_class(u64, carray_u64)
+
+%array_class(float, carray_float)
+%array_class(double, carray_double)

--- a/swig/track.i
+++ b/swig/track.i
@@ -1,0 +1,8 @@
+%module track
+
+%{
+#include "track.h"
+%}
+
+%include "swiftnav_ext.i"
+%include "track.h"

--- a/swig/tropo.i
+++ b/swig/tropo.i
@@ -1,0 +1,7 @@
+%module tropo
+
+%{
+#include "tropo.h"
+%}
+
+%include "tropo.h"


### PR DESCRIPTION
Our bindings to libswiftnav get stale pretty quickly, and lack full,
or even accurate, coverage of some core functionality. While working
with libswiftnav-python for the filter testing, I'm also experimenting
with some Swig-generated bindings in parallel so we can reuse some
more work going forward.

This includes common interface definitions using only the header
files. libswiftnav-python will consume these from libswiftnav via a
submodule.

/cc @cbeighley @fnoble @mfine

<!---
@huboard:{"order":9.325873406851315e-15,"milestone_order":137,"custom_state":""}
-->
