### PR TITLE
S32 -> S64

### DIFF
--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -45,7 +45,7 @@ typedef struct {
   unanimous_amb_check_t amb_check;
 } ambiguity_test_t;
 
-typedef s32 z_t;
+typedef s64 z_t;
 
 /* See doc string above inclusion_loop_body in ambiguity_test.c for info on
  * matrices and lower/upper bounds fields: */
@@ -56,21 +56,21 @@ typedef struct {
   z_t *Z1_inv;
   z_t *Z2;
   z_t *Z2_inv;
-  s32 *counter;          /* Current position within itr_box bounds. */
+  z_t *counter;          /* Current position within itr_box bounds. */
   z_t *zimage;           /* Current point in V1 being tested. */
   u8 new_dim;            /* Dimension of new satellite space V2. */
   u8 old_dim;            /* Dimension of old satellite space. */
-  s32 *itr_lower_bounds;
-  s32 *itr_upper_bounds;
-  s32 *box_lower_bounds;
-  s32 *box_upper_bounds;
+  z_t *itr_lower_bounds;
+  z_t *itr_upper_bounds;
+  z_t *box_lower_bounds;
+  z_t *box_upper_bounds;
 } intersection_count_t; 
 
 typedef struct {
   intersection_count_t *x;
   u8 ndxs_of_old_in_new[MAX_CHANNELS-1];
   u8 ndxs_of_added_in_new[MAX_CHANNELS-1];
-  s32 *Z_new_inv;
+  z_t *Z_new_inv;
 } generate_hypothesis_state_t2;
 
 void print_s32_mtx_diff(u32 m, u32 n, s32 *Z_inv1, s32 *Z_inv2);
@@ -116,23 +116,23 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
 u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection,
                             const sats_management_t *float_sats, const double *float_mean,
                             const double *float_cov_U, const double *float_cov_D);
-u32 float_to_decor(const double *addible_float_cov,
+z_t float_to_decor(const double *addible_float_cov,
                    const double *addible_float_mean,
                    u8 num_addible_dds,
                    u8 num_dds_to_add,
-                   s32 *lower_bounds, s32 *upper_bounds,
+                   z_t *lower_bounds, z_t *upper_bounds,
                    z_t *Z, z_t *Z_inv);
 // TODO(dsk) delete
 s8 determine_sats_addition(ambiguity_test_t *amb_test,
                            double *float_N_cov, u8 num_float_dds, double *float_N_mean,
-                           s32 *lower_bounds, s32 *upper_bounds, u8 *num_dds_to_add,
-                           s32 *Z_inv);
+                           z_t *lower_bounds, z_t *upper_bounds, u8 *num_dds_to_add,
+                           z_t *Z_inv);
 // TODO(dsk) delete
 void add_sats_old(ambiguity_test_t *amb_test,
                   u8 ref_prn,
                   u32 num_added_dds, u8 *added_prns,
-                  s32 *lower_bounds, s32 *upper_bounds,
-                  s32 *Z_inv);
+                  z_t *lower_bounds, z_t *upper_bounds,
+                  z_t *Z_inv);
 void init_residual_matrices(residual_mtxs_t *res_mtxs, u8 num_dds, double *DE_mtx, double *obs_cov);
 void assign_residual_covariance_inverse(u8 num_dds, double *obs_cov, double *q, double *r_cov_inv);
 void assign_r_vec(residual_mtxs_t *res_mtxs, u8 num_dds, double *dd_measurements, double *r_vec);

--- a/include/libswiftnav/linear_algebra.h
+++ b/include/libswiftnav/linear_algebra.h
@@ -50,6 +50,8 @@ void matrix_multiply(u32 n, u32 m, u32 p, const double *a,
                      const double *b, double *c);
 void matrix_multiply_i(u32 n, u32 m, u32 p, const s32 *a,
                        const s32 *b, s32 *c);
+void matrix_multiply_s64(u32 n, u32 m, u32 p, const s64 *a,
+                         const s64 *b, s64 *c);
 void matrix_triu(u32 n, double *M);
 void matrix_eye(u32 n, double *M);
 void matrix_udu(u32 n, double *M, double *U, double *D);

--- a/include/libswiftnav/printing_utils.h
+++ b/include/libswiftnav/printing_utils.h
@@ -21,7 +21,6 @@ void print_s32_mtx_diff(u32 m, u32 n, s32 *mat1, s32 *mat2);
 void print_s32_mtx(s32 *mat, u32 m, u32 n);
 void print_s32_gemv(u32 m, u32 n, s32 *M, s32 *v);
 void print_intersection_state(intersection_count_t *x);
-void print_Z(s8 label, u8 full_dim, u8 new_dim, z_t * Z);
 
 
 #endif /* LIBSWIFTNAV_PRINTING_UTILS_H */

--- a/include/libswiftnav/printing_utils.h
+++ b/include/libswiftnav/printing_utils.h
@@ -21,6 +21,7 @@ void print_s32_mtx_diff(u32 m, u32 n, s32 *mat1, s32 *mat2);
 void print_s32_mtx(s32 *mat, u32 m, u32 n);
 void print_s32_gemv(u32 m, u32 n, s32 *M, s32 *v);
 void print_intersection_state(intersection_count_t *x);
+void print_Z(s8 label, u8 full_dim, u8 new_dim, z_t * Z);
 
 
 #endif /* LIBSWIFTNAV_PRINTING_UTILS_H */

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -34,8 +34,8 @@
 #define LOG_PROB_RAT_THRESHOLD -90
 #define SINGLE_OBS_CHISQ_THRESHOLD 20
 
-// TODO delete
-void matrix_multiply_z_t(u32 n, u32 m, u32 p, const z_t *a,
+// TODO delete?
+static void matrix_multiply_z_t(u32 n, u32 m, u32 p, const z_t *a,
                          const z_t *b, z_t *c)
 {
   matrix_multiply_s64(n,m,p,a,b,c);

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -34,6 +34,13 @@
 #define LOG_PROB_RAT_THRESHOLD -90
 #define SINGLE_OBS_CHISQ_THRESHOLD 20
 
+// TODO delete
+void matrix_multiply_z_t(u32 n, u32 m, u32 p, const z_t *a,
+                         const z_t *b, z_t *c)
+{
+  matrix_multiply_s64(n,m,p,a,b,c);
+}
+
 /** \defgroup ambiguity_test Integer Ambiguity Resolution
  * Integer ambiguity resolution using bayesian hypothesis testing.
  * \{ */
@@ -971,9 +978,9 @@ static void vec_plus(u8 cols, u8 rows, z_t *v, z_t *Z, z_t mult, u8 column)
     v[i] += Z[i * cols + column] * mult;
   }
 }
-static s8 increment_matrix_product(u8 len, s32 *counter, u8 vlen, z_t *Z,
-                                   z_t *v, s32 *lower_bounds, s32 *upper_bounds) {
-  if (memcmp(upper_bounds, counter, len * sizeof(s32)) == 0) {
+static s8 increment_matrix_product(u8 len, z_t *counter, u8 vlen, z_t *Z,
+                                   z_t *v, z_t *lower_bounds, z_t *upper_bounds) {
+  if (memcmp(upper_bounds, counter, len * sizeof(z_t)) == 0) {
     /* counter has reached upper_bound, terminate iteration. */
     return 0;
   }
@@ -994,7 +1001,7 @@ static s8 increment_matrix_product(u8 len, s32 *counter, u8 vlen, z_t *Z,
   return 1;
 }
 
-static bool inside(u32 dim, z_t *point, s32 *lower_bounds, s32 *upper_bounds)
+static bool inside(u32 dim, z_t *point, z_t *lower_bounds, z_t *upper_bounds)
 {
   /* Without a slight tolerance, some cases have strange behavior because
    * points on the boundary may not be included; e.g. even with an identity Z
@@ -1012,16 +1019,16 @@ static void init_intersection_count_vector(intersection_count_t *x, hypothesis_t
 {
   u8 full_dim = x->old_dim + x->new_dim;
   /* Initialize counter using lower bounds. */
-  memcpy(x->counter, x->itr_lower_bounds, x->new_dim * sizeof(s32));
+  memcpy(x->counter, x->itr_lower_bounds, x->new_dim * sizeof(z_t));
   z_t v0[full_dim];
   /* Map the lower bound vector using Z2_inverse into the second half of v0. */
-  matrix_multiply_i(x->new_dim, x->new_dim, 1, x->Z2_inv, x->counter, v0 + x->old_dim);
+  matrix_multiply_z_t(x->new_dim, x->new_dim, 1, x->Z2_inv, x->counter, v0 + x->old_dim);
   /* Map the old hypothesis values identically into the first half of v0. */
   for (u8 i = 0; i < x->old_dim; i++) {
     v0[i] = hyp->N[i];
   }
   /* Decorrelate the joint vector. */
-  matrix_multiply_i(full_dim, full_dim, 1, x->Z1, v0, x->zimage);
+  matrix_multiply_z_t(full_dim, full_dim, 1, x->Z1, v0, x->zimage);
 }
 
 static void fold_intersection_count(void *arg, element_t *elem)
@@ -1043,7 +1050,7 @@ static void fold_intersection_count(void *arg, element_t *elem)
                   x->itr_lower_bounds, x->itr_upper_bounds));
 }
 
-static void round_matrix(u32 rows, u32 cols, const double *A, s32 *B)
+static void round_matrix(u32 rows, u32 cols, const double *A, z_t *B)
 {
   for (u8 i=0; i < rows; i++) {
     for (u8 j=0; j < cols; j++) {
@@ -1062,7 +1069,7 @@ static void compute_Z(u8 old_dim, u8 new_dim, const z_t *Z1, const z_t * Z2_inv,
   for (u8 i = 0; i < full_dim; i++) {
     memcpy(&Z1_right[i*new_dim], &Z1[i*full_dim + old_dim], new_dim * sizeof(z_t));
   }
-  matrix_multiply_i(full_dim, new_dim, new_dim, Z1_right, Z2_inv, transform);
+  matrix_multiply_z_t(full_dim, new_dim, new_dim, Z1_right, Z2_inv, transform);
 }
 
 /* TODO(dsk) Use submatrix for this instead? */
@@ -1245,6 +1252,7 @@ static u8 inclusion_loop_body(
         state_dim, full_dim,
         x->box_lower_bounds, x->box_upper_bounds, x->Z1, x->Z1_inv);
 
+
   /* Useful for debugging. */
   *full_size_return = full_size;
 
@@ -1388,11 +1396,11 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
       row_map, reordering, N_mean_ordered);
 
   /* Initialize intersection struct. */
-  s32 counter[num_addible_dds];
-  s32 lower_bounds1[state_dim];
-  s32 upper_bounds1[state_dim];
-  s32 lower_bounds2[num_addible_dds];
-  s32 upper_bounds2[num_addible_dds];
+  z_t counter[num_addible_dds];
+  z_t lower_bounds1[state_dim];
+  z_t upper_bounds1[state_dim];
+  z_t lower_bounds2[num_addible_dds];
+  z_t upper_bounds2[num_addible_dds];
   z_t zimage[state_dim];
   z_t Z1[state_dim * state_dim];
   z_t Z1_inv[state_dim * state_dim];
@@ -1515,9 +1523,9 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
   }
 
   /* Find the largest set of sats we can add */
-  s32 Z_inv[num_addible_dds * num_addible_dds];
-  s32 lower_bounds[num_addible_dds];
-  s32 upper_bounds[num_addible_dds];
+  z_t Z_inv[num_addible_dds * num_addible_dds];
+  z_t lower_bounds[num_addible_dds];
+  z_t upper_bounds[num_addible_dds];
   u8 num_dds_to_add;
   s8 add_any_sats = determine_sats_addition(amb_test,
                                             addible_float_cov, num_addible_dds, addible_float_mean,
@@ -1535,11 +1543,11 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
   }
 }
 
-u32 float_to_decor(const double *addible_float_cov,
+z_t float_to_decor(const double *addible_float_cov,
                    const double *addible_float_mean,
                    u8 num_addible_dds,
                    u8 num_dds_to_add,
-                   s32 *lower_bounds, s32 *upper_bounds,
+                   z_t *lower_bounds, z_t *upper_bounds,
                    z_t *Z, z_t *Z_inv)
 {
   u8 dim = num_dds_to_add;
@@ -1583,7 +1591,7 @@ u32 float_to_decor(const double *addible_float_cov,
     }
   }
 
-  u32 new_hyp_set_cardinality = 1;
+  u64 new_hyp_set_cardinality = 1;
   for (u8 i=0; i<num_dds_to_add; i++) {
     double search_distance = NUM_SEARCH_STDS * sqrt(decor_float_cov_diag[i]);
     upper_bounds[i] = lround(ceil(decor_float_mean[i] + search_distance));
@@ -1603,7 +1611,7 @@ u32 float_to_decor(const double *addible_float_cov,
 /* TODO(dsk) remove this function. */
 s8 determine_sats_addition(ambiguity_test_t *amb_test,
                            double *float_N_cov, u8 num_float_dds, double *float_N_mean,
-                           s32 *lower_bounds, s32 *upper_bounds, u8 *num_dds_to_add,
+                           z_t *lower_bounds, z_t *upper_bounds, u8 *num_dds_to_add,
                            z_t *Z_inv)
 {
   u8 num_current_dds = CLAMP_DIFF(amb_test->sats.num_sats, 1);
@@ -1755,14 +1763,14 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
 
 /* TODO(dsk) remove dead code. */
 typedef struct {
-  s32 upper_bounds[MAX_CHANNELS-1];
-  s32 lower_bounds[MAX_CHANNELS-1];
-  s32 counter[MAX_CHANNELS-1];
+  z_t upper_bounds[MAX_CHANNELS-1];
+  z_t lower_bounds[MAX_CHANNELS-1];
+  z_t counter[MAX_CHANNELS-1];
   u8 ndxs_of_old_in_new[MAX_CHANNELS-1];
   u8 ndxs_of_added_in_new[MAX_CHANNELS-1];
   u8 num_added_dds;
   u8 num_old_dds;
-  s32 Z_inv[(MAX_CHANNELS-1) * (MAX_CHANNELS-1)];
+  z_t Z_inv[(MAX_CHANNELS-1) * (MAX_CHANNELS-1)];
 } generate_hypothesis_state_t;
 
 static s8 generate_next_hypothesis(void *x_, u32 n)
@@ -1770,7 +1778,7 @@ static s8 generate_next_hypothesis(void *x_, u32 n)
   (void) n;
   generate_hypothesis_state_t *x = (generate_hypothesis_state_t *)x_;
 
-  if (memcmp(x->upper_bounds, x->counter, x->num_added_dds * sizeof(s32)) == 0) {
+  if (memcmp(x->upper_bounds, x->counter, x->num_added_dds * sizeof(z_t)) == 0) {
     /* counter has reached upper_bound, terminate iteration. */
     return 0;
   }
@@ -1801,7 +1809,7 @@ static void hypothesis_prod(element_t *new_, void *x_, u32 n, element_t *elem_)
   u8 *ndxs_of_added_in_new = x->ndxs_of_added_in_new;
 
   s32 old_N[MAX_CHANNELS-1];
-  memcpy(old_N, new->N, x->num_old_dds * sizeof(s32));
+  memcpy(old_N, new->N, x->num_old_dds * sizeof(z_t));
 
   for (u8 i=0; i < x->num_old_dds; i++) {
     new->N[ndxs_of_old_in_new[i]] = old_N[i];
@@ -1825,14 +1833,14 @@ static s8 no_init(void *x, element_t *elem) {
 void add_sats_old(ambiguity_test_t *amb_test,
                   u8 ref_prn,
                   u32 num_added_dds, u8 *added_prns,
-                  s32 *lower_bounds, s32 *upper_bounds,
-                  s32 *Z_inv)
+                  z_t *lower_bounds, z_t *upper_bounds,
+                  z_t *Z_inv)
 {
   /* Make a generator that iterates over the new hypotheses. */
   generate_hypothesis_state_t x0;
-  memcpy(x0.upper_bounds, upper_bounds, num_added_dds * sizeof(s32));
-  memcpy(x0.lower_bounds, lower_bounds, num_added_dds * sizeof(s32));
-  memcpy(x0.counter, lower_bounds, num_added_dds * sizeof(s32));
+  memcpy(x0.upper_bounds, upper_bounds, num_added_dds * sizeof(z_t));
+  memcpy(x0.lower_bounds, lower_bounds, num_added_dds * sizeof(z_t));
+  memcpy(x0.counter, lower_bounds, num_added_dds * sizeof(z_t));
 
   x0.num_added_dds = num_added_dds;
   x0.num_old_dds = CLAMP_DIFF(amb_test->sats.num_sats, 1);
@@ -1883,7 +1891,7 @@ void add_sats_old(ambiguity_test_t *amb_test,
   if (DEBUG) {
     memory_pool_map(amb_test->pool, &x0.num_old_dds, &print_hyp);
   }
-  memcpy(x0.Z_inv, Z_inv, num_added_dds * num_added_dds * sizeof(s32));
+  memcpy(x0.Z_inv, Z_inv, num_added_dds * num_added_dds * sizeof(z_t));
   /* Take the product of our current hypothesis state with the generator, recorrelating the new ones as we go. */
   memory_pool_product_generator(amb_test->pool, &x0, MAX_HYPOTHESES, sizeof(x0),
                                 &no_init, &generate_next_hypothesis, &hypothesis_prod);

--- a/src/linear_algebra.c
+++ b/src/linear_algebra.c
@@ -630,6 +630,18 @@ inline void matrix_multiply_i(u32 n, u32 m, u32 p, const s32 *a,
     }
 }
 
+inline void matrix_multiply_s64(u32 n, u32 m, u32 p, const s64 *a,
+                                const s64 *b, s64 *c)
+{
+  u32 i, j, k;
+  for (i = 0; i < n; i++)
+    for (j = 0; j < p; j++) {
+      c[p*i + j] = 0;
+      for (k = 0; k < m; k++)
+        c[p*i + j] += a[m*i+k] * b[p*k + j];
+    }
+}
+
 /** Zero lower triangle of an `n` x `n` square matrix.
  * Some routines designed to work on upper triangular matricies use the lower
  * triangle as scratch space. This function zeros the lower triangle such that

--- a/src/printing_utils.c
+++ b/src/printing_utils.c
@@ -96,6 +96,23 @@ void print_s32_mtx(s32 *mat, u32 m, u32 n)
   printf("\n");
 }
 
+/** Prints a s64 valued matrix.
+ *
+ * \param m     The number of rows to be printed in the matrices.
+ * \param n     The number of columns in the matrix.
+ * \param mat1  The matrix to be printed.
+ */
+void print_s64_mtx(s64 *mat, u32 m, u32 n)
+{
+  for (u32 i=0; i < m; i++) {
+    for (u32 j=0; j < n; j++) {
+      printf("%"PRId64", ", mat[i*n + j]);
+    }
+    printf("\n");
+  }
+  printf("\n");
+}
+
 /** Prints the result of a matrix-vector product of s32's.
  * Given a matrix M and vector v of s32's, prints the result of M*v.
  *
@@ -139,7 +156,7 @@ void print_hyp(void *arg, element_t *elem)
 static void print_Z(s8 label, u8 full_dim, u8 new_dim, z_t * Z)
 {
   printf("Z %i:\n", label);
-  print_s32_mtx(Z, full_dim, new_dim);
+  print_s64_mtx(Z, full_dim, new_dim);
 }
 
 void print_intersection_state(intersection_count_t *x)
@@ -148,25 +165,25 @@ void print_intersection_state(intersection_count_t *x)
 
   printf("itr lower bounds:\n");
   for (u8 i = 0; i < x->new_dim; i++) {
-    printf("%"PRIi32"\n", x->itr_lower_bounds[i]);
+    printf("%"PRIi64"\n", x->itr_lower_bounds[i]);
   }
   printf("itr upper bounds:\n");
   for (u8 i = 0; i < x->new_dim; i++) {
-    printf("%"PRIi32"\n", x->itr_upper_bounds[i]);
+    printf("%"PRIi64"\n", x->itr_upper_bounds[i]);
   }
   printf("box lower bounds:\n");
   for (u8 i = 0; i < full_dim; i++) {
-    printf("%"PRIi32"\n", x->box_lower_bounds[i]);
+    printf("%"PRIi64"\n", x->box_lower_bounds[i]);
   }
   printf("box upper bounds:\n");
   for (u8 i = 0; i < full_dim; i++) {
-    printf("%"PRIi32"\n", x->box_upper_bounds[i]);
+    printf("%"PRIi64"\n", x->box_upper_bounds[i]);
   }
   printf("transformation matrix:\n");
   print_Z(68, full_dim, x->new_dim, x->Z);
   printf("z1:\n");
-  print_s32_mtx(x->Z1, full_dim, full_dim);
+  print_Z(0, full_dim, full_dim, x->Z1);
   printf("z2_inv:\n");
-  print_s32_mtx(x->Z2_inv, x->new_dim, x->new_dim);
+  print_Z(0, x->new_dim, x->new_dim, x->Z2_inv);
 }
 

--- a/src/printing_utils.c
+++ b/src/printing_utils.c
@@ -102,7 +102,7 @@ void print_s32_mtx(s32 *mat, u32 m, u32 n)
  * \param n     The number of columns in the matrix.
  * \param mat1  The matrix to be printed.
  */
-void print_s64_mtx(s64 *mat, u32 m, u32 n)
+static void print_s64_mtx(s64 *mat, u32 m, u32 n)
 {
   for (u32 i=0; i < m; i++) {
     for (u32 j=0; j < n; j++) {

--- a/tests/check_ambiguity_test.c
+++ b/tests/check_ambiguity_test.c
@@ -10,6 +10,7 @@
 #include "check_utils.h"
 
 
+
 /* Assure that when the sdiffs match amb_test's sats, amb_test's sats are unchanged. */
 START_TEST(test_update_sats_same_sats)
 {
@@ -140,9 +141,6 @@ START_TEST(test_amb_sat_inclusion)
   u8 dim = 7;
   double cov_mat[state_dim * state_dim];
   double multiplier[state_dim * state_dim];
-  double multiplierT[state_dim * state_dim];
-  double a[state_dim * state_dim];
-  double b[state_dim * state_dim];
   matrix_eye(state_dim, cov_mat);
   double diag = 0.08;
   for (u8 i = 0; i < state_dim; i++) {
@@ -164,6 +162,9 @@ START_TEST(test_amb_sat_inclusion)
   /* Compute a lightly randomized covariance matrix:
    *     multiplier * diag * multiplier^t
    */
+  double multiplierT[state_dim * state_dim];
+  double a[state_dim * state_dim];
+  double b[state_dim * state_dim];
   matrix_transpose(state_dim, state_dim, multiplier, multiplierT);
   matrix_multiply(state_dim, state_dim, state_dim, multiplier, cov_mat, a);
   matrix_multiply(state_dim, state_dim, state_dim, a, multiplierT, b);
@@ -200,27 +201,27 @@ START_TEST(test_amb_sat_inclusion)
   u8 flag;
   pool_size = memory_pool_n_allocated(amb_test.pool);
   printf("pool size before: %i\n", pool_size);
-  /* Include. This one should succeed. */
+  /* Include. This one should succeed and add 5 sats. */
   flag = ambiguity_sat_inclusion(&amb_test, 0, &float_sats, mean, u, d);
   printf("inclusion return code: %i\n", flag);
   pool_size = memory_pool_n_allocated(amb_test.pool);
   printf("pool size after 1: %i\n", pool_size);
   fail_unless(flag == 1);
+  fail_unless(pool_size == 625);
   /* Include again. This one should succeed. */
   flag = ambiguity_sat_inclusion(&amb_test, 0, &float_sats, mean, u, d);
   printf("inclusion return code: %i\n", flag);
   pool_size = memory_pool_n_allocated(amb_test.pool);
   printf("pool size after 2: %i\n", pool_size);
   fail_unless(flag == 1);
-  /* Include again. This one should fail due to high covariance. */
+  fail_unless(pool_size == 547);
+  /* Include again. This one should fail. */
   flag = ambiguity_sat_inclusion(&amb_test, 0, &float_sats, mean, u, d);
   printf("inclusion return code: %i\n", flag);
   pool_size = memory_pool_n_allocated(amb_test.pool);
-  printf("pool size after 3: %i\n", pool_size);
+  printf("pool size after 2: %i\n", pool_size);
   fail_unless(flag == 0);
-
-  /* Checks */
-  fail_unless(pool_size > 1);
+  fail_unless(pool_size == 547);
 }
 END_TEST
 

--- a/tests/check_ambiguity_test.c
+++ b/tests/check_ambiguity_test.c
@@ -143,6 +143,9 @@ START_TEST(test_amb_sat_inclusion)
   double multiplier[state_dim * state_dim];
   matrix_eye(state_dim, cov_mat);
   double diag = 0.08;
+
+  srandom(1);
+
   for (u8 i = 0; i < state_dim; i++) {
     cov_mat[i*state_dim+i] = diag;
   }

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -66,11 +66,11 @@ void check_dgnss_management_teardown()
  * \param n The size of the matrix.
  * \param M Pointer to the matrix.
  */
-void matrix_eye_s32(u32 n, s32 *M)
+void matrix_eye_s64(u32 n, s64 *M)
 {
   /* NOTE: This function has been bounds checked. Please check again if
    * modifying. */
-  memset(M, 0, n * n * sizeof(s32));
+  memset(M, 0, n * n * sizeof(s64));
   for (u32 i=0; i<n; i++) {
     M[i*n + i] = 1;
   }
@@ -229,13 +229,13 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_first) {
   prns[1] = 3;
   prns[2] = 4;
   prns[3] = 5;
-  s32 lower[4];
-  s32 upper[4];
-  memset(lower, 0, sizeof(s32) * 4);
-  memset(upper, 0, sizeof(s32) * 4);
+  z_t lower[4];
+  z_t upper[4];
+  memset(lower, 0, sizeof(z_t) * 4);
+  memset(upper, 0, sizeof(z_t) * 4);
 
-  s32 Z_inv[16];
-  matrix_eye_s32(4, Z_inv);
+  z_t Z_inv[16];
+  matrix_eye_s64(4, Z_inv);
 
   add_sats_old(&ambiguity_test,
            1,
@@ -249,7 +249,7 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_first) {
   ambiguity_test.amb_check.matching_ndxs[1] = 1;
   ambiguity_test.amb_check.matching_ndxs[2] = 2;
   ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(s32) * 5);
+  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
@@ -274,13 +274,13 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_middle) {
   prns[1] = 3;
   prns[2] = 4;
   prns[3] = 5;
-  s32 lower[4];
-  s32 upper[4];
-  memset(lower, 0, sizeof(s32) * 4);
-  memset(upper, 0, sizeof(s32) * 4);
+  z_t lower[4];
+  z_t upper[4];
+  memset(lower, 0, sizeof(z_t) * 4);
+  memset(upper, 0, sizeof(z_t) * 4);
 
-  s32 Z_inv[16];
-  matrix_eye_s32(4, Z_inv);
+  z_t Z_inv[16];
+  matrix_eye_s64(4, Z_inv);
 
   add_sats_old(&ambiguity_test,
            ref_prn,
@@ -294,7 +294,7 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_middle) {
   ambiguity_test.amb_check.matching_ndxs[1] = 1;
   ambiguity_test.amb_check.matching_ndxs[2] = 2;
   ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(s32) * 5);
+  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
@@ -319,13 +319,13 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_end) {
   prns[1] = 2;
   prns[2] = 3;
   prns[3] = 4;
-  s32 lower[4];
-  s32 upper[4];
-  memset(lower, 0, sizeof(s32) * 4);
-  memset(upper, 0, sizeof(s32) * 4);
+  z_t lower[4];
+  z_t upper[4];
+  memset(lower, 0, sizeof(z_t) * 4);
+  memset(upper, 0, sizeof(z_t) * 4);
 
-  s32 Z_inv[16];
-  matrix_eye_s32(4, Z_inv);
+  z_t Z_inv[16];
+  matrix_eye_s64(4, Z_inv);
 
   add_sats_old(&ambiguity_test,
            ref_prn,
@@ -339,7 +339,7 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_end) {
   ambiguity_test.amb_check.matching_ndxs[1] = 1;
   ambiguity_test.amb_check.matching_ndxs[2] = 2;
   ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(s32) * 5);
+  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
@@ -364,13 +364,13 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_fixed_point) {
   prns[1] = 2;
   prns[2] = 3;
   prns[3] = 4;
-  s32 lower[4];
-  s32 upper[4];
-  memset(lower, 0, sizeof(s32) * 4);
-  memset(upper, 0, sizeof(s32) * 4);
+  z_t lower[4];
+  z_t upper[4];
+  memset(lower, 0, sizeof(z_t) * 4);
+  memset(upper, 0, sizeof(z_t) * 4);
 
-  s32 Z_inv[16];
-  matrix_eye_s32(4, Z_inv);
+  z_t Z_inv[16];
+  matrix_eye_s64(4, Z_inv);
 
   add_sats_old(&ambiguity_test,
            ref_prn,


### PR DESCRIPTION
this should fix an occasional overflow issue in the sat inclusion process. integer ambiguities fit within an s32, but when decorrelated, occasionally exceed that bound.