### PR TITLE
Remove unused functions

### DIFF
--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -33,10 +33,6 @@ s8 calc_sat_state(const ephemeris_t *ephemeris, gps_time_t t,
                   double pos[3], double vel[3],
                   double *clock_err, double *clock_rate_err);
 
-double predict_range(double rx_pos[3],
-                     gps_time_t tot,
-                     ephemeris_t *ephemeris);
-
 u8 ephemeris_good(ephemeris_t *eph, gps_time_t t);
 
 void decode_ephemeris(u32 frame_words[3][8], ephemeris_t *e);

--- a/include/libswiftnav/single_diff.h
+++ b/include/libswiftnav/single_diff.h
@@ -29,15 +29,9 @@ typedef struct {
   u8 prn;
 } sdiff_t;
 
-u8 propagate(u8 n, double ref_ecef[3],
-             navigation_measurement_t *m_in_base, gps_time_t *t_base,
-             navigation_measurement_t *m_in_rover, gps_time_t *t_rover,
-             navigation_measurement_t *m_out_base);
-
 u8 single_diff(u8 n_a, navigation_measurement_t *m_a,
                u8 n_b, navigation_measurement_t *m_b,
                sdiff_t *sds);
-void double_diff(u8 n, sdiff_t *sds, sdiff_t *dds, u8 ref_idx);
 
 int sdiff_search_prn(const void *a, const void *b);
 

--- a/include/libswiftnav/single_diff.h
+++ b/include/libswiftnav/single_diff.h
@@ -47,8 +47,6 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           ephemeris_t *es, gps_time_t t,
                           sdiff_t *sds);
 
-void almanacs_to_single_diffs(u8 n, almanac_t *alms, gps_time_t timestamp, sdiff_t *sdiffs);
-
 s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 
 u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop, u8 *sats_to_drop);

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -151,22 +151,6 @@ s8 calc_sat_state(const ephemeris_t *ephemeris, gps_time_t t,
 
   return 0;
 }
-
-double predict_range(double rx_pos[3],
-                     gps_time_t t,
-                     ephemeris_t *ephemeris)
-{
-  double sat_pos[3];
-  double sat_vel[3];
-  double temp[3];
-  double clock_err, clock_rate_err;
-
-  calc_sat_state(ephemeris, t, sat_pos, sat_vel, &clock_err, &clock_rate_err);
-
-  vector_subtract(3, sat_pos, rx_pos, temp); /* temp = sat_pos - rx_pos */
-  return vector_norm(3, temp);
-}
-
 /** Is this ephemeris usable?
  *
  * \todo This should actually be more than just the "valid" flag.

--- a/src/single_diff.c
+++ b/src/single_diff.c
@@ -198,30 +198,6 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
   return n;
 }
 
-
-/** Convert a list of almanacs to a list of single differences.
- * This only fills the position, velocity and prn.
- *
- * It's only useful for using functions that need a sdiff_t when you have almanac_t.
- */
-void almanacs_to_single_diffs(u8 n, almanac_t *alms, gps_time_t timestamp, sdiff_t *sdiffs)
-{
-  for (u8 i=0; i<n; i++) {
-    double p[3];
-    double v[3];
-    calc_sat_state_almanac(&alms[i], timestamp.tow, timestamp.wn, p, v);
-    memcpy(sdiffs[i].sat_pos, &p[0], 3 * sizeof(double));
-    memcpy(sdiffs[i].sat_vel, &v[0], 3 * sizeof(double));
-    sdiffs[i].prn = alms[i].prn;
-    if (i==0) {
-      sdiffs[i].snr = 1;
-    }
-    else {
-      sdiffs[i].snr = 0;
-    }
-  }
-}
-
 void double_diff(u8 n, sdiff_t *sds, sdiff_t *dds, u8 ref_idx)
 {
   for (u8 i=0; i<n; i++) {

--- a/src/single_diff.c
+++ b/src/single_diff.c
@@ -19,8 +19,6 @@
 #include "constants.h"
 #include "sats_management.h"
 
-#define GPS_L1_LAMBDA (GPS_C / GPS_L1_HZ)
-
 /** \defgroup single_diff Single Difference Observations
  * Functions for storing and manipulating single difference observations.
  * \{ */


### PR DESCRIPTION
almanacs_to_single_diffs() needs to be elided from libswiftnav-python.  Others aren't referred to anywhere.