### PR TITLE
Added outlier detection and robustness to the KF and amb test

### DIFF
--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -22,6 +22,8 @@
 
 #define MAX_STATE_DIM (MAX_CHANNELS - 1)
 #define MAX_OBS_DIM (2 * MAX_CHANNELS - 5)
+#define KF_SOS_TIMESCALE 7.0f
+#define SOS_SWITCH 10.0f
 
 typedef struct {
   u32 state_dim;
@@ -34,9 +36,10 @@ typedef struct {
   double state_mean[MAX_STATE_DIM];
   double state_cov_U[MAX_STATE_DIM * MAX_STATE_DIM];
   double state_cov_D[MAX_STATE_DIM];
+  double l_sos_avg;
 } nkf_t;
 
-void nkf_update(nkf_t *kf, double *measurements);
+u8 nkf_update(nkf_t *kf, const double *measurements);
 
 void assign_phase_obs_null_basis(u8 num_dds, double *DE_mtx, double *q);
 void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var, double amb_init_var,
@@ -62,6 +65,9 @@ void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats
 
 void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
 void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
+
+double get_sos_innov(const nkf_t *kf, const double *decor_obs);
+u8 outlier_check(nkf_t *kf, const double *decor_obs, double *k_scalar);
 
 #endif /* LIBSWIFTNAV_AMB_KF_H */
 

--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -31,22 +31,33 @@
 #define SOS_SWITCH 10.0f
 
 typedef struct {
+  /** The dimension of the state vector. */
   u32 state_dim;
+  /** The dimension of the observation vector. */
   u32 obs_dim;
+  /** The variance to use for the prediction update step (diffusion). */
   double amb_drift_var;
   /** The observation decorrelation matrix. Takes raw measurements and
    * decorrelates them. */
   double decor_mtx[MAX_OBS_DIM * MAX_OBS_DIM];
-  /* The observation matrix for decorrelated measurements. */
+  /** The observation matrix for decorrelated measurements. */
   double decor_obs_mtx[MAX_STATE_DIM * MAX_OBS_DIM];
-  /* The diagonal of the decorrelated observation covariance (for cholesky it's
+  /** The diagonal of the decorrelated observation covariance (for cholesky it's
    * ones). */
   double decor_obs_cov[MAX_OBS_DIM];
+  /** A basis for the left nullspace usual DGNSS observatio matrix, made of
+   * the DD line of sight vectors from the receivers to the sats. Used to
+   * project out the baseline's influence from the observations. */
   double null_basis_Q[(MAX_STATE_DIM - 3) * MAX_OBS_DIM];
+  /** The current state estimate. */
   double state_mean[MAX_STATE_DIM];
+  /** The upper unit triangular U matrix of the UDU decomposition of the
+   * covariance of the current state estimate. Stored dense. */
   double state_cov_U[MAX_STATE_DIM * MAX_STATE_DIM];
+  /** The diagonal D matrix of the UDU decomposition of the covariance of the current
+   * state estimate. Stored as a vector. */
   double state_cov_D[MAX_STATE_DIM];
-  /* A moving average of the log of the weighted sum of squares innovations. */
+  /** A moving average of the log of the weighted sum of squares innovations. */
   double l_sos_avg;
 } nkf_t;
 

--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -20,26 +20,39 @@
 #include "observation.h"
 #include "constants.h"
 
+/** \addtogroup amb_kf
+ * \{ */
+
 #define MAX_STATE_DIM (MAX_CHANNELS - 1)
 #define MAX_OBS_DIM (2 * MAX_CHANNELS - 5)
+/** The timescale for smoothing the innovation weighted sum of squares. */
 #define KF_SOS_TIMESCALE 7.0f
+/** The outlier cutoff for the highpassed innovation weighted sum of squares. */
 #define SOS_SWITCH 10.0f
 
 typedef struct {
   u32 state_dim;
   u32 obs_dim;
   double amb_drift_var;
-  double decor_mtx[MAX_OBS_DIM * MAX_OBS_DIM]; //the decorrelation matrix. takes raw measurements and decorrelates them
-  double decor_obs_mtx[MAX_STATE_DIM * MAX_OBS_DIM]; //the observation matrix for decorrelated measurements
-  double decor_obs_cov[MAX_OBS_DIM]; //the diagonal of the decorrelated observation covariance (for cholesky is ones)
+  /** The observation decorrelation matrix. Takes raw measurements and
+   * decorrelates them. */
+  double decor_mtx[MAX_OBS_DIM * MAX_OBS_DIM];
+  /* The observation matrix for decorrelated measurements. */
+  double decor_obs_mtx[MAX_STATE_DIM * MAX_OBS_DIM];
+  /* The diagonal of the decorrelated observation covariance (for cholesky it's
+   * ones). */
+  double decor_obs_cov[MAX_OBS_DIM];
   double null_basis_Q[(MAX_STATE_DIM - 3) * MAX_OBS_DIM];
   double state_mean[MAX_STATE_DIM];
   double state_cov_U[MAX_STATE_DIM * MAX_STATE_DIM];
   double state_cov_D[MAX_STATE_DIM];
+  /* A moving average of the log of the weighted sum of squares innovations. */
   double l_sos_avg;
 } nkf_t;
 
-u8 nkf_update(nkf_t *kf, const double *measurements);
+/** \} */
+
+bool nkf_update(nkf_t *kf, const double *measurements);
 
 void assign_phase_obs_null_basis(u8 num_dds, double *DE_mtx, double *q);
 void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var, double amb_init_var,
@@ -67,7 +80,13 @@ void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8
 void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
 
 double get_sos_innov(const nkf_t *kf, const double *decor_obs);
-u8 outlier_check(nkf_t *kf, const double *decor_obs, double *k_scalar);
+double compute_innovation_terms(u32 state_dim, const double *h,
+                                double R, const double *U,
+                                const double *D, double *f, double *g);
+bool outlier_check(nkf_t *kf, const double *decor_obs, double *k_scalar);
+void update_kf_state(nkf_t *kf, double R, const double *f, const double *g,
+                   double alpha, double k_scalar,
+                   double innov);
 
 #endif /* LIBSWIFTNAV_AMB_KF_H */
 

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -94,7 +94,7 @@ void test_ambiguities(ambiguity_test_t *amb_test, double *ambiguity_dd_measureme
 u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
                          const sdiff_t *sdiffs, const sats_management_t *float_sats,
                          const double *float_mean, const double *float_cov_U,
-                         const double *float_cov_D);
+                         const double *float_cov_D, u8 is_bad_measurement);
 u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff_t *sdiffs_with_ref_first, u8 *intersection_ndxs);
 u8 ambiguity_iar_can_solve(ambiguity_test_t *ambiguity_test);
 s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_sdiffs, sdiff_t *sdiffs,

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -362,7 +362,7 @@ static void diffuse_state(nkf_t *kf)
 }
 
 /** In place updating of the KF state mean and covariance.
- * Does both the temporal and measurement updates to the KF.
+ * Does both the prediction and measurement updates to the KF.
  *
  * \param kf            The KF to update
  * \param measurements  The observations. The first (kf->state_dim) elements are
@@ -383,7 +383,7 @@ bool nkf_update(nkf_t *kf, const double *measurements)
               kf->obs_dim, kf->decor_mtx, kf->obs_dim, /*  N, A, lda. */
               resid_measurements, 1); /*  X, incX. */
 
-  /*  Temporal update */
+  /*  Prediction update */
   diffuse_state(kf);
   /* Measurement update */
   bool is_bad_measurement = incorporate_obs(kf, resid_measurements);

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -14,6 +14,11 @@
  * This is a Bierman-Thornton kalman filter implementation, as described in:
  *  [1] Gibbs, Bruce P. "Advanced Kalman Filtering, Least-Squares, and Modeling."
  *      John C. Wiley & Sons, Inc., 2011.
+ * It has been modified to be more robust. It can be verified by following a
+ * proof parallel to the one in Bierman's original derivation [2] of the U-D
+ * updates with a data-scaled Kalman gain.
+ *  [2] Bierman, Gerald J. "Factorization Methods for Discrete Sequential
+        Estimation" Academic Press, Inc., 1977.
  */
 
 #include <string.h>
@@ -38,75 +43,102 @@
  * Preliminary integer ambiguity estimation with a Kalman Filter.
  * \{ */
 
-/** In place updating of the state cov and k vec using a scalar observation
- * This is from section 10.2.1 of Gibbs [1], with some extra logic for handling
- *    singular matrices, dictating that zeros from cov_D dominate.
+/**Calculation of vectors needed for the innovation scaling.
+ * We compute two vectors needed to make the Bierman update,
+ * as well as the variance of the innovation.
  *
+ * \param state_dim The dimension of the KF state.
+ * \param h         A row of the observation matrix.
+ * \param R         The variance of the observation.
+ * \param U         KF state covariance U (not packed form)
+ * \param D         KF state covariance D (stored as a vector)
+ * \param f         U^T * h.
+ * \param g         diag(D) * f.
+ * \return          alpha = f * g + R, the innovation variance.
  */
-static void incorporate_scalar_measurement(u32 state_dim, double *h, double R,
-                                           double *U, double *D, double *k)
+static double compute_innovation_terms(u32 state_dim, const double *h,
+                                       double R, const double *U,
+                                       const double *D, double *f, double *g)
 {
-  DEBUG_ENTRY();
-
-  if (DEBUG) {
-    VEC_PRINTF(h, state_dim);
-    printf("R = %.16f", R);
-    if (abs(R) == 0) {
-      printf(" \t (R == 0 exactly)\n");
-    }
-    else {
-      printf("\n");
-    }
-  }
-
-  double f[state_dim]; /*  f = U^T * h. */
   memcpy(f, h, state_dim * sizeof(double));
+  /*  f = U^T * h. */
   cblas_dtrmv(CblasRowMajor, CblasUpper, CblasTrans, CblasUnit,
               /* ^ CBLAS_ORDER, CBLAS_UPLO, CBLAS_TRANSPOSE transA, CBLAS_DIAG. */
               state_dim, U,     /* int N, double *A. */
               state_dim, f, 1); /*  int lda, double *X, int incX. */
 
 
-  double g[state_dim]; /*  g = diag(D) * f. */
-  double alpha = R;    /*  alpha = f * g + R = f^T * diag(D) * f + R. */
+  /*  g = diag(D) * f.
+      alpha = f * g + R = f^T * diag(D) * f + R. */
+  double alpha = R;
   for (u32 i=0; i<state_dim; i++) {
     g[i] = D[i] * f[i];
     alpha += f[i] * g[i];
   }
-  if (DEBUG) {
-    VEC_PRINTF(f, state_dim);
-    VEC_PRINTF(g, state_dim);
-    printf("alpha = %.16f", alpha);
-    if (abs(alpha) == 0) {
-      printf(" \t (alpha == 0 exactly)\n");
-    }
-    else {
-      printf("\n");
-    }
-  }
+  return alpha;
+}
 
-  double gamma[state_dim];
+
+/** In place updating of the state cov and k vec using a scalar observation
+ * This is from section 10.2.1 of Gibbs [1], with some extra logic for handling
+ * singular matrices, dictating that zeros from cov_D dominate in a particular
+ * potential 0 / 0.
+ * We also make it more robust, by multiplying k by k_scalar <=  1.
+ * To still perform the update in factored form, we modified the derivation
+ * in section V.3 of [2] to arrive at the following code.
+ *
+ * \param kf        The KF to update
+ * \param R         The measurement variance
+ * \param f         U^T * h
+ * \param g         diag(D) * f
+ * \param alpha     The innovation variance
+ * \param k_scalar  A scalar to multiply the Kalman gain by (softens outliers)
+ * \param innov     The difference between the actual and predicted observation
+ */
+static void update_kf_state(nkf_t *kf, double R, double *f, double *g,
+                            double alpha, double k_scalar,
+                            double innov)
+{
+  DEBUG_ENTRY();
+
+  assert(k_scalar <= 1);
+  assert(k_scalar >= 0);
+  if (k_scalar == 0) {
+    return;
+  }
+  u32 state_dim = kf->state_dim;
+  double *U = kf->state_cov_U;
+  double *D = kf->state_cov_D;
+  double k[state_dim];
+
   double U_bar[state_dim * state_dim];
   double D_bar[state_dim];
 
-  memset(gamma, 0,             state_dim * sizeof(double));
   memset(U_bar, 0, state_dim * state_dim * sizeof(double));
   memset(D_bar, 0,             state_dim * sizeof(double));
   memset(k,     0,             state_dim * sizeof(double));
 
-  gamma[0] = R + g[0] * f[0];
+  /* Turns out that to use k' = k * k_scalar instead of k as the Kalman gain,
+   * the only change in the covariance calculation needed is the initialization
+   * of gamma (alpha_i in Bierman's old book [2] V.3) */
+  double gamma = R / k_scalar + g[0] * f[0];
+  if (k_scalar < 1) {
+    for (u8 i = 0; i < kf->state_dim; i++) {
+      gamma += (1 - k_scalar) / k_scalar * g[i] * f[i];
+    }
+  }
   if (D[0] == 0 || R == 0) {
     /*  This is just an expansion of the other branch with the proper
      *  0 `div` 0 definitions. */
     D_bar[0] = 0;
   }
   else {
-    D_bar[0] = D[0] * R / gamma[0];
+    D_bar[0] = D[0] * R / gamma;
   }
   k[0] = g[0];
   U_bar[0] = 1;
   if (DEBUG) {
-    printf("gamma[0] = %f\n", gamma[0]);
+    printf("gamma[0] = %f\n", gamma);
     printf("D_bar[0] = %f\n", D_bar[0]);
     VEC_PRINTF(k, state_dim);
     printf("U_bar[:,0] = {");
@@ -116,16 +148,17 @@ static void incorporate_scalar_measurement(u32 state_dim, double *h, double R,
     printf("}\n");
   }
   for (u32 j=1; j<state_dim; j++) {
-    gamma[j] = gamma[j-1] + g[j] * f[j];
-    if (D[j] == 0 || gamma[j-1] == 0) {
+    double gamma_prev = gamma;
+    gamma += g[j] * f[j];
+    if (D[j] == 0 || gamma_prev == 0) {
       /* This is just an expansion of the other branch with the proper
        * 0 `div` 0 definitions. */
       D_bar[j] = 0;
     }
     else {
-      D_bar[j] = D[j] * gamma[j-1] / gamma[j];
+      D_bar[j] = D[j] * gamma_prev / gamma;
     }
-    double f_over_gamma = f[j] / gamma[j-1];
+    double f_over_gamma = f[j] / gamma_prev;
     for (u32 i=0; i<=j; i++) {
       if (k[i] == 0) {
       /* This is just an expansion of the other branch with the proper
@@ -139,7 +172,7 @@ static void incorporate_scalar_measurement(u32 state_dim, double *h, double R,
       k[i] += g[j] * U[i*state_dim + j]; /*  k = k + g[j] * U[:,j]. */
     }
     if (DEBUG) {
-      printf("gamma[%"PRIu32"] = %f\n", j, gamma[j]);
+      printf("gamma[%"PRIu32"] = %f\n", j, gamma);
       printf("D_bar[%"PRIu32"] = %f\n", j, D_bar[j]);
       VEC_PRINTF(k, state_dim);
       printf("U_bar[:,%"PRIu32"] = {", j);
@@ -154,6 +187,11 @@ static void incorporate_scalar_measurement(u32 state_dim, double *h, double R,
   }
   memcpy(U, U_bar, state_dim * state_dim * sizeof(double));
   memcpy(D, D_bar,             state_dim * sizeof(double));
+
+  /* Update the KF mean, scaled by some heuristic term for robustness */
+  for (u32 j=0; j<kf->state_dim; j++) {
+      kf->state_mean[j] += k[j] * k_scalar * innov;
+  }
   if (DEBUG) {
     MAT_PRINTF(U, state_dim, state_dim);
     VEC_PRINTF(D, state_dim);
@@ -162,21 +200,100 @@ static void incorporate_scalar_measurement(u32 state_dim, double *h, double R,
   DEBUG_EXIT();
 }
 
-/** In place updating of the state mean and covariances to use the (decorrelated) observations
- * This is directly from section 10.2.1 of Gibbs [1]
+/** Get the weighted sum of squared innovations.
+ * It's a normalized error metric. High is bad.
+ * More precisely, we square the difference between the predicted observations
+ * and the actual observations, divide them by their variances (FPF' + R),
+ * but pretending they're independent, and then sum them.
+ * It's: sum_i (z - H * x)_i / (F * P * F' + R)_ii.
+ * If FPF'+R was actually diagonal and these measurements were independent,
+ * these would be chi square with kf->obs_dim degrees of freedom.
+ *
+ * \param kf        Kalman filter struct
+ * \param decor_obs Decorrelated observation vector
+ * \return          The weighted SOS.
  */
-static void incorporate_obs(nkf_t *kf, double *decor_obs)
+double get_sos_innov(const nkf_t *kf, const double *decor_obs)
+{
+  double predicted_obs[kf->obs_dim];
+  matrix_multiply(kf->obs_dim, kf->state_dim, 1,
+                  kf->decor_obs_mtx, kf->state_mean, predicted_obs);
+  double hu[kf->obs_dim * kf->state_dim];
+  /* TODO use the fact that U is unit triangular to save a ton of time */
+  matrix_multiply(kf->obs_dim, kf->state_dim, kf->state_dim,
+                  kf->decor_obs_mtx, kf->state_cov_U, hu);
+  /* (H * U * D * U^T * H^T)_ii = (HU * D * HU^T)_ii
+   *                            = Sum_kl (HU_ik * D_kl * HU^T_li)
+   *                            = Sum_kl (HU_ik * D_kl * HU_il)
+   *                            = Sum_k (HU_ik * D_kk * HU_ik) */
+  double sos = 0;
+  for (u8 i=0; i < kf->obs_dim; i++) {
+    double hph_r_ii = kf->decor_obs_cov[i];
+    for (u8 k=0; k < kf->state_dim; k++) {
+      hph_r_ii += hu[i * kf->state_dim + k] *
+                  hu[i * kf->state_dim + k] *
+                  kf->state_cov_D[k];
+    }
+    sos += (predicted_obs[i] - decor_obs[i]) *
+           (predicted_obs[i] - decor_obs[i]) /
+           hph_r_ii;
+  }
+  return sos;
+}
+
+/** Compute a scale factor to soften outliers, updating an outlier filter.
+ * We want to have some form of outlier detection that allows them
+ * (especially near the edge of the classifier) to influence the filter.
+ * This way, we soften the influence of any outliers, while eventually letting
+ * change-points through.
+ *
+ * I have found this moving average in log space to work best, only
+ * surpassed by a moving median. Both seem optimal with a timescale
+ * of 7 observations, as per detecting change points, but if we reduce
+ * the number of cycle slips, we may want to increase it.
+ *
+ * \param kf        The Kalman filter
+ * \param decor_obs Decorrelated observation vector
+ * \param k_scalar
+ * \return          A scalar to multiply Kalman gain by
+ */
+u8 outlier_check(nkf_t *kf, const double *decor_obs, double *k_scalar)
+{
+  double sos = get_sos_innov(kf, decor_obs) / kf->obs_dim;
+  double l_sos = log(MAX(1e-10,sos));
+  double new_weight = 1.0f / KF_SOS_TIMESCALE;
+  *k_scalar =  MIN(1, SOS_SWITCH * exp(kf->l_sos_avg) / MAX(1e-10, sos));
+  kf->l_sos_avg = kf->l_sos_avg * (1 - new_weight) +
+                  l_sos * new_weight;
+  return (*k_scalar < 1);
+}
+
+/** In place updating of the state mean and covariances to use the (decorrelated) observations
+ * A modification of the update in section 10.2.1 of Gibbs [1].
+ * Changes are: -Scaling the kalman gain to deal with outliers.
+ *              -Some minor tweaks to handle singular matrices.
+ *
+ * \param kf        Kalman filter to be updated.
+ * \param decor_obs Decorrelated observation vector.
+ * \return          Whether we think the observations were bad.
+ */
+static u8 incorporate_obs(nkf_t *kf, double *decor_obs)
 {
   DEBUG_ENTRY();
+
+  double k_scalar;
+  u8 is_outlier = outlier_check(kf, decor_obs, &k_scalar);
 
   for (u32 i=0; i<kf->obs_dim; i++) {
     double *h = &kf->decor_obs_mtx[kf->state_dim * i]; /* vector of length kf->state_dim. */
     double R = kf->decor_obs_cov[i]; /* scalar. */
-    double k[kf->state_dim]; /*  vector of length kf->state_dim. */
 
-    /* updates cov and sets k. */
-    incorporate_scalar_measurement(kf->state_dim, h, R, kf->state_cov_U, kf->state_cov_D, &k[0]);
+    double f[kf->state_dim];
+    double g[kf->state_dim];
 
+    double alpha = compute_innovation_terms(kf->state_dim, h, R,
+                                            kf->state_cov_U, kf->state_cov_D,
+                                            f, g);
     double predicted_obs = 0;
     /* TODO take advantage of sparsity of h. */
     for (u32 j=0; j<kf->state_dim; j++) {
@@ -184,16 +301,15 @@ static void incorporate_obs(nkf_t *kf, double *decor_obs)
     }
     double obs_minus_predicted_obs = decor_obs[i] - predicted_obs;
 
-    for (u32 j=0; j<kf->state_dim; j++) {
-      kf->state_mean[j] += k[j] * obs_minus_predicted_obs; /* uses k to update mean. */
-    }
+    /* updates kf state. */
+    update_kf_state(kf, R, f, g, alpha, k_scalar, obs_minus_predicted_obs);
   }
-
   DEBUG_EXIT();
+  return is_outlier;
 }
 
 /*  Turns (phi, rho) into Q_tilde * (phi, rho). */
-static void make_residual_measurements(nkf_t *kf, double *measurements, double *resid_measurements)
+static void make_residual_measurements(const nkf_t *kf, const double *measurements, double *resid_measurements)
 {
   u8 constraint_dim = CLAMP_DIFF(kf->state_dim, 3);
   cblas_dgemv (CblasRowMajor, CblasNoTrans, /* Order, TransA. */
@@ -208,18 +324,35 @@ static void make_residual_measurements(nkf_t *kf, double *measurements, double *
   }
 }
 
+/** The temporal update step of the KF.
+ * To be really strict, since changes are equally likely on all channels,
+ * This should be += (I + 1 * 1^T)*var instead of I*var, but it's
+ * unlikely to be significant.
+ *
+ * \param kf The KF to be updated.
+ */
 static void diffuse_state(nkf_t *kf)
 {
+  double cov[kf->state_dim * kf->state_dim];
+  matrix_reconstruct_udu(kf->state_dim, kf->state_cov_U, kf->state_cov_D, cov);
   for (u8 i=0; i< kf->state_dim; i++) {
     /* TODO make this a tunable parameter defined at the right time. */
-    kf->state_cov_D[i] += kf->amb_drift_var;
+    cov[i*kf->state_dim + i] += kf->amb_drift_var;
   }
+  matrix_udu(kf->state_dim, cov, kf->state_cov_U, kf->state_cov_D);
 }
 
-
-/** In place updating of the state mean and covariance. Modifies measurements.
+/** In place updating of the KF state mean and covariance.
+ * Does both the temporal and measurement updates to the KF.
+ *
+ * \param kf            The KF to update
+ * \param measurements  The observations. The first (kf->state_dim) elements are
+ *                      carrier phases, and the next (kf->state_dim) are
+ *                      pseudoranges.
+ * \return              Whether the KF thought the measurement was a bad
+ *                      measurement.
  */
-void nkf_update(nkf_t *kf, double *measurements)
+u8 nkf_update(nkf_t *kf, const double *measurements)
 {
   DEBUG_ENTRY();
 
@@ -231,17 +364,18 @@ void nkf_update(nkf_t *kf, double *measurements)
               kf->obs_dim, kf->decor_mtx, kf->obs_dim, /*  N, A, lda. */
               resid_measurements, 1); /*  X, incX. */
 
-  /*  predict_forward(kf);. */
+  /*  Temporal update */
   diffuse_state(kf);
-  incorporate_obs(kf, resid_measurements);
+  /* Measurement update */
+  u8 is_bad_measurement = incorporate_obs(kf, resid_measurements);
 
   if (DEBUG) {
     MAT_PRINTF(kf->state_cov_U, kf->state_dim, kf->state_dim);
     VEC_PRINTF(kf->state_cov_D, kf->state_dim);
     VEC_PRINTF(kf->state_mean, kf->state_dim);
   }
-
   DEBUG_EXIT();
+  return is_bad_measurement;
 }
 
 /* Initializes the ambiguity means and variances.
@@ -494,7 +628,7 @@ void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var,
   set_nkf_matrices(kf, phase_var, code_var, num_sdiffs, sdiffs_with_ref_first, ref_ecef);
   /* Given plain old measurements, initialize the state. */
   initialize_state(kf, dd_measurements, amb_init_var);
-
+  kf->l_sos_avg = 1;
   DEBUG_EXIT();
 }
 

--- a/tests/check_amb_kf.c
+++ b/tests/check_amb_kf.c
@@ -4,6 +4,7 @@
 #include "baseline.h"
 #include "amb_kf.h"
 #include "observation.h"
+#include "linear_algebra.h"
 #include "check_utils.h"
 
 START_TEST(test_lsq)
@@ -71,12 +72,73 @@ START_TEST(test_lsq)
 }
 END_TEST
 
+START_TEST(test_sos_innov)
+{
+  /* Test with H, U, D, R = I */
+  nkf_t kf;
+  kf.state_dim = 2;
+  kf.obs_dim = 2;
+  matrix_eye(2, kf.decor_obs_mtx);
+  kf.decor_obs_cov[0] = 1;
+  kf.decor_obs_cov[1] = 1;
+  matrix_eye(2, kf.state_cov_U);
+  kf.state_cov_D[0] = 2;
+  kf.state_cov_D[1] = 3;
+  kf.state_mean[0] = 1;
+  kf.state_mean[1] = 2;
+  double obs[2] = {1,2};
+  /* Test with the predicted and actual observations the same. */
+  fail_unless(within_epsilon(get_sos_innov(&kf, obs), 0));
+  kf.state_mean[0] = 0;
+  kf.state_mean[1] = 0;
+  /* Test with the predicted and actual observations slightly different.
+   * S = R + H * U * D * U^T * H^T = diag(3,4).
+   * y = z - H*x = z = (1, 2).
+   * sos = sum_i (y_i / S_ii) = 1/3 + 2^2 / 4. */
+  fail_unless(within_epsilon(get_sos_innov(&kf, obs), 1.0f/3 + 4.0f/4));
+}
+END_TEST
+
+START_TEST(test_outlier)
+{
+  /* Test with H, U, D, R = I */
+  nkf_t kf;
+  kf.state_dim = 2;
+  kf.obs_dim = 2;
+  matrix_eye(2, kf.decor_obs_mtx);
+  kf.decor_obs_cov[0] = 1;
+  kf.decor_obs_cov[1] = 1;
+  matrix_eye(2, kf.state_cov_U);
+  kf.state_cov_D[0] = 2;
+  kf.state_cov_D[1] = 3;
+  kf.state_mean[0] = 1;
+  kf.state_mean[1] = 2;
+  double obs[2] = {1,2};
+  double k_scalar;
+  /* Test with the predicted and actual observations the same. */
+  u8 is_outlier = outlier_check(&kf, obs, &k_scalar);
+  /* A perfect match should never be an outlier, so k_scalar must be 1. */
+  fail_unless(!is_outlier);
+  fail_unless(within_epsilon(k_scalar, 1));
+  kf.state_mean[0] = 1e20;
+  kf.state_mean[1] = 1e20;
+  /* Test with the predicted and actual observations wildly different. */
+  is_outlier = outlier_check(&kf, obs, &k_scalar);
+  /* This horrible of a match should always be an outlier,
+   * so k_scalar must be < 1. */
+  fail_unless(is_outlier);
+  fail_unless(k_scalar < 1);
+}
+END_TEST
+
 Suite* amb_kf_test_suite(void)
 {
   Suite *s = suite_create("Ambiguity Kalman Filter");
 
   TCase *tc_core = tcase_create("Core");
   tcase_add_test(tc_core, test_lsq);
+  tcase_add_test(tc_core, test_sos_innov);
+  tcase_add_test(tc_core, test_outlier);
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/check_amb_kf.c
+++ b/tests/check_amb_kf.c
@@ -89,6 +89,7 @@ START_TEST(test_sos_innov)
   double obs[2] = {1,2};
   /* Test with the predicted and actual observations the same. */
   fail_unless(within_epsilon(get_sos_innov(&kf, obs), 0));
+  fail_unless(get_sos_innov(&kf, obs) >= 0);
   kf.state_mean[0] = 0;
   kf.state_mean[1] = 0;
   /* Test with the predicted and actual observations slightly different.
@@ -96,6 +97,50 @@ START_TEST(test_sos_innov)
    * y = z - H*x = z = (1, 2).
    * sos = sum_i (y_i / S_ii) = 1/3 + 2^2 / 4. */
   fail_unless(within_epsilon(get_sos_innov(&kf, obs), 1.0f/3 + 4.0f/4));
+  /* Test it with a singular matrix.
+     kf.state_cov = {{1,1},{1,1}} */
+  matrix_eye(2, kf.state_cov_U);
+  kf.state_cov_U[1] = 1;
+  kf.state_cov_D[0] = 0;
+  kf.state_cov_D[1] = 1;
+  memset(kf.decor_obs_cov, 0, 2*sizeof(double));
+  fail_unless(isfinite(get_sos_innov(&kf, obs)));
+  fail_unless(get_sos_innov(&kf, obs) >= 0);
+}
+END_TEST
+
+START_TEST(test_sos_innov_dims)
+{
+  nkf_t kf;
+  kf.state_dim = 1;
+  kf.obs_dim = 1;
+  matrix_eye(2, kf.decor_obs_mtx);
+  kf.decor_obs_cov[0] = 1;
+  kf.decor_obs_cov[1] = 1;
+  matrix_eye(2, kf.state_cov_U);
+  kf.state_cov_D[0] = 2;
+  kf.state_cov_D[1] = 3;
+  kf.state_mean[0] = -1;
+  kf.state_mean[1] = -2;
+  double obs[2] = {1,2};
+  fail_unless(within_epsilon(get_sos_innov(&kf, obs), 4.0f/3));
+  kf.state_dim = 0;
+  kf.obs_dim = 1;
+  fail_unless(get_sos_innov(&kf, obs) == 0);
+  kf.state_dim = 1;
+  kf.obs_dim = 0;
+  fail_unless(get_sos_innov(&kf, obs) == 0);
+  kf.state_dim = 0;
+  kf.obs_dim = 0;
+  fail_unless(get_sos_innov(&kf, obs) == 0);
+  kf.state_dim = 1;
+  kf.obs_dim = 2;
+  kf.decor_obs_mtx[0] = 1;
+  kf.decor_obs_mtx[1] = 1;
+  fail_unless(within_epsilon(get_sos_innov(&kf, obs), 4.0f/3 + 9.0f/3));
+  kf.state_dim = 2;
+  kf.obs_dim = 1;
+  fail_unless(within_epsilon(get_sos_innov(&kf, obs), 16.0f/6));
 }
 END_TEST
 
@@ -116,18 +161,61 @@ START_TEST(test_outlier)
   double obs[2] = {1,2};
   double k_scalar;
   /* Test with the predicted and actual observations the same. */
-  u8 is_outlier = outlier_check(&kf, obs, &k_scalar);
+  bool is_outlier = outlier_check(&kf, obs, &k_scalar);
   /* A perfect match should never be an outlier, so k_scalar must be 1. */
   fail_unless(!is_outlier);
   fail_unless(within_epsilon(k_scalar, 1));
   kf.state_mean[0] = 1e20;
   kf.state_mean[1] = 1e20;
+
   /* Test with the predicted and actual observations wildly different. */
   is_outlier = outlier_check(&kf, obs, &k_scalar);
   /* This horrible of a match should always be an outlier,
    * so k_scalar must be < 1. */
   fail_unless(is_outlier);
   fail_unless(k_scalar < 1);
+}
+END_TEST
+
+START_TEST(test_outlier_dims)
+{
+  /* Test that the outlier stuff says it's a good measurement
+     When the dimension is 0. */
+  nkf_t kf = {.state_dim = 1,
+              .obs_dim = 0};
+  double obs;
+  double k_scalar;
+  bool bad = outlier_check(&kf, &obs, &k_scalar);
+  fail_unless(bad == false);
+  fail_unless(within_epsilon(k_scalar, 1));
+  kf.state_dim = 0;
+  kf.obs_dim = 1;
+  bad = outlier_check(&kf, &obs, &k_scalar);
+  fail_unless(bad == false);
+  fail_unless(within_epsilon(k_scalar, 1));
+  kf.state_dim = 0;
+  kf.obs_dim = 0;
+  bad = outlier_check(&kf, &obs, &k_scalar);
+  fail_unless(bad == false);
+  fail_unless(within_epsilon(k_scalar, 1));
+}
+END_TEST
+
+START_TEST(test_kf_update)
+{
+  nkf_t kf;
+  memset(&kf, 1, sizeof(nkf_t));
+  kf.state_dim = 0;
+  nkf_t kf2;
+  memcpy(&kf2, &kf, sizeof(nkf_t));
+  double R = 0;
+  double innov = 0;
+  double f[10] = {0,0,0,0,0,0,0,0,0,0};
+  double g[10] = {0,0,0,0,0,0,0,0,0,0};
+  double alpha = 0;
+  double k_scalar = 0;
+  update_kf_state(&kf, R, f, g, alpha, k_scalar, innov);
+  fail_unless(memcmp(&kf, &kf2, sizeof(nkf_t)) == 0);
 }
 END_TEST
 
@@ -139,6 +227,9 @@ Suite* amb_kf_test_suite(void)
   tcase_add_test(tc_core, test_lsq);
   tcase_add_test(tc_core, test_sos_innov);
   tcase_add_test(tc_core, test_outlier);
+  tcase_add_test(tc_core, test_sos_innov_dims);
+  tcase_add_test(tc_core, test_outlier_dims);
+  tcase_add_test(tc_core, test_kf_update);
   suite_add_tcase(s, tc_core);
 
   return s;

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -15,7 +15,7 @@ u8 within_epsilon(double a, double b) {
   return 0;
 }
 
-u8 vec_within_epsilon(u32 n, const double *a, const double *b) {
+u8 arr_within_epsilon(u32 n, const double *a, const double *b) {
   for (u32 i=0; i < n; i++) {
     if (!within_epsilon(a[i], b[i])) {
       return false;
@@ -33,7 +33,7 @@ double frand(double fmin, double fmax) {
   return fmin + f * (fmax - fmin);
 }
 
-void vec_frand(u32 n, double fmin, double fmax, double *v)
+void arr_frand(u32 n, double fmin, double fmax, double *v)
 {
   for (u32 i=0; i < n; i++) {
     v[i] = frand(fmin, fmax);

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -15,6 +15,15 @@ u8 within_epsilon(double a, double b) {
   return 0;
 }
 
+u8 vec_within_epsilon(u32 n, const double *a, const double *b) {
+  for (u32 i=0; i < n; i++) {
+    if (!within_epsilon(a[i], b[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 void seed_rng(void) {
   srandom(time(NULL));
 }
@@ -22,6 +31,13 @@ void seed_rng(void) {
 double frand(double fmin, double fmax) {
   double f = (double)random() / RAND_MAX;
   return fmin + f * (fmax - fmin);
+}
+
+void vec_frand(u32 n, double fmin, double fmax, double *v)
+{
+  for (u32 i=0; i < n; i++) {
+    v[i] = frand(fmin, fmax);
+  }
 }
 
 u32 sizerand(u32 sizemax) {

--- a/tests/check_utils.h
+++ b/tests/check_utils.h
@@ -1,8 +1,8 @@
 #include "common.h"
 
 u8 within_epsilon(double a, double b);
-u8 vec_within_epsilon(u32 n, const double *a, const double *b);
+u8 arr_within_epsilon(u32 n, const double *a, const double *b);
 void seed_rng(void);
 double frand(double fmin, double fmax);
-void vec_frand(u32 n, double fmin, double fmax, double *v);
+void arr_frand(u32 n, double fmin, double fmax, double *v);
 u32 sizerand(u32 sizemax);

--- a/tests/check_utils.h
+++ b/tests/check_utils.h
@@ -1,6 +1,8 @@
 #include "common.h"
 
 u8 within_epsilon(double a, double b);
+u8 vec_within_epsilon(u32 n, const double *a, const double *b);
 void seed_rng(void);
 double frand(double fmin, double fmax);
+void vec_frand(u32 n, double fmin, double fmax, double *v);
 u32 sizerand(u32 sizemax);


### PR DESCRIPTION
Because of cycle slips, false locks, and general mismodelling brought about by changing satellite sets, I opted not to use a data editing scheme, which would have allowed the possibility of locking up the filter forever and worked poorly in testing. Instead, I opted to use a more robust measurement update that essentially allows for heavier tails in the measurement model. If the measurement is good enough, it will be acted upon as normal, and the effect of this change is continuous and smooth. "Good" here refers to an adaptively scaled weighted sum of squares of KF innovations, weighted by their variances.
The KF also now returns whether it thought this data point was an outlier.

### Sacrifices made:
- We weight the SOS by their variances instead of by the whole covariance. We saved a few matrix multiplies and the solution of a system of equations.
- We are scaling by a slightly heuristic term, with connections to Huber's minimax estimators, but the connection is still kinda loose and ad hoc. It was simpler to implement and seems good enough.
- We implement the KF gain scaling in a slightly not-statistically-optimal way, but again, it seems good enough. The important thing here is that the covariances still update properly to match the mean.

### Some things to note:
- I got about 1 in 1000 false positives in early testing (SITL). They are mostly independent and therefore spaced out.
- I use an adaptive filter to decide the scale of what is and isn't an outlier, which dramatically decreases the incidence of long series of false positives.
- The timescale of adaptation is quite short, so this handles cycle slips/change points quite well, but won't handle long streams of outliers well. That said, there was an order of magnitude between the cutoff and the smallest outlier in my (small) training set. If we decrease the frequency of cycle slips, we can choose a longer timescale.
- When using a median filter rather than basic 1st (0th?) order IIR for the adaptation in the classifier, the median had a slightly lower false positive rate (FPR) for the same same FNR with less sensitivity between FNR and FPR. However, the median filter would have been more expensive and harder to implement.

### Plots/metrics:
In this plot, we are using the short timescale IIR with false positive rate a little over 1e-3, basically where it hooks over:
![fpr versus safety](https://cloud.githubusercontent.com/assets/391217/8096775/8ad16482-0f8f-11e5-921b-b14602ff5a51.png)

To connect a point on those curves to an actual cutoff, we consult this graph (this is for the short timeframe IIR, used in this PR):
![fpr versus cutoff](https://cloud.githubusercontent.com/assets/391217/8097238/9f722dae-0f94-11e5-983b-c4e5bdcbfa73.png)


cc @kovach, @fnoble, @mookerji 
