### PR TITLE
fixed multiple off by one bugs

### DIFF
--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -669,6 +669,13 @@ void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
                   kf->decor_obs_mtx);
 }
 
+/** Currently this function is only used to find the index of a prn in a
+ *  permuted basis, so all callsites assert the result is not -1.
+ *  \param num_elements Size of list
+ *  \param x the prn to search for
+ *  \param list the prn list to search
+ *  \return index of x in list, or -1 if no element is equal to x
+ */
 s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list)
 {
   for (u32 i=0; i<num_elements; i++) {
@@ -688,8 +695,15 @@ void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8
   u8 old_ref = old_prns[0];
   u8 new_ref = new_prns[0];
 
+  if (old_ref == new_ref) {
+    /* Nothing needs to be done; same basis. */
+    return;
+  }
+
   double new_mean[state_dim];
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats, new_ref, &old_prns[1]);
+  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  assert(index_of_new_ref_in_old != -1);
+
   double val_for_new_ref_in_old_basis = mean[index_of_new_ref_in_old];
   for (u8 i=0; i<state_dim; i++) {
     u8 new_prn = new_prns[1+i];
@@ -697,7 +711,8 @@ void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8
       new_mean[i] = - val_for_new_ref_in_old_basis;
     }
     else {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats, new_prn, &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prn, &old_prns[1]);
+      assert(index_of_this_sat_in_old_basis != -1);
       new_mean[i] = mean[index_of_this_sat_in_old_basis] - val_for_new_ref_in_old_basis;
     }
   }
@@ -715,12 +730,22 @@ static void assign_state_rebase_mtx(const u8 num_sats, const u8 *old_prns,
   u8 old_ref = old_prns[0];
   u8 new_ref = new_prns[0];
 
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(state_dim, new_ref, &old_prns[1]);
-  s32 index_of_old_ref_in_new = find_index_of_element_in_u8s(state_dim, old_ref, &new_prns[1]);
+  if (old_ref == new_ref) {
+    /* No rebase needs to occur, return identity. */
+    matrix_eye(state_dim, rebase_mtx);
+    return;
+  }
+
+  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  assert(index_of_new_ref_in_old != -1);
+  s32 index_of_old_ref_in_new = find_index_of_element_in_u8s(num_sats-1, old_ref, &new_prns[1]);
+  assert(index_of_old_ref_in_new != -1);
+
   for (u8 i=0; i<state_dim; i++) {
     rebase_mtx[i*state_dim + index_of_new_ref_in_old] = -1;
     if (i != (u8) index_of_old_ref_in_new) {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(state_dim, new_prns[i+1], &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prns[i+1], &old_prns[1]);
+      assert(index_of_this_sat_in_old_basis != -1);
       rebase_mtx[i*state_dim + index_of_this_sat_in_old_basis] = 1;
     }
   }

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -633,7 +633,9 @@ static void rebase_hypothesis(void *arg, element_t *elem) //TODO make it so it d
   u8 new_ref = new_prns[0];
 
   s32 new_N[num_sats-1];
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats, new_ref, &old_prns[1]);
+  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  assert(index_of_new_ref_in_old != -1);
+
   s32 val_for_new_ref_in_old_basis = hypothesis->N[index_of_new_ref_in_old];
   for (u8 i=0; i<num_sats-1; i++) {
     u8 new_prn = new_prns[1+i];
@@ -641,7 +643,8 @@ static void rebase_hypothesis(void *arg, element_t *elem) //TODO make it so it d
       new_N[i] = - val_for_new_ref_in_old_basis;
     }
     else {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats, new_prn, &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prn, &old_prns[1]);
+      assert(index_of_this_sat_in_old_basis != -1);
       new_N[i] = hypothesis->N[index_of_this_sat_in_old_basis] - val_for_new_ref_in_old_basis;
     }
   }

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -10,6 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -79,8 +80,10 @@ static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats
   return n;
 }
 
-/** Puts sdiffs into sdiffs_with_ref_first with the sdiff for ref_prn first
+/** Updates the ref prn for a sorted prn array.
+ *  Inserts the old ref prn so the tail of the array is sorted.
  */
+/* TODO use the set abstraction fnoble is working on. */
 void set_reference_sat_of_prns(const u8 ref_prn, const u8 num_sats, u8 *prns)
 {
   u8 old_ref = prns[0];
@@ -91,29 +94,32 @@ void set_reference_sat_of_prns(const u8 ref_prn, const u8 num_sats, u8 *prns)
     memcpy(old_prns, prns, num_sats * sizeof(u8));
     u8 set_old_yet = 0;
     prns[0] = ref_prn;
-    for (u8 i=1; i<num_sats; i++) {
+    for (u8 i=1; i<num_sats; ) {
       if (old_prns[i] != ref_prn) {
         if (old_prns[i]>old_ref && set_old_yet == 0) {
           prns[j] = old_ref;
           j++;
-          i--;
-          set_old_yet = 1;
+          set_old_yet++;
         }
         else {
           prns[j] = old_prns[i];
-          j++;
+          i++, j++;
         }
       }
-      else if (i == num_sats-1) {
-        prns[j] = old_ref;
-      }
     }
+    if (set_old_yet == 0) {
+      prns[j] = old_ref;
+      set_old_yet++;
+    }
+    assert(set_old_yet == 1);
   }
 }
 
 
 /** Puts sdiffs into sdiffs_with_ref_first with the sdiff for ref_prn first, while updating sats_management
+ *  Inserts the old ref prn so the tail of the sats_management array is sorted.
  */
+/* TODO use the set abstraction fnoble is working on. */
 static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_management,
                               const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
@@ -129,24 +135,26 @@ static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_manageme
     memcpy(old_prns, sats_management->prns, sats_management->num_sats * sizeof(u8));
     u8 set_old_yet = 0;
     sats_management->prns[0] = ref_prn;
-    for (u8 i=1; i<sats_management->num_sats; i++) {
+    for (u8 i=1; i<sats_management->num_sats; ) {
       if (old_prns[i] != ref_prn) {
         if (old_prns[i]>old_ref && set_old_yet == 0) {
           sats_management->prns[j] = old_ref;
           j++;
-          i--;
-          set_old_yet = 1;
+          set_old_yet++;
         }
         else {
           sats_management->prns[j] = old_prns[i];
-          j++;
+          i++, j++;
         }
       }
-      else if (i == sats_management->num_sats-1) {
-        sats_management->prns[j] = old_ref;
-      }
     }
+    if (set_old_yet == 0) {
+      sats_management->prns[j] = old_ref;
+      set_old_yet++;
+    }
+    assert(set_old_yet == 1);
   }
+
   j=1;
   for (u8 i=0; i<num_sdiffs; i++) {
     if (sdiffs[i].prn != ref_prn) {
@@ -240,7 +248,7 @@ s8 rebase_sats_management(sats_management_t *sats_management,
   }
   else {
     sdiff_t intersection_sats[num_sdiffs];
-    u8 num_intersection = intersect_sats(sats_management->num_sats, num_sdiffs,
+    u8 num_intersection = intersect_sats(sats_management->num_sats-1, num_sdiffs,
                                          &(sats_management->prns[1]), sdiffs, intersection_sats);
     if (num_intersection < INTERSECTION_SATS_THRESHOLD_SIZE) {
       DEBUG_EXIT();


### PR DESCRIPTION
fixes an issue that may cause memory corruption when the ref satellite changes and the old ref is the largest prn in the sats_management struct

<!---
@huboard:{"order":376.6953125,"milestone_order":167.0,"custom_state":""}
-->
