### PR TITLE
REFACTOR: Remove global dgnss state; add some const-correctness

### DIFF
--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -40,9 +40,9 @@ void nkf_update(nkf_t *kf, double *measurements);
 
 void assign_phase_obs_null_basis(u8 num_dds, double *DE_mtx, double *q);
 void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var, double amb_init_var,
-            u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double *dd_measurements, double ref_ecef[3]);
+            u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, const double *dd_measurements, const double ref_ecef[3]);
 void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
-                     u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double ref_ecef[3]);
+                     u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, const double ref_ecef[3]);
 s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list);
 void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns);
 
@@ -59,7 +59,7 @@ void nkf_state_inclusion(nkf_t *kf,
 
 void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns);
 void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats, u8 *old_prns, u8 *new_prns);
-void least_squares_solve_b(nkf_t *kf, const sdiff_t *sdiffs_with_ref_first,
+void least_squares_solve_b(const nkf_t *kf, const sdiff_t *sdiffs_with_ref_first,
          const double *dd_measurements, const double ref_ecef[3], double b[3]);
 
 void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -74,36 +74,36 @@ typedef struct {
 } generate_hypothesis_state_t2;
 
 void print_s32_mtx_diff(u32 m, u32 n, s32 *Z_inv1, s32 *Z_inv2);
-s8 get_single_hypothesis(ambiguity_test_t *amb_test, s32 *hyp_N);
+s8 get_single_hypothesis(const ambiguity_test_t *amb_test, s32 *hyp_N);
 void create_empty_ambiguity_test(ambiguity_test_t *amb_test);
 void create_ambiguity_test(ambiguity_test_t *amb_test);
 void reset_ambiguity_test(ambiguity_test_t *amb_test);
 void destroy_ambiguity_test(ambiguity_test_t *amb_test);
 s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs);
 u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
-void update_ambiguity_test(double ref_ecef[3], double phase_var, double code_var,
-                           ambiguity_test_t *amb_test, u8 state_dim, sdiff_t *sdiffs,
+void update_ambiguity_test(const double ref_ecef[3], double phase_var, double code_var,
+                           ambiguity_test_t *amb_test, u8 state_dim, const sdiff_t *sdiffs,
                            u8 changed_sats);
 void update_unanimous_ambiguities(ambiguity_test_t *amb_test);
-u32 ambiguity_test_n_hypotheses(ambiguity_test_t *amb_test);
-u8 ambiguity_test_pool_contains(ambiguity_test_t *amb_test, double *ambs);
-double ambiguity_test_pool_ll(ambiguity_test_t *amb_test, u8 num_ambs, double *ambs);
-double ambiguity_test_pool_prob(ambiguity_test_t *amb_test, u8 num_ambs, double *ambs);
-void ambiguity_test_MLE_ambs(ambiguity_test_t *amb_test, s32 *ambs);
+u32 ambiguity_test_n_hypotheses(const ambiguity_test_t *amb_test);
+u8 ambiguity_test_pool_contains(const ambiguity_test_t *amb_test, double *ambs);
+double ambiguity_test_pool_ll(const ambiguity_test_t *amb_test, u8 num_ambs, const double *ambs);
+double ambiguity_test_pool_prob(const ambiguity_test_t *amb_test, u8 num_ambs, const double *ambs);
+void ambiguity_test_MLE_ambs(const ambiguity_test_t *amb_test, s32 *ambs);
 void test_ambiguities(ambiguity_test_t *amb_test, double *ambiguity_dd_measurements);
 u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
                          const sdiff_t *sdiffs, const sats_management_t *float_sats,
                          const double *float_mean, const double *float_cov_U,
                          const double *float_cov_D);
 u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs);
-u8 ambiguity_iar_can_solve(ambiguity_test_t *ambiguity_test);
-s8 make_ambiguity_resolved_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test,
-            u8 num_sdiffs, sdiff_t *sdiffs,
+u8 ambiguity_iar_can_solve(const ambiguity_test_t *ambiguity_test);
+s8 make_ambiguity_resolved_dd_measurements_and_sdiffs(const ambiguity_test_t *amb_test,
+            u8 num_sdiffs, const sdiff_t *sdiffs,
             double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs);
-s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
+s8 make_ambiguity_dd_measurements_and_sdiffs(const ambiguity_test_t *amb_test, u8 num_sdiffs, const sdiff_t *sdiffs,
                                                double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs);
-s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
-                                   u8 num_sdiffs, sdiff_t *sdiffs,
+s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dds,
+                                   u8 num_sdiffs, const sdiff_t *sdiffs,
                                    double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs);
 u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_intersection, const u8 *dd_intersection_ndxs);
 // TODO(dsk) delete

--- a/include/libswiftnav/dgnss_management.h
+++ b/include/libswiftnav/dgnss_management.h
@@ -50,64 +50,63 @@ typedef struct {
   double new_int_var;
 } dgnss_settings_t;
 
-extern dgnss_settings_t dgnss_settings;
+typedef struct {
+  dgnss_settings_t settings;
+  nkf_t nkf;
+  sats_management_t sats_management;  /* TODO: This really belongs inside of nkf */
+  ambiguity_test_t ambiguity_test;  /* Note: ambiguity_test contains another, different
+                                       sats_management (which should be a subset of the above) */
+} dgnss_state_t;
 
-void dgnss_set_settings(double phase_var_test, double code_var_test,
-                        double phase_var_kf, double code_var_kf,
-                        double amb_drift_var, double amb_init_var,
-                        double new_int_var);
 void make_measurements(u8 num_diffs, const sdiff_t *sdiffs, double *raw_measurements);
-void dgnss_init(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3]);
-void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3]);
-void dgnss_rebase_ref(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3],
+void dgnss_init(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double reciever_ecef[3]);
+void dgnss_update(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double reciever_ecef[3]);
+void dgnss_rebase_ref(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double reciever_ecef[3],
                       u8 old_prns[MAX_CHANNELS], sdiff_t *corrected_sdiffs);
-nkf_t * get_dgnss_nkf(void);
-sats_management_t * get_sats_management(void);
-ambiguity_test_t* get_ambiguity_test(void);
 
-s8 dgnss_iar_resolved(void);
-u32 dgnss_iar_num_hyps(void);
-u32 dgnss_iar_num_sats(void);
-s8 dgnss_iar_get_single_hyp(double *hyp);
-void dgnss_reset_iar(void);
-void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3], double b[3]);
+s8 dgnss_iar_resolved(const dgnss_state_t *dgs);
+u32 dgnss_iar_num_hyps(const dgnss_state_t *dgs);
+u32 dgnss_iar_num_sats(const dgnss_state_t *dgs);
+s8 dgnss_iar_get_single_hyp(const dgnss_state_t *dgs, double *hyp);
+void dgnss_reset_iar(dgnss_state_t *dgs); 
+void dgnss_init_known_baseline(dgnss_state_t *dgs, u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3], double b[3]);
 void dgnss_float_baseline(u8 *num_used, double b[3]);
-void dgnss_new_float_baseline(u8 num_sats, sdiff_t *sdiffs, double ref_ecef[3], u8 *num_used, double b[3]);
-s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
+void dgnss_new_float_baseline(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double ref_ecef[3], u8 *num_used, double b[3]);
+s8 dgnss_fixed_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
                         u8 *num_used, double b[3]);
-s8 dgnss_low_latency_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                               double ref_ecef[3], u8 *num_used, double b[3]);
-void measure_amb_kf_b(u8 num_sdiffs, sdiff_t *sdiffs,
+s8 dgnss_low_latency_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                               const double ref_ecef[3], u8 *num_used, double b[3]);
+void measure_amb_kf_b(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
                       const double receiver_ecef[3], double *b);
-void measure_b_with_external_ambs(u8 state_dim, const double *state_mean,
+void measure_b_with_external_ambs(const dgnss_state_t *dgs, u8 state_dim, const double *state_mean,
                                   u8 num_sdiffs, sdiff_t *sdiffs,
                                   const double receiver_ecef[3], double *b);
-void measure_iar_b_with_external_ambs(double *state_mean,
-                                      u8 num_sdiffs, sdiff_t *sdiffs,
-                                      double receiver_ecef[3],
+void measure_iar_b_with_external_ambs(const dgnss_state_t *dgs, double *state_mean,
+                                      u8 num_sdiffs, const sdiff_t *sdiffs,
+                                      const double receiver_ecef[3],
                                       double *b);
-u8 get_amb_kf_de_and_phase(u8 num_sdiffs, sdiff_t *sdiffs,
+u8 get_amb_kf_de_and_phase(const dgnss_state_t *dgs, u8 num_sdiffs, sdiff_t *sdiffs,
                            double ref_ecef[3],
                            double *de, double *phase);
-u8 get_iar_de_and_phase(u8 num_sdiffs, sdiff_t *sdiffs,
+u8 get_iar_de_and_phase(const dgnss_state_t *dgs, u8 num_sdiffs, sdiff_t *sdiffs,
                         double ref_ecef[3],
                         double *de, double *phase);
-u8 dgnss_iar_pool_contains(double *ambs);
-double dgnss_iar_pool_ll(u8 num_ambs, double *ambs);
-double dgnss_iar_pool_prob(u8 num_ambs, double *ambs);
-u8 get_amb_kf_mean(double *ambs);
-u8 get_amb_kf_cov(double *cov);
-u8 get_amb_kf_prns(u8 *prns);
-u8 get_amb_test_prns(u8 *prns);
-u8 dgnss_iar_MLE_ambs(s32 *ambs);
+u8 dgnss_iar_pool_contains(const dgnss_state_t *dgs, double *ambs);
+double dgnss_iar_pool_ll(const dgnss_state_t *dgs, u8 num_ambs, double *ambs);
+double dgnss_iar_pool_prob(const dgnss_state_t *dgs, u8 num_ambs, double *ambs);
+u8 get_amb_kf_mean(const dgnss_state_t *dgs, double *ambs);
+u8 get_amb_kf_cov(const dgnss_state_t *dgs, double *cov);
+u8 get_amb_kf_prns(const dgnss_state_t *dgs, u8 *prns);
+u8 get_amb_test_prns(const dgnss_state_t *dgs, u8 *prns);
+u8 dgnss_iar_MLE_ambs(const dgnss_state_t *dgs, s32 *ambs);
 
 
 /* Functions for internal use in the file. In here so we can unit test them
  * without having to extern them (where they could get out of sync with
  * changes in type signature) */
-s8 _dgnss_low_latency_float_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                                    double ref_ecef[3], u8 *num_used, double b[3]);
-s8 _dgnss_low_latency_IAR_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                                  double ref_ecef[3], u8 *num_used, double b[3]);
+s8 _dgnss_low_latency_float_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                                    const double ref_ecef[3], u8 *num_used, double b[3]);
+s8 _dgnss_low_latency_IAR_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                                  const double ref_ecef[3], u8 *num_used, double b[3]);
 
 #endif /* LIBSWIFTNAV_DGNSS_MANAGEMENT_H */

--- a/include/libswiftnav/memory_pool.h
+++ b/include/libswiftnav/memory_pool.h
@@ -51,12 +51,12 @@ s8 memory_pool_init(memory_pool_t *new_pool, u32 n_elements,
                     size_t element_size, void *buff);
 void memory_pool_destroy(memory_pool_t *pool);
 s32 memory_pool_n_free(memory_pool_t *pool);
-s32 memory_pool_n_allocated(memory_pool_t *pool);
+s32 memory_pool_n_allocated(const memory_pool_t *pool);
 u8 memory_pool_empty(memory_pool_t *pool);
 u32 memory_pool_n_elements(memory_pool_t *pool);
 
 element_t *memory_pool_add(memory_pool_t *pool);
-s32 memory_pool_to_array(memory_pool_t *pool, void *array);
+s32 memory_pool_to_array(const memory_pool_t *pool, void *array);
 
 s32 memory_pool_map(memory_pool_t *pool, void *arg,
                     void (*f)(void *arg, element_t *elem));

--- a/include/libswiftnav/sats_management.h
+++ b/include/libswiftnav/sats_management.h
@@ -36,9 +36,9 @@ void print_sats_management(sats_management_t *sats_management);
 void print_sats_management_short(sats_management_t *sats_management);
 s8 rebase_sats_management(sats_management_t *sats_management,
                           const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
-void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, sdiff_t *non_ref_sdiffs);
+void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, const sdiff_t *non_ref_sdiffs);
 
 void set_reference_sat_of_prns(u8 ref_prn, u8 num_sats, u8 *prns);
-s8 match_sdiffs_to_sats_man(sats_management_t *sats, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
+s8 match_sdiffs_to_sats_man(const sats_management_t *sats, u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 
 #endif /* LIBSWIFTNAV_SATS_MANAGEMENT_H */

--- a/include/libswiftnav/single_diff.h
+++ b/include/libswiftnav/single_diff.h
@@ -43,8 +43,8 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
 
 bool is_prn_set(u8 len, const u8 *prns);
 
-s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
-                                   u8 num_sdiffs, sdiff_t *sdiffs_in,
+s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dds,
+                                   u8 num_sdiffs, const sdiff_t *sdiffs_in,
                                    double *dd_meas, sdiff_t *sdiffs_out);
 
 s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -244,7 +244,7 @@ void nkf_update(nkf_t *kf, double *measurements)
   DEBUG_EXIT();
 }
 
-void least_squares_solve_b(nkf_t *kf, const sdiff_t *sdiffs_with_ref_first,
+void least_squares_solve_b(const nkf_t *kf, const sdiff_t *sdiffs_with_ref_first,
                       const double *dd_measurements, const double ref_ecef[3],
                       double b[3])
 {
@@ -254,7 +254,7 @@ void least_squares_solve_b(nkf_t *kf, const sdiff_t *sdiffs_with_ref_first,
 
 /* Initializes the ambiguity means and variances.
  * Note that the covariance is  in UDU form, and U starts as identity. */
-static void initialize_state(nkf_t *kf, double *dd_measurements, double init_var)
+static void initialize_state(nkf_t *kf, const double *dd_measurements, double init_var)
 {
   u8 num_dds = kf->state_dim;
   for (u32 i=0; i<num_dds; i++) {
@@ -451,8 +451,8 @@ static void assign_H_prime(u8 res_dim, u8 constraint_dim, u8 num_dds,
  *
  * This function constructs D, U^-1, and H'
  */
-static void get_kf_matrices(u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first,
-                            double ref_ecef[3],
+static void get_kf_matrices(u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first,
+                            const double ref_ecef[3],
                             double phase_var, double code_var,
                             double *null_basis_Q,
                             double *U_inv, double *D,
@@ -494,7 +494,7 @@ static void get_kf_matrices(u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first,
 
 /* REQUIRES num_sats > 1 */
 void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var, double amb_init_var,
-            u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double *dd_measurements, double ref_ecef[3])
+            u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, const double *dd_measurements, const double ref_ecef[3])
 {
   DEBUG_ENTRY();
 
@@ -507,7 +507,7 @@ void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var,
 }
 
 void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
-                     u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double ref_ecef[3])
+                     u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, const double ref_ecef[3])
 {
   assert(num_sdiffs > 1);
 

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -82,7 +82,7 @@ void destroy_ambiguity_test(ambiguity_test_t *amb_test)
  * \param hyp_N       A pointer to the array of s32's to represent the output hyp.
  * \return            0 iff there only one hypothesis in the pool, -1 otherwise.
  */
-s8 get_single_hypothesis(ambiguity_test_t *amb_test, s32 *hyp_N)
+s8 get_single_hypothesis(const ambiguity_test_t *amb_test, s32 *hyp_N)
 {
   if (memory_pool_n_allocated(amb_test->pool) == 1) {
     hypothesis_t hyp;
@@ -130,7 +130,7 @@ static void fold_contains(void *x, element_t *elem)
  * \param ambs        The ambiguity hypothesis to look for.
  * \return            Whether or not the pool contains ambs.
  */
-u8 ambiguity_test_pool_contains(ambiguity_test_t *amb_test, double *ambs)
+u8 ambiguity_test_pool_contains(const ambiguity_test_t *amb_test, double *ambs)
 {
   fold_contains_t acc;
   acc.num_dds = amb_test->sats.num_sats-1;
@@ -183,7 +183,7 @@ static void fold_ll(void *x, element_t *elem)
  * \return            The pseudo log-likelihood of the hypothesis if it is
  *                    in the pool, and a positive number otherwise.
  */
-double ambiguity_test_pool_ll(ambiguity_test_t *amb_test, u8 num_ambs, double *ambs)
+double ambiguity_test_pool_ll(const ambiguity_test_t *amb_test, u8 num_ambs, const double *ambs)
 {
   fold_ll_t acc;
   acc.num_dds = amb_test->sats.num_sats-1;
@@ -218,7 +218,7 @@ static void fold_prob(void *x, element_t *elem)
  * \return            The probability of the hypothesis if it is
  *                    in the pool, and a negative number otherwise.
  */
-double ambiguity_test_pool_prob(ambiguity_test_t *amb_test, u8 num_ambs, double *ambs)
+double ambiguity_test_pool_prob(const ambiguity_test_t *amb_test, u8 num_ambs, const double *ambs)
 {
   fold_ll_t acc;
   acc.num_dds = amb_test->sats.num_sats-1;
@@ -272,7 +272,7 @@ static void fold_mle(void *x, element_t *elem)
  * \param amb_test  The ambiguity test to perform MLE in.
  * \param ambs      The output MLE hypothesis.
  */
-void ambiguity_test_MLE_ambs(ambiguity_test_t *amb_test, s32 *ambs)
+void ambiguity_test_MLE_ambs(const ambiguity_test_t *amb_test, s32 *ambs)
 {
   fold_mle_t mle;
   mle.started = 0;
@@ -304,8 +304,8 @@ void ambiguity_test_MLE_ambs(ambiguity_test_t *amb_test, s32 *ambs)
  *
  *  INVALIDATES unanimous ambiguities
  */
-void update_ambiguity_test(double ref_ecef[3], double phase_var, double code_var,
-                           ambiguity_test_t *amb_test, u8 state_dim, sdiff_t *sdiffs,
+void update_ambiguity_test(const double ref_ecef[3], double phase_var, double code_var,
+                           ambiguity_test_t *amb_test, u8 state_dim, const sdiff_t *sdiffs,
                            u8 changed_sats)
 {
   DEBUG_ENTRY();
@@ -364,7 +364,7 @@ void update_ambiguity_test(double ref_ecef[3], double phase_var, double code_var
  * \param amb_test    The ambiguity test whose number of hypotheses we want.
  * \return            The number of hypotheses currently in the ambiguity test.
  */
-u32 ambiguity_test_n_hypotheses(ambiguity_test_t *amb_test)
+u32 ambiguity_test_n_hypotheses(const ambiguity_test_t *amb_test)
 {
   return memory_pool_n_allocated(amb_test->pool);
 }
@@ -530,7 +530,7 @@ void test_ambiguities(ambiguity_test_t *amb_test, double *dd_measurements)
 
 /* This says whether we can use the ambiguity_test to resolve a position in 3-space.
  */
-u8 ambiguity_iar_can_solve(ambiguity_test_t *amb_test)
+u8 ambiguity_iar_can_solve(const ambiguity_test_t *amb_test)
 {
   return amb_test->amb_check.initialized &&
          amb_test->amb_check.num_matching_ndxs >= 3;
@@ -557,7 +557,7 @@ u8 ambiguity_iar_can_solve(ambiguity_test_t *amb_test)
  * \return error code; see make_dd_measurements_and_sdiffs docstring.
  */
 s8 make_ambiguity_resolved_dd_measurements_and_sdiffs(
-            ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
+            const ambiguity_test_t *amb_test, u8 num_sdiffs, const sdiff_t *sdiffs,
             double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs)
 {
   DEBUG_ENTRY();
@@ -603,13 +603,13 @@ s8 make_ambiguity_resolved_dd_measurements_and_sdiffs(
  *                                  constructed from the input sdiffs.
  * \return error code. see make_dd_measurements_and_sdiffs docstring.
  */
-s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,
+s8 make_ambiguity_dd_measurements_and_sdiffs(const ambiguity_test_t *amb_test, u8 num_sdiffs, const sdiff_t *sdiffs,
                                                double *ambiguity_dd_measurements, sdiff_t *amb_sdiffs)
 {
   DEBUG_ENTRY();
 
   u8 ref_prn = amb_test->sats.prns[0];
-  u8 *non_ref_prns = &amb_test->sats.prns[1];
+  const u8 *non_ref_prns = &amb_test->sats.prns[1];
   u8 num_dds = CLAMP_DIFF(amb_test->sats.num_sats, 1);
   s8 valid_sdiffs = make_dd_measurements_and_sdiffs(ref_prn, non_ref_prns,
                                   num_dds, num_sdiffs, sdiffs,

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -22,34 +22,6 @@
 #include "filter_utils.h"
 #include "ambiguity_test.h"
 
-nkf_t nkf;
-sats_management_t sats_management;
-ambiguity_test_t ambiguity_test;
-
-dgnss_settings_t dgnss_settings = {
-  .phase_var_test = DEFAULT_PHASE_VAR_TEST,
-  .code_var_test = DEFAULT_CODE_VAR_TEST,
-  .phase_var_kf = DEFAULT_PHASE_VAR_KF,
-  .code_var_kf = DEFAULT_CODE_VAR_KF,
-  .amb_drift_var = DEFAULT_AMB_DRIFT_VAR,
-  .amb_init_var = DEFAULT_AMB_INIT_VAR,
-  .new_int_var = DEFAULT_NEW_INT_VAR,
-};
-
-void dgnss_set_settings(double phase_var_test, double code_var_test,
-                        double phase_var_kf, double code_var_kf,
-                        double amb_drift_var, double amb_init_var,
-                        double new_int_var)
-{
-  dgnss_settings.phase_var_test = phase_var_test;
-  dgnss_settings.code_var_test  = code_var_test;
-  dgnss_settings.phase_var_kf   = phase_var_kf;
-  dgnss_settings.code_var_kf    = code_var_kf;
-  dgnss_settings.amb_drift_var  = amb_drift_var;
-  dgnss_settings.amb_init_var   = amb_init_var;
-  dgnss_settings.new_int_var    = new_int_var;
-}
-
 void make_measurements(u8 num_double_diffs, const sdiff_t *sdiffs, double *raw_measurements)
 {
   DEBUG_ENTRY();
@@ -64,10 +36,10 @@ void make_measurements(u8 num_double_diffs, const sdiff_t *sdiffs, double *raw_m
   DEBUG_EXIT();
 }
 
-static bool prns_match(const u8 *old_non_ref_prns, u8 num_non_ref_sdiffs,
+static bool prns_match(const dgnss_state_t *dgs, const u8 *old_non_ref_prns, u8 num_non_ref_sdiffs,
                        const sdiff_t *non_ref_sdiffs)
 {
-  if (sats_management.num_sats-1 != num_non_ref_sdiffs) {
+  if (dgs->sats_management.num_sats-1 != num_non_ref_sdiffs) {
     /* lengths don't match */
     return false;
   }
@@ -104,14 +76,22 @@ static u8 dgnss_intersect_sats(u8 num_old_prns, const u8 *old_prns,
   return n;
 }
 
-void dgnss_init(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3])
+void dgnss_init(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double reciever_ecef[3])
 {
   DEBUG_ENTRY();
+  
+  dgs->settings.phase_var_test = DEFAULT_PHASE_VAR_TEST;
+  dgs->settings.code_var_test = DEFAULT_CODE_VAR_TEST;
+  dgs->settings.phase_var_kf = DEFAULT_PHASE_VAR_KF;
+  dgs->settings.code_var_kf = DEFAULT_CODE_VAR_KF;
+  dgs->settings.amb_drift_var = DEFAULT_AMB_DRIFT_VAR;
+  dgs->settings.amb_init_var = DEFAULT_AMB_INIT_VAR;
+  dgs->settings.new_int_var = DEFAULT_NEW_INT_VAR;
 
   sdiff_t corrected_sdiffs[num_sats];
-  init_sats_management(&sats_management, num_sats, sdiffs, corrected_sdiffs);
+  init_sats_management(&dgs->sats_management, num_sats, sdiffs, corrected_sdiffs);
 
-  create_ambiguity_test(&ambiguity_test);
+  create_ambiguity_test(&dgs->ambiguity_test);
 
   if (num_sats <= 1) {
     DEBUG_EXIT();
@@ -122,25 +102,25 @@ void dgnss_init(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3])
   make_measurements(num_sats-1, corrected_sdiffs, dd_measurements);
 
   set_nkf(
-    &nkf,
-    dgnss_settings.amb_drift_var,
-    dgnss_settings.phase_var_kf, dgnss_settings.code_var_kf,
-    dgnss_settings.amb_init_var,
+    &dgs->nkf,
+    dgs->settings.amb_drift_var,
+    dgs->settings.phase_var_kf, dgs->settings.code_var_kf,
+    dgs->settings.amb_init_var,
     num_sats, corrected_sdiffs, dd_measurements, reciever_ecef
   );
 
   DEBUG_EXIT();
 }
 
-void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double reciever_ecef[3], u8 old_prns[MAX_CHANNELS], sdiff_t *corrected_sdiffs)
+void dgnss_rebase_ref(dgnss_state_t*dgs, u8 num_sdiffs, const sdiff_t *sdiffs, const double reciever_ecef[3], u8 old_prns[MAX_CHANNELS], sdiff_t *corrected_sdiffs)
 {
   (void)reciever_ecef;
   /* all the ref sat stuff */
-  s8 sats_management_code = rebase_sats_management(&sats_management, num_sdiffs, sdiffs, corrected_sdiffs);
+  s8 sats_management_code = rebase_sats_management(&dgs->sats_management, num_sdiffs, sdiffs, corrected_sdiffs);
   if (sats_management_code == NEW_REF_START_OVER) {
-    log_info("Unable to rebase to new ref, resetting filters and starting over\n");
-    dgnss_init(num_sdiffs, sdiffs, reciever_ecef);
-    memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+    log_error("Unable to rebase to new ref, resetting filters and starting over\n");
+    dgnss_init(dgs, num_sdiffs, sdiffs, reciever_ecef);
+    memcpy(old_prns, &dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
     if (num_sdiffs >= 1) {
       copy_sdiffs_put_ref_first(old_prns[0], num_sdiffs, sdiffs, corrected_sdiffs);
     }
@@ -149,12 +129,12 @@ void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double reciever_ecef[3], u
   }
   else if (sats_management_code == NEW_REF) {
     /* do everything related to changing the reference sat here */
-    rebase_nkf(&nkf, sats_management.num_sats, &old_prns[0], &sats_management.prns[0]);
+    rebase_nkf(&dgs->nkf, dgs->sats_management.num_sats, &old_prns[0], &dgs->sats_management.prns[0]);
   }
 }
 
 
-static void sdiffs_to_prns(u8 n, sdiff_t *sdiffs, u8 *prns)
+static void sdiffs_to_prns(u8 n, const sdiff_t *sdiffs, u8 *prns)
 {
   for (u8 i=0; i<n; i++) {
     prns[i] = sdiffs[i].prn;
@@ -184,39 +164,39 @@ static void dgnss_simple_amb_meas(const u8 num_sdiffs,
   }
 }
 
-static void dgnss_update_sats(u8 num_sdiffs, double reciever_ecef[3],
-                              sdiff_t *sdiffs_with_ref_first,
-                              double *dd_measurements)
+static void dgnss_update_sats(dgnss_state_t *dgs, u8 num_sdiffs, const double reciever_ecef[3],
+                              const sdiff_t *sdiffs_with_ref_first,
+                              const double *dd_measurements __attribute__((unused)))
 {
   DEBUG_ENTRY();
 
-  (void)dd_measurements;
   u8 new_prns[num_sdiffs];
   sdiffs_to_prns(num_sdiffs, sdiffs_with_ref_first, new_prns);
 
   u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  memcpy(old_prns, dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
 
-  if (!prns_match(&old_prns[1], num_sdiffs-1, &sdiffs_with_ref_first[1])) {
-    u8 ndx_of_intersection_in_old[sats_management.num_sats];
-    u8 ndx_of_intersection_in_new[sats_management.num_sats];
+  if (!prns_match(dgs, &old_prns[1], num_sdiffs-1, &sdiffs_with_ref_first[1])) {
+    log_warn("dgnss_update_sats: prns don't match");
+    u8 ndx_of_intersection_in_old[dgs->sats_management.num_sats];
+    u8 ndx_of_intersection_in_new[dgs->sats_management.num_sats];
     ndx_of_intersection_in_old[0] = 0;
     ndx_of_intersection_in_new[0] = 0;
     u8 num_intersection_sats = dgnss_intersect_sats(
-        sats_management.num_sats-1, &old_prns[1],
+        dgs->sats_management.num_sats-1, &old_prns[1],
         num_sdiffs-1, &sdiffs_with_ref_first[1],
         &ndx_of_intersection_in_old[1],
         &ndx_of_intersection_in_new[1]) + 1;
 
     set_nkf_matrices(
-      &nkf,
-      dgnss_settings.phase_var_kf, dgnss_settings.code_var_kf,
+      &dgs->nkf,
+      dgs->settings.phase_var_kf, dgs->settings.code_var_kf,
       num_sdiffs, sdiffs_with_ref_first, reciever_ecef
     );
 
-    if (num_intersection_sats < sats_management.num_sats) { /* we lost sats */
-      nkf_state_projection(&nkf,
-                           sats_management.num_sats-1,
+    if (num_intersection_sats < dgs->sats_management.num_sats) { /* we lost sats */
+      nkf_state_projection(&dgs->nkf,
+                           dgs->sats_management.num_sats-1,
                            num_intersection_sats-1,
                            &ndx_of_intersection_in_old[1]);
     }
@@ -224,20 +204,20 @@ static void dgnss_update_sats(u8 num_sdiffs, double reciever_ecef[3],
       double simple_estimates[num_sdiffs-1];
       dgnss_simple_amb_meas(num_sdiffs, sdiffs_with_ref_first,
                             simple_estimates);
-      nkf_state_inclusion(&nkf,
+      nkf_state_inclusion(&dgs->nkf,
                           num_intersection_sats-1,
                           num_sdiffs-1,
                           &ndx_of_intersection_in_new[1],
                           simple_estimates,
-                          dgnss_settings.new_int_var);
+                          dgs->settings.new_int_var);
     }
 
-    update_sats_sats_management(&sats_management, num_sdiffs-1, &sdiffs_with_ref_first[1]);
+    update_sats_sats_management(&dgs->sats_management, num_sdiffs-1, &sdiffs_with_ref_first[1]);
   }
   else {
     set_nkf_matrices(
-      &nkf,
-      dgnss_settings.phase_var_kf, dgnss_settings.code_var_kf,
+      &dgs->nkf,
+      dgs->settings.phase_var_kf, dgs->settings.code_var_kf,
       num_sdiffs, sdiffs_with_ref_first, reciever_ecef
     );
   }
@@ -245,13 +225,13 @@ static void dgnss_update_sats(u8 num_sdiffs, double reciever_ecef[3],
   DEBUG_EXIT();
 }
 
-static void dgnss_incorporate_observation(sdiff_t *sdiffs, double * dd_measurements,
-                                          double *reciever_ecef)
+static void dgnss_incorporate_observation(dgnss_state_t *dgs, const sdiff_t *sdiffs, double *dd_measurements,
+                                          const double *reciever_ecef)
 {
   DEBUG_ENTRY();
 
   double b2[3];
-  least_squares_solve_b(&nkf, sdiffs, dd_measurements, reciever_ecef, b2);
+  least_squares_solve_b(&dgs->nkf, sdiffs, dd_measurements, reciever_ecef, b2);
 
   double ref_ecef[3];
 
@@ -261,140 +241,140 @@ static void dgnss_incorporate_observation(sdiff_t *sdiffs, double * dd_measureme
 
   /* TODO: make a common DE and use it instead. */
 
-  set_nkf_matrices(&nkf,
-                   dgnss_settings.phase_var_kf, dgnss_settings.code_var_kf,
-                   sats_management.num_sats, sdiffs, ref_ecef);
+  set_nkf_matrices(&dgs->nkf,
+                   dgs->settings.phase_var_kf, dgs->settings.code_var_kf,
+                   dgs->sats_management.num_sats, sdiffs, ref_ecef);
 
-  nkf_update(&nkf, dd_measurements);
+  nkf_update(&dgs->nkf, dd_measurements);
   DEBUG_EXIT();
 }
 
-void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3])
+void dgnss_update(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double reciever_ecef[3])
 {
   DEBUG_ENTRY();
   if (DEBUG) {
     printf("sdiff[*].prn = {");
     for (u8 i=0; i < num_sats; i++) {
-      printf("%u, ",sdiffs[i].prn);
+      printf("%u, ", sdiffs[i].prn);
     }
     printf("}\n");
   }
 
   if (num_sats <= 1) {
-    sats_management.num_sats = num_sats;
+    dgs->sats_management.num_sats = num_sats;
     if (num_sats == 1) {
-      sats_management.prns[0] = sdiffs[0].prn;
+      dgs->sats_management.prns[0] = sdiffs[0].prn;
     }
-    create_ambiguity_test(&ambiguity_test);
+    create_ambiguity_test(&dgs->ambiguity_test);
     DEBUG_EXIT();
     return;
   }
 
-  if (sats_management.num_sats <= 1) {
-    dgnss_init(num_sats, sdiffs, reciever_ecef);
+  if (dgs->sats_management.num_sats <= 1) {
+    dgnss_init(dgs, num_sats, sdiffs, reciever_ecef);
   }
 
   sdiff_t sdiffs_with_ref_first[num_sats];
 
   u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  memcpy(old_prns, dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
 
   /* rebase globals to a new reference sat
    * (permutes sdiffs_with_ref_first accordingly) */
-  dgnss_rebase_ref(num_sats, sdiffs, reciever_ecef, old_prns, sdiffs_with_ref_first);
+  dgnss_rebase_ref(dgs, num_sats, sdiffs, reciever_ecef, old_prns, sdiffs_with_ref_first);
 
   double dd_measurements[2*(num_sats-1)];
   make_measurements(num_sats-1, sdiffs_with_ref_first, dd_measurements);
 
   /* all the added/dropped sat stuff */
-  dgnss_update_sats(num_sats, reciever_ecef, sdiffs_with_ref_first, dd_measurements);
+  dgnss_update_sats(dgs, num_sats, reciever_ecef, sdiffs_with_ref_first, dd_measurements);
 
   double ref_ecef[3];
   if (num_sats >= 5) {
-    dgnss_incorporate_observation(sdiffs_with_ref_first, dd_measurements, reciever_ecef);
+    dgnss_incorporate_observation(dgs, sdiffs_with_ref_first, dd_measurements, reciever_ecef);
 
     double b2[3];
-    least_squares_solve_b(&nkf, sdiffs_with_ref_first, dd_measurements, reciever_ecef, b2);
+    least_squares_solve_b(&dgs->nkf, sdiffs_with_ref_first, dd_measurements, reciever_ecef, b2);
 
     ref_ecef[0] = reciever_ecef[0] + 0.5 * b2[0];
     ref_ecef[1] = reciever_ecef[1] + 0.5 * b2[1];
     ref_ecef[2] = reciever_ecef[2] + 0.5 * b2[2];
   }
 
-  u8 changed_sats = ambiguity_update_sats(&ambiguity_test, num_sats, sdiffs,
-                                          &sats_management, nkf.state_mean,
-                                          nkf.state_cov_U, nkf.state_cov_D);
+  u8 changed_sats = ambiguity_update_sats(&dgs->ambiguity_test, num_sats, sdiffs,
+                                          &dgs->sats_management, dgs->nkf.state_mean,
+                                          dgs->nkf.state_cov_U, dgs->nkf.state_cov_D);
 
   update_ambiguity_test(ref_ecef,
-                        dgnss_settings.phase_var_test,
-                        dgnss_settings.code_var_test,
-                        &ambiguity_test, nkf.state_dim,
+                        dgs->settings.phase_var_test,
+                        dgs->settings.code_var_test,
+                        &dgs->ambiguity_test, dgs->nkf.state_dim,
                         sdiffs, changed_sats);
 
-  update_unanimous_ambiguities(&ambiguity_test);
+  update_unanimous_ambiguities(&dgs->ambiguity_test);
 
   if (DEBUG) {
     if (num_sats >=4) {
       double b3[3];
-      least_squares_solve_b(&nkf, sdiffs_with_ref_first, dd_measurements, reciever_ecef, b3);
+      least_squares_solve_b(&dgs->nkf, sdiffs_with_ref_first, dd_measurements, reciever_ecef, b3);
 
       ref_ecef[0] = reciever_ecef[0] + 0.5 * b3[0];
       ref_ecef[1] = reciever_ecef[1] + 0.5 * b3[1];
       ref_ecef[2] = reciever_ecef[2] + 0.5 * b3[2];
       double bb[3];
       u8 num_used;
-      dgnss_fixed_baseline(num_sats, sdiffs, ref_ecef,
+      dgnss_fixed_baseline(dgs, num_sats, sdiffs, ref_ecef,
                            &num_used, bb);
       log_debug("\ndgnss_fixed_baseline:\nb = %f, \t%f, \t%f\nnum_used/num_sats = %u/%u\nusing_iar = %u\n\n",
              bb[0], bb[1], bb[2],
              num_used, num_sats,
-             ambiguity_iar_can_solve(&ambiguity_test));
+             ambiguity_iar_can_solve(&dgs->ambiguity_test));
     }
   }
   DEBUG_EXIT();
 }
 
-u32 dgnss_iar_num_hyps(void)
+u32 dgnss_iar_num_hyps(const dgnss_state_t *dgs)
 {
-  if (ambiguity_test.pool == NULL) {
+  if (dgs->ambiguity_test.pool == NULL) {
     return 0;
   } else {
-    return ambiguity_test_n_hypotheses(&ambiguity_test);
+    return ambiguity_test_n_hypotheses(&dgs->ambiguity_test);
   }
 }
 
-u32 dgnss_iar_num_sats(void)
+u32 dgnss_iar_num_sats(const dgnss_state_t *dgs)
 {
-  return ambiguity_test.sats.num_sats;
+  return dgs->ambiguity_test.sats.num_sats;
 }
 
-s8 dgnss_iar_get_single_hyp(double *dhyp)
+s8 dgnss_iar_get_single_hyp(const dgnss_state_t *dgs, double *dhyp)
 {
-  u8 num_dds = ambiguity_test.sats.num_sats;
+  u8 num_dds = dgs->ambiguity_test.sats.num_sats;
   s32 hyp[num_dds];
-  s8 ret = get_single_hypothesis(&ambiguity_test, hyp);
+  s8 ret = get_single_hypothesis(&dgs->ambiguity_test, hyp);
   for (u8 i=0; i<num_dds; i++) {
     dhyp[i] = hyp[i];
   }
   return ret;
 }
 
-void dgnss_new_float_baseline(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3], u8 *num_used, double b[3])
+void dgnss_new_float_baseline(dgnss_state_t *dgs, u8 num_sats, const sdiff_t *sdiffs, const double receiver_ecef[3], u8 *num_used, double b[3])
 {
   DEBUG_ENTRY();
   sdiff_t corrected_sdiffs[num_sats];
 
   u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  memcpy(old_prns, dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
   /* Rebase globals to a new reference sat
    * (permutes corrected_sdiffs accordingly) */
-  dgnss_rebase_ref(num_sats, sdiffs, receiver_ecef, old_prns, corrected_sdiffs);
+  dgnss_rebase_ref(dgs, num_sats, sdiffs, receiver_ecef, old_prns, corrected_sdiffs);
 
   double dd_measurements[2*(num_sats-1)];
   make_measurements(num_sats-1, corrected_sdiffs, dd_measurements);
 
-  least_squares_solve_b(&nkf, corrected_sdiffs, dd_measurements, receiver_ecef, b);
-  *num_used = sats_management.num_sats;
+  least_squares_solve_b(&dgs->nkf, corrected_sdiffs, dd_measurements, receiver_ecef, b);
+  *num_used = dgs->sats_management.num_sats;
   DEBUG_EXIT();
 }
 
@@ -404,18 +384,18 @@ void dgnss_new_float_baseline(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef
  *         0 If iar cannot solve or an error occurs. Signals that float
  *           baseline is needed instead.
  */
-s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
+s8 dgnss_fixed_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
                         u8 *num_used, double b[3])
 {
-  if (!ambiguity_iar_can_solve(&ambiguity_test)) {
+  if (!ambiguity_iar_can_solve(&dgs->ambiguity_test)) {
     return 0;
   }
 
-  sdiff_t ambiguity_sdiffs[ambiguity_test.amb_check.num_matching_ndxs+1];
-  double dd_meas[2 * ambiguity_test.amb_check.num_matching_ndxs];
+  sdiff_t ambiguity_sdiffs[dgs->ambiguity_test.amb_check.num_matching_ndxs+1];
+  double dd_meas[2 * dgs->ambiguity_test.amb_check.num_matching_ndxs];
 
   s8 valid_sdiffs = make_ambiguity_resolved_dd_measurements_and_sdiffs(
-      &ambiguity_test, num_sdiffs, sdiffs, dd_meas, ambiguity_sdiffs);
+      &dgs->ambiguity_test, num_sdiffs, sdiffs, dd_meas, ambiguity_sdiffs);
 
   /* At this point, sdiffs should be valid due to dgnss_update
    * Return code not equal to 0 signals an error. */
@@ -426,12 +406,12 @@ s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
     return 0;
   }
 
-  double DE[ambiguity_test.amb_check.num_matching_ndxs * 3];
-  assign_de_mtx(ambiguity_test.amb_check.num_matching_ndxs + 1,
+  double DE[dgs->ambiguity_test.amb_check.num_matching_ndxs * 3];
+  assign_de_mtx(dgs->ambiguity_test.amb_check.num_matching_ndxs + 1,
                 ambiguity_sdiffs, ref_ecef, DE);
-  *num_used = ambiguity_test.amb_check.num_matching_ndxs + 1;
-  s8 ret = lesq_solution_int(ambiguity_test.amb_check.num_matching_ndxs, dd_meas,
-                             ambiguity_test.amb_check.ambs, DE, b, 0);
+  *num_used = dgs->ambiguity_test.amb_check.num_matching_ndxs + 1;
+  s8 ret = lesq_solution_int(dgs->ambiguity_test.amb_check.num_matching_ndxs, dd_meas,
+                             dgs->ambiguity_test.amb_check.ambs, DE, b, 0);
   if (ret) {
     log_error("dgnss_fixed_baseline: "
               "lesq_solution returned error %d\n", ret);
@@ -467,11 +447,11 @@ s8 dgnss_fixed_baseline(u8 num_sdiffs, sdiff_t *sdiffs, double ref_ecef[3],
  * \return -1 if it can't solve.
  *          0 If it can solve.
  */
-s8 _dgnss_low_latency_float_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                                     double ref_ecef[3], u8 *num_used, double b[3])
+s8 _dgnss_low_latency_float_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                                     const double ref_ecef[3], u8 *num_used, double b[3])
 {
   DEBUG_ENTRY();
-  if (num_sdiffs < 4 || sats_management.num_sats < 4) {
+  if (num_sdiffs < 4 || dgs->sats_management.num_sats < 4) {
     /* For a position solution, we need at least 4 sats. That means we must
      * have at least 4 sats in common between what the KF is tracking and
      * the sdiffs we give this function. If either is less than 4,
@@ -482,10 +462,10 @@ s8 _dgnss_low_latency_float_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
     return -1;
   }
 
-  double float_dd_measurements[2 * (sats_management.num_sats - 1)];
-  sdiff_t float_sdiffs[sats_management.num_sats];
-  s8 can_make_obs = make_dd_measurements_and_sdiffs(sats_management.prns[0],
-             &sats_management.prns[1], sats_management.num_sats - 1,
+  double float_dd_measurements[2 * (dgs->sats_management.num_sats - 1)];
+  sdiff_t float_sdiffs[dgs->sats_management.num_sats];
+  s8 can_make_obs = make_dd_measurements_and_sdiffs(dgs->sats_management.prns[0],
+             &dgs->sats_management.prns[1], dgs->sats_management.num_sats - 1,
              num_sdiffs, sdiffs,
              float_dd_measurements, float_sdiffs);
   if (can_make_obs == -1) {
@@ -493,9 +473,9 @@ s8 _dgnss_low_latency_float_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
     DEBUG_EXIT();
     return -1;
   }
-  least_squares_solve_b(&nkf, float_sdiffs, float_dd_measurements,
+  least_squares_solve_b(&dgs->nkf, float_sdiffs, float_dd_measurements,
                         ref_ecef, b);
-  *num_used = sats_management.num_sats;
+  *num_used = dgs->sats_management.num_sats;
   DEBUG_EXIT();
   return 0;
 }
@@ -528,21 +508,21 @@ s8 _dgnss_low_latency_float_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
  * \return -1 if it can't solve.
  *          0 If it can solve.
  */
-s8 _dgnss_low_latency_IAR_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                                   double ref_ecef[3], u8 *num_used, double b[3])
+s8 _dgnss_low_latency_IAR_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                                   const double ref_ecef[3], u8 *num_used, double b[3])
 {
   DEBUG_ENTRY();
   assert(num_sdiffs >= 4);
-  if (!ambiguity_iar_can_solve(&ambiguity_test)) {
+  if (!ambiguity_iar_can_solve(&dgs->ambiguity_test)) {
     DEBUG_EXIT();
     return -1;
   }
 
-  sdiff_t ambiguity_sdiffs[ambiguity_test.amb_check.num_matching_ndxs+1];
-  double dd_meas[2 * ambiguity_test.amb_check.num_matching_ndxs];
+  sdiff_t ambiguity_sdiffs[dgs->ambiguity_test.amb_check.num_matching_ndxs+1];
+  double dd_meas[2 * dgs->ambiguity_test.amb_check.num_matching_ndxs];
 
   s8 valid_sdiffs = make_ambiguity_resolved_dd_measurements_and_sdiffs(
-      &ambiguity_test, num_sdiffs, sdiffs, dd_meas, ambiguity_sdiffs);
+      &dgs->ambiguity_test, num_sdiffs, sdiffs, dd_meas, ambiguity_sdiffs);
 
   if (valid_sdiffs != 0) {
     if (valid_sdiffs != -1) {
@@ -553,12 +533,12 @@ s8 _dgnss_low_latency_IAR_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
   }
 
   /* TODO: check internals of this if's content and abstract it from the KF */
-  double DE[ambiguity_test.amb_check.num_matching_ndxs * 3];
-  assign_de_mtx(ambiguity_test.amb_check.num_matching_ndxs + 1,
+  double DE[dgs->ambiguity_test.amb_check.num_matching_ndxs * 3];
+  assign_de_mtx(dgs->ambiguity_test.amb_check.num_matching_ndxs + 1,
                 ambiguity_sdiffs, ref_ecef, DE);
-  *num_used = ambiguity_test.amb_check.num_matching_ndxs + 1;
-  s8 ret = lesq_solution_int(ambiguity_test.amb_check.num_matching_ndxs,
-                             dd_meas, ambiguity_test.amb_check.ambs, DE, b, 0);
+  *num_used = dgs->ambiguity_test.amb_check.num_matching_ndxs + 1;
+  s8 ret = lesq_solution_int(dgs->ambiguity_test.amb_check.num_matching_ndxs,
+                             dd_meas, dgs->ambiguity_test.amb_check.ambs, DE, b, 0);
   if (ret) {
     log_error("_dgnss_low_latency_IAR_baseline: "
               "lesq_solution returned error %d\n", ret);
@@ -586,11 +566,11 @@ s8 _dgnss_low_latency_IAR_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
  *          2 if we are using a float baseline.
  *         -1 if we can't give a baseline.
  */
-s8 dgnss_low_latency_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
-                              double ref_ecef[3], u8 *num_used, double b[3])
+s8 dgnss_low_latency_baseline(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
+                              const double ref_ecef[3], u8 *num_used, double b[3])
 {
   DEBUG_ENTRY();
-  if (num_sdiffs < 4 || sats_management.num_sats < 4) {
+  if (num_sdiffs < 4 || dgs->sats_management.num_sats < 4) {
     /* For a position solution, we need at least 4 sats. That means we must
      * have at least 4 sats in common between what the filters are tracking and
      * the sdiffs we give this function. If num_sdiffs, or the number of KF
@@ -600,7 +580,7 @@ s8 dgnss_low_latency_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
     DEBUG_EXIT();
     return -1;
   }
-  if (0 == _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  if (0 == _dgnss_low_latency_IAR_baseline(dgs, num_sdiffs, sdiffs,
                                   ref_ecef, num_used, b)) {
     log_debug("low latency IAR solution\n");
     DEBUG_EXIT();
@@ -608,7 +588,7 @@ s8 dgnss_low_latency_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
   }
   /* if we get here, we weren't able to get an IAR resolved baseline.
    * Check if we can get a float baseline. */
-  s8 float_ret_code = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 float_ret_code = _dgnss_low_latency_float_baseline(dgs, num_sdiffs, sdiffs,
                                               ref_ecef, num_used, b);
   if (float_ret_code == 0) {
     log_debug("low latency float solution\n");
@@ -620,12 +600,12 @@ s8 dgnss_low_latency_baseline(u8 num_sdiffs, sdiff_t *sdiffs,
   return -1;
 }
 
-void dgnss_reset_iar()
+void dgnss_reset_iar(dgnss_state_t *dgs)
 {
-  create_ambiguity_test(&ambiguity_test);
+  create_ambiguity_test(&dgs->ambiguity_test);
 }
 
-void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs,
+void dgnss_init_known_baseline(dgnss_state_t *dgs, u8 num_sats, sdiff_t *sdiffs,
                                double receiver_ecef[3], double b[3])
 {
   double ref_ecef[3];
@@ -636,10 +616,10 @@ void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs,
   sdiff_t corrected_sdiffs[num_sats];
 
   u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  memcpy(old_prns, dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
   /* rebase globals to a new reference sat
    * (permutes corrected_sdiffs accordingly) */
-  dgnss_rebase_ref(num_sats, sdiffs, ref_ecef, old_prns, corrected_sdiffs);
+  dgnss_rebase_ref(dgs, num_sats, sdiffs, ref_ecef, old_prns, corrected_sdiffs);
 
   double dds[2*(num_sats-1)];
   make_measurements(num_sats-1, corrected_sdiffs, dds);
@@ -647,10 +627,10 @@ void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs,
   double DE[(num_sats-1)*3];
   assign_de_mtx(num_sats, corrected_sdiffs, ref_ecef, DE);
 
-  dgnss_reset_iar();
+  dgnss_reset_iar(dgs);
 
-  memcpy(&ambiguity_test.sats, &sats_management, sizeof(sats_management));
-  hypothesis_t *hyp = (hypothesis_t *)memory_pool_add(ambiguity_test.pool);
+  memcpy(&dgs->ambiguity_test.sats, &dgs->sats_management, sizeof(dgs->sats_management));
+  hypothesis_t *hyp = (hypothesis_t *)memory_pool_add(dgs->ambiguity_test.pool);
   hyp->ll = 0;
   amb_from_baseline(num_sats-1, DE, dds, b, hyp->N);
 
@@ -662,17 +642,17 @@ void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs,
       u8 i_ = i+num_dds;
       u8 j_ = j+num_dds;
       if (i==j) {
-        obs_cov[i*2*num_dds + j] = dgnss_settings.phase_var_test * 2;
-        obs_cov[i_*2*num_dds + j_] = dgnss_settings.code_var_test * 2;
+        obs_cov[i*2*num_dds + j] = dgs->settings.phase_var_test * 2;
+        obs_cov[i_*2*num_dds + j_] = dgs->settings.code_var_test * 2;
       }
       else {
-        obs_cov[i*2*num_dds + j] = dgnss_settings.phase_var_test;
-        obs_cov[i_*2*num_dds + j_] = dgnss_settings.code_var_test;
+        obs_cov[i*2*num_dds + j] = dgs->settings.phase_var_test;
+        obs_cov[i_*2*num_dds + j_] = dgs->settings.code_var_test;
       }
     }
   }
 
-  init_residual_matrices(&ambiguity_test.res_mtxs, num_sats-1, DE, obs_cov);
+  init_residual_matrices(&dgs->ambiguity_test.res_mtxs, num_sats-1, DE, obs_cov);
 }
 
 static void measure_b(u8 state_dim, const double *state_mean,
@@ -701,7 +681,7 @@ static void measure_b(u8 state_dim, const double *state_mean,
 }
 
 
-void measure_b_with_external_ambs(u8 state_dim, const double *state_mean,
+void measure_b_with_external_ambs(const dgnss_state_t *dgs, u8 state_dim, const double *state_mean,
                                   u8 num_sdiffs, sdiff_t *sdiffs,
                                   const double receiver_ecef[3], double *b)
 {
@@ -709,7 +689,7 @@ void measure_b_with_external_ambs(u8 state_dim, const double *state_mean,
 
   sdiff_t sdiffs_with_ref_first[num_sdiffs];
   /* We require the sats updating has already been done with these sdiffs */
-  u8 ref_prn = sats_management.prns[0];
+  u8 ref_prn = dgs->sats_management.prns[0];
   copy_sdiffs_put_ref_first(ref_prn, num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
   measure_b(state_dim, state_mean, num_sdiffs, sdiffs_with_ref_first, receiver_ecef, b);
@@ -717,41 +697,41 @@ void measure_b_with_external_ambs(u8 state_dim, const double *state_mean,
   DEBUG_EXIT();
 }
 
-void measure_amb_kf_b(u8 num_sdiffs, sdiff_t *sdiffs,
+void measure_amb_kf_b(const dgnss_state_t *dgs, u8 num_sdiffs, const sdiff_t *sdiffs,
                       const double receiver_ecef[3], double *b)
 {
   DEBUG_ENTRY();
 
   sdiff_t sdiffs_with_ref_first[num_sdiffs];
   /* We require the sats updating has already been done with these sdiffs */
-  u8 ref_prn = sats_management.prns[0];
+  u8 ref_prn = dgs->sats_management.prns[0];
   copy_sdiffs_put_ref_first(ref_prn, num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
-  measure_b( nkf.state_dim, nkf.state_mean,
+  measure_b(dgs->nkf.state_dim, dgs->nkf.state_mean,
       num_sdiffs, sdiffs_with_ref_first, receiver_ecef, b);
 
   DEBUG_EXIT();
 }
 
-void measure_iar_b_with_external_ambs(double *state_mean,
-                                      u8 num_sdiffs, sdiff_t *sdiffs,
-                                      double receiver_ecef[3],
+void measure_iar_b_with_external_ambs(const dgnss_state_t *dgs, double *state_mean,
+                                      u8 num_sdiffs, const sdiff_t *sdiffs,
+                                      const double receiver_ecef[3],
                                       double *b)
 {
   DEBUG_ENTRY();
 
   sdiff_t sdiffs_with_ref_first[num_sdiffs];
-  match_sdiffs_to_sats_man(&ambiguity_test.sats, num_sdiffs, sdiffs, sdiffs_with_ref_first);
+  match_sdiffs_to_sats_man(&dgs->ambiguity_test.sats, num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
-  measure_b(CLAMP_DIFF(ambiguity_test.sats.num_sats, 1), state_mean,
+  measure_b(CLAMP_DIFF(dgs->ambiguity_test.sats.num_sats, 1), state_mean,
       num_sdiffs, sdiffs_with_ref_first, receiver_ecef, b);
 
   DEBUG_EXIT();
 }
 
-static u8 get_de_and_phase(sats_management_t *sats_man,
-                           u8 num_sdiffs, sdiff_t *sdiffs,
-                           double ref_ecef[3],
+static u8 get_de_and_phase(const sats_management_t *sats_man,
+                           u8 num_sdiffs, const sdiff_t *sdiffs,
+                           const double ref_ecef[3],
                            double *de, double *phase)
 {
   u8 ref_prn = sats_man->prns[0];
@@ -798,89 +778,74 @@ static u8 get_de_and_phase(sats_management_t *sats_man,
   return num_sats;
 }
 
-u8 get_amb_kf_de_and_phase(u8 num_sdiffs, sdiff_t *sdiffs,
+u8 get_amb_kf_de_and_phase(const dgnss_state_t *dgs, u8 num_sdiffs, sdiff_t *sdiffs,
                            double ref_ecef[3],
                            double *de, double *phase)
 {
-  return get_de_and_phase(&sats_management,
+  return get_de_and_phase(&dgs->sats_management,
                           num_sdiffs, sdiffs,
                           ref_ecef,
                           de, phase);
 }
 
-u8 get_iar_de_and_phase(u8 num_sdiffs, sdiff_t *sdiffs,
+u8 get_iar_de_and_phase(const dgnss_state_t *dgs, u8 num_sdiffs, sdiff_t *sdiffs,
                         double ref_ecef[3],
                         double *de, double *phase)
 {
-  return get_de_and_phase(&ambiguity_test.sats,
+  return get_de_and_phase(&dgs->ambiguity_test.sats,
                           num_sdiffs, sdiffs,
                           ref_ecef,
                           de, phase);
 }
 
-u8 get_amb_kf_mean(double *ambs)
+u8 get_amb_kf_mean(const dgnss_state_t *dgs, double *ambs)
 {
-  u8 num_dds = CLAMP_DIFF(sats_management.num_sats, 1);
-  memcpy(ambs, nkf.state_mean, num_dds * sizeof(double));
+  u8 num_dds = CLAMP_DIFF(dgs->sats_management.num_sats, 1);
+  memcpy(ambs, dgs->nkf.state_mean, num_dds * sizeof(double));
   return num_dds;
 }
 
-u8 get_amb_kf_cov(double *cov)
+u8 get_amb_kf_cov(const dgnss_state_t *dgs, double *cov)
 {
-  u8 num_dds = CLAMP_DIFF(sats_management.num_sats, 1);
-  matrix_reconstruct_udu(num_dds, nkf.state_cov_U, nkf.state_cov_D, cov);
+  u8 num_dds = CLAMP_DIFF(dgs->sats_management.num_sats, 1);
+  matrix_reconstruct_udu(num_dds, dgs->nkf.state_cov_U, dgs->nkf.state_cov_D, cov);
   return num_dds;
 }
 
-u8 get_amb_kf_prns(u8 *prns)
+u8 get_amb_kf_prns(const dgnss_state_t *dgs, u8 *prns)
 {
-  memcpy(prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
-  return sats_management.num_sats;
+  memcpy(prns, dgs->sats_management.prns, dgs->sats_management.num_sats * sizeof(u8));
+  return dgs->sats_management.num_sats;
 }
 
-u8 get_amb_test_prns(u8 *prns)
+u8 get_amb_test_prns(const dgnss_state_t *dgs, u8 *prns)
 {
-  memcpy(prns, ambiguity_test.sats.prns, ambiguity_test.sats.num_sats * sizeof(u8));
-  return ambiguity_test.sats.num_sats;
+  memcpy(prns, dgs->ambiguity_test.sats.prns, dgs->ambiguity_test.sats.num_sats * sizeof(u8));
+  return dgs->ambiguity_test.sats.num_sats;
 }
 
-s8 dgnss_iar_resolved()
+s8 dgnss_iar_resolved(const dgnss_state_t *dgs)
 {
-  return ambiguity_iar_can_solve(&ambiguity_test);
+  return ambiguity_iar_can_solve(&dgs->ambiguity_test);
 }
 
-u8 dgnss_iar_pool_contains(double *ambs)
+u8 dgnss_iar_pool_contains(const dgnss_state_t *dgs, double *ambs)
 {
-  return ambiguity_test_pool_contains(&ambiguity_test, ambs);
+  return ambiguity_test_pool_contains(&dgs->ambiguity_test, ambs);
 }
 
-double dgnss_iar_pool_ll(u8 num_ambs, double *ambs)
+double dgnss_iar_pool_ll(const dgnss_state_t *dgs, u8 num_ambs, double *ambs)
 {
-  return ambiguity_test_pool_ll(&ambiguity_test, num_ambs, ambs);
+  return ambiguity_test_pool_ll(&dgs->ambiguity_test, num_ambs, ambs);
 }
 
-double dgnss_iar_pool_prob(u8 num_ambs, double *ambs)
+double dgnss_iar_pool_prob(const dgnss_state_t *dgs, u8 num_ambs, double *ambs)
 {
-  return ambiguity_test_pool_prob(&ambiguity_test, num_ambs, ambs);
+  return ambiguity_test_pool_prob(&dgs->ambiguity_test, num_ambs, ambs);
 }
 
-u8 dgnss_iar_MLE_ambs(s32 *ambs)
+u8 dgnss_iar_MLE_ambs(const dgnss_state_t *dgs, s32 *ambs)
 {
-  ambiguity_test_MLE_ambs(&ambiguity_test, ambs);
-  return CLAMP_DIFF(ambiguity_test.sats.num_sats, 1);
-}
-
-nkf_t* get_dgnss_nkf(void)
-{
-  return &nkf;
-}
-
-sats_management_t* get_sats_management(void)
-{
-  return &sats_management;
-}
-
-ambiguity_test_t* get_ambiguity_test(void)
-{
-  return &ambiguity_test;
+  ambiguity_test_MLE_ambs(&dgs->ambiguity_test, ambs);
+  return CLAMP_DIFF(dgs->ambiguity_test.sats.num_sats, 1);
 }

--- a/src/memory_pool.c
+++ b/src/memory_pool.c
@@ -179,7 +179,7 @@ s32 memory_pool_n_free(memory_pool_t *pool)
  * \param pool Pointer to a memory pool
  * \returns Number of allocated elements or `< 0` on an error.
  */
-s32 memory_pool_n_allocated(memory_pool_t *pool)
+s32 memory_pool_n_allocated(const memory_pool_t *pool)
 {
   u32 count = 0;
 
@@ -226,7 +226,7 @@ u32 memory_pool_n_elements(memory_pool_t *pool)
  * \param array Array to which the elements will be written
  * \return Number of elements written to the array or `< 0` on an error.
  */
-s32 memory_pool_to_array(memory_pool_t *pool, void *array)
+s32 memory_pool_to_array(const memory_pool_t *pool, void *array)
 {
   u32 count = 0;
 

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -275,7 +275,7 @@ s8 rebase_sats_management(sats_management_t *sats_management,
   return return_code;
 }
 
-void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, sdiff_t *non_ref_sdiffs)
+void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, const sdiff_t *non_ref_sdiffs)
 {
   sats_management->num_sats = num_non_ref_sdiffs + 1;
   for (u8 i=1; i<num_non_ref_sdiffs+1; i++) {
@@ -285,8 +285,8 @@ void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_
 
 
 
-s8 match_sdiffs_to_sats_man(sats_management_t *sats, u8 num_sdiffs,
-                            sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+s8 match_sdiffs_to_sats_man(const sats_management_t *sats, u8 num_sdiffs,
+                            const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   u8 j = 1;
   u8 ref_prn = sats->prns[0];

--- a/src/single_diff.c
+++ b/src/single_diff.c
@@ -197,16 +197,16 @@ bool is_prn_set(u8 n, const u8 *prns)
  * \param num_dds                    The number of dds used in the IAR
  *                                   (length of non_ref_prns).
  * \param num_sdiffs                 The number of sdiffs being passed in.
- * \param sdiffs                     The sdiffs to pull measurements out of.
+ * \param sdiffs_in                  The sdiffs to pull measurements out of.
  * \param dd_meas  The output vector of DD measurements
  *                                   to be used to update the IAR.
- * \param amb_sdiffs                 The sdiffs that correspond to the IAR PRNs.
+ * \param sdiffs_out                 The sdiffs that correspond to the IAR PRNs.
  * \return 0 if the input sdiffs are superset of the IAR sats,
  *        -1 if they are not,
  *        -2 if non_ref_prns is not an ordered set.
  */
-s8 make_dd_measurements_and_sdiffs(u8 ref_prn, u8 *non_ref_prns, u8 num_dds,
-                                   u8 num_sdiffs, sdiff_t *sdiffs_in,
+s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dds,
+                                   u8 num_sdiffs, const sdiff_t *sdiffs_in,
                                    double *dd_meas, sdiff_t *sdiffs_out)
 {
   DEBUG_ENTRY();

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -6,9 +6,7 @@
 #include "dgnss_management.h"
 #include "ambiguity_test.h"
 
-extern sats_management_t sats_management;
-extern nkf_t nkf;
-extern ambiguity_test_t ambiguity_test;
+dgnss_state_t dgs;
 
 sdiff_t sdiffs[6];
 double ref_ecef[3];
@@ -49,11 +47,11 @@ void check_dgnss_management_setup()
 
   sdiffs[5].prn = 99;
 
-  memset(nkf.state_mean, 0, sizeof(double) * 5);
-  nkf.state_dim = 4;
-  nkf.obs_dim = 8;
+  memset(dgs.nkf.state_mean, 0, sizeof(double) * 5);
+  dgs.nkf.state_dim = 4;
+  dgs.nkf.obs_dim = 8;
 
-  create_ambiguity_test(&ambiguity_test);
+  create_ambiguity_test(&dgs.ambiguity_test);
 }
 
 void check_dgnss_management_teardown()
@@ -79,18 +77,18 @@ void matrix_eye_s64(u32 n, s64 *M)
 /* Check that it works with the first sdiff as the reference sat.
  * This should verify that the loop can start correctly.*/
 START_TEST(test_dgnss_low_latency_float_baseline_ref_first) {
-  sats_management.num_sats = 5;
-  sats_management.prns[0] = 1;
-  sats_management.prns[1] = 2;
-  sats_management.prns[2] = 3;
-  sats_management.prns[3] = 4;
-  sats_management.prns[4] = 5;
+  dgs.sats_management.num_sats = 5;
+  dgs.sats_management.prns[0] = 1;
+  dgs.sats_management.prns[1] = 2;
+  dgs.sats_management.prns[2] = 3;
+  dgs.sats_management.prns[3] = 4;
+  dgs.sats_management.prns[4] = 5;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -103,18 +101,18 @@ END_TEST
 /* Check that it works with a middle sdiff as the reference sat.
  * This should verify that the induction works. */
 START_TEST(test_dgnss_low_latency_float_baseline_ref_middle) {
-  sats_management.num_sats = 5;
-  sats_management.prns[0] = 2;
-  sats_management.prns[1] = 1;
-  sats_management.prns[2] = 3;
-  sats_management.prns[3] = 4;
-  sats_management.prns[4] = 5;
+  dgs.sats_management.num_sats = 5;
+  dgs.sats_management.prns[0] = 2;
+  dgs.sats_management.prns[1] = 1;
+  dgs.sats_management.prns[2] = 3;
+  dgs.sats_management.prns[3] = 4;
+  dgs.sats_management.prns[4] = 5;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -127,18 +125,18 @@ END_TEST
 /* Check that it works with the last sdiff as the reference sat.
  * This should verify that the loop can terminate correctly.*/
 START_TEST(test_dgnss_low_latency_float_baseline_ref_end) {
-  sats_management.num_sats = 5;
-  sats_management.prns[0] = 5;
-  sats_management.prns[1] = 1;
-  sats_management.prns[2] = 2;
-  sats_management.prns[3] = 3;
-  sats_management.prns[4] = 4;
+  dgs.sats_management.num_sats = 5;
+  dgs.sats_management.prns[0] = 5;
+  dgs.sats_management.prns[1] = 1;
+  dgs.sats_management.prns[2] = 2;
+  dgs.sats_management.prns[3] = 3;
+  dgs.sats_management.prns[4] = 4;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 5;
 
-  s8 valid = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -151,12 +149,12 @@ END_TEST
 /* Check that measurements generated from a baseline result in an estimate
  * matching the baseline. */
 START_TEST(test_dgnss_low_latency_float_baseline_fixed_point) {
-  sats_management.num_sats = 5;
-  sats_management.prns[0] = 5;
-  sats_management.prns[1] = 1;
-  sats_management.prns[2] = 2;
-  sats_management.prns[3] = 3;
-  sats_management.prns[4] = 4;
+  dgs.sats_management.num_sats = 5;
+  dgs.sats_management.prns[0] = 5;
+  dgs.sats_management.prns[1] = 1;
+  dgs.sats_management.prns[2] = 2;
+  dgs.sats_management.prns[3] = 3;
+  dgs.sats_management.prns[4] = 4;
 
   double b_orig[3];
   b_orig[0] = 1;
@@ -187,7 +185,7 @@ START_TEST(test_dgnss_low_latency_float_baseline_fixed_point) {
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -198,21 +196,21 @@ START_TEST(test_dgnss_low_latency_float_baseline_fixed_point) {
 END_TEST
 
 START_TEST(test_dgnss_low_latency_float_baseline_few_sats) {
-  sats_management.prns[0] = 5;
-  sats_management.num_sats = 1;
+  dgs.sats_management.prns[0] = 5;
+  dgs.sats_management.num_sats = 1;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                               ref_ecef, &num_used, b);
 
   fail_unless(valid == -1);
 
-  sats_management.num_sats = 0;
+  dgs.sats_management.num_sats = 0;
 
-  _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                    ref_ecef, &num_used, b);
 
   fail_unless(valid == -1);
@@ -237,25 +235,25 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_first) {
   z_t Z_inv[16];
   matrix_eye_s64(4, Z_inv);
 
-  add_sats_old(&ambiguity_test,
+  add_sats_old(&dgs.ambiguity_test,
            1,
            4, prns,
            lower, upper,
            Z_inv);
 
-  ambiguity_test.amb_check.initialized = 1;
-  ambiguity_test.amb_check.num_matching_ndxs = 4;
-  ambiguity_test.amb_check.matching_ndxs[0] = 0;
-  ambiguity_test.amb_check.matching_ndxs[1] = 1;
-  ambiguity_test.amb_check.matching_ndxs[2] = 2;
-  ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
+  dgs.ambiguity_test.amb_check.initialized = 1;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 4;
+  dgs.ambiguity_test.amb_check.matching_ndxs[0] = 0;
+  dgs.ambiguity_test.amb_check.matching_ndxs[1] = 1;
+  dgs.ambiguity_test.amb_check.matching_ndxs[2] = 2;
+  dgs.ambiguity_test.amb_check.matching_ndxs[3] = 3;
+  memset(dgs.ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -282,25 +280,25 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_middle) {
   z_t Z_inv[16];
   matrix_eye_s64(4, Z_inv);
 
-  add_sats_old(&ambiguity_test,
+  add_sats_old(&dgs.ambiguity_test,
            ref_prn,
            4, prns,
            lower, upper,
            Z_inv);
 
-  ambiguity_test.amb_check.initialized = 1;
-  ambiguity_test.amb_check.num_matching_ndxs = 4;
-  ambiguity_test.amb_check.matching_ndxs[0] = 0;
-  ambiguity_test.amb_check.matching_ndxs[1] = 1;
-  ambiguity_test.amb_check.matching_ndxs[2] = 2;
-  ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
+  dgs.ambiguity_test.amb_check.initialized = 1;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 4;
+  dgs.ambiguity_test.amb_check.matching_ndxs[0] = 0;
+  dgs.ambiguity_test.amb_check.matching_ndxs[1] = 1;
+  dgs.ambiguity_test.amb_check.matching_ndxs[2] = 2;
+  dgs.ambiguity_test.amb_check.matching_ndxs[3] = 3;
+  memset(dgs.ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -327,25 +325,25 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_ref_end) {
   z_t Z_inv[16];
   matrix_eye_s64(4, Z_inv);
 
-  add_sats_old(&ambiguity_test,
+  add_sats_old(&dgs.ambiguity_test,
            ref_prn,
            4, prns,
            lower, upper,
            Z_inv);
 
-  ambiguity_test.amb_check.initialized = 1;
-  ambiguity_test.amb_check.num_matching_ndxs = 4;
-  ambiguity_test.amb_check.matching_ndxs[0] = 0;
-  ambiguity_test.amb_check.matching_ndxs[1] = 1;
-  ambiguity_test.amb_check.matching_ndxs[2] = 2;
-  ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
+  dgs.ambiguity_test.amb_check.initialized = 1;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 4;
+  dgs.ambiguity_test.amb_check.matching_ndxs[0] = 0;
+  dgs.ambiguity_test.amb_check.matching_ndxs[1] = 1;
+  dgs.ambiguity_test.amb_check.matching_ndxs[2] = 2;
+  dgs.ambiguity_test.amb_check.matching_ndxs[3] = 3;
+  memset(dgs.ambiguity_test.amb_check.ambs, 0, sizeof(z_t) * 5);
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 5;
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -372,19 +370,19 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_fixed_point) {
   z_t Z_inv[16];
   matrix_eye_s64(4, Z_inv);
 
-  add_sats_old(&ambiguity_test,
+  add_sats_old(&dgs.ambiguity_test,
            ref_prn,
            4, prns,
            lower, upper,
            Z_inv);
 
-  ambiguity_test.amb_check.initialized = 1;
-  ambiguity_test.amb_check.num_matching_ndxs = 4;
-  ambiguity_test.amb_check.matching_ndxs[0] = 0;
-  ambiguity_test.amb_check.matching_ndxs[1] = 1;
-  ambiguity_test.amb_check.matching_ndxs[2] = 2;
-  ambiguity_test.amb_check.matching_ndxs[3] = 3;
-  memset(ambiguity_test.amb_check.ambs, 0, sizeof(s32) * 5);
+  dgs.ambiguity_test.amb_check.initialized = 1;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 4;
+  dgs.ambiguity_test.amb_check.matching_ndxs[0] = 0;
+  dgs.ambiguity_test.amb_check.matching_ndxs[1] = 1;
+  dgs.ambiguity_test.amb_check.matching_ndxs[2] = 2;
+  dgs.ambiguity_test.amb_check.matching_ndxs[3] = 3;
+  memset(dgs.ambiguity_test.amb_check.ambs, 0, sizeof(s32) * 5);
 
   double b_orig[3];
   b_orig[0] = 1;
@@ -415,7 +413,7 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_fixed_point) {
   u8 num_used;
   u8 num_sdiffs = 6;
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                  ref_ecef, &num_used, b);
 
   fail_unless(valid == 0);
@@ -426,58 +424,58 @@ START_TEST(test_dgnss_low_latency_IAR_baseline_fixed_point) {
 END_TEST
 
 START_TEST(test_dgnss_low_latency_IAR_baseline_few_sats) {
-  ambiguity_test.amb_check.initialized = 1;
-  ambiguity_test.amb_check.num_matching_ndxs = 1;
+  dgs.ambiguity_test.amb_check.initialized = 1;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 1;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                               ref_ecef, &num_used, b);
   fail_unless(valid == -1);
 
-  ambiguity_test.amb_check.num_matching_ndxs = 0;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 0;
 
-  _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                    ref_ecef, &num_used, b);
   fail_unless(valid == -1);
 
-  ambiguity_test.amb_check.initialized = 0;
-  ambiguity_test.amb_check.num_matching_ndxs = 4;
+  dgs.ambiguity_test.amb_check.initialized = 0;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 4;
 
-  _dgnss_low_latency_float_baseline(num_sdiffs, sdiffs,
+  _dgnss_low_latency_float_baseline(&dgs, num_sdiffs, sdiffs,
                                    ref_ecef, &num_used, b);
   fail_unless(valid == -1);
 }
 END_TEST
 
 START_TEST(test_dgnss_low_latency_IAR_baseline_uninitialized) {
-  ambiguity_test.amb_check.initialized = 0;
-  ambiguity_test.amb_check.num_matching_ndxs = 5;
+  dgs.ambiguity_test.amb_check.initialized = 0;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 5;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                               ref_ecef, &num_used, b);
   fail_unless(valid == -1);
 }
 END_TEST
 
 START_TEST(test_dgnss_low_latency_baseline_uninitialized) {
-  ambiguity_test.amb_check.initialized = 0;
-  ambiguity_test.amb_check.num_matching_ndxs = 5;
+  dgs.ambiguity_test.amb_check.initialized = 0;
+  dgs.ambiguity_test.amb_check.num_matching_ndxs = 5;
 
   double b[3];
   u8 num_used;
   u8 num_sdiffs = 6;
 
 
-  s8 valid = _dgnss_low_latency_IAR_baseline(num_sdiffs, sdiffs,
+  s8 valid = _dgnss_low_latency_IAR_baseline(&dgs, num_sdiffs, sdiffs,
                                               ref_ecef, &num_used, b);
   fail_unless(valid == -1);
 }


### PR DESCRIPTION
The structs settings, nkf, sats_management and ambiguity_test
which maintain the state of the DGNSS filters were previously
globals in dgnss_management.c.  Now they are members of the context
struct 'dgnss_state_t' which should be instantiated in the host program
and initialized via dgnss_init().  A pointer to this struct must be
passed to most dgnss_* functions.

Many functions are now also const-correct, though I have not attempted
complete const-correct coverage.

Changes to piksi_firmware, libswiftnav-python and gnss_analysis will be
required.

/cc @fnoble @imh for review, @mookerji FYI

<!---
@huboard:{"order":1.6726203755368374e-13,"milestone_order":150,"custom_state":""}
-->
