### PR TITLE
PVT: Compute HDOP and VDOP correctly

### DIFF
--- a/include/libswiftnav/coord_system.h
+++ b/include/libswiftnav/coord_system.h
@@ -59,5 +59,7 @@ void wgsned2ecef_d(const double ned[3], const double ref_ecef[3],
 void wgsecef2azel(const double ecef[3], const double ref_ecef[3],
                   double* azimuth, double* elevation);
 
+void ecef2ned_matrix(const double ref_ecef[3], double M[3][3]);
+
 #endif /* LIBSWIFTNAV_COORD_SYSTEM_H */
 

--- a/include/libswiftnav/linear_algebra.h
+++ b/include/libswiftnav/linear_algebra.h
@@ -39,6 +39,8 @@ void dmtx_printi(s32 *mtx, u32 m, u32 n);
 void submatrix(u32 new_rows, u32 new_cols, u32 old_cols, const double *old,
                const u32 *new_row_to_old, const u32 *new_col_to_old,
                double *new);
+void submatrix_ul(u32 new_rows, u32 new_cols, u32 old_cols, const double *old,
+                  double *new);
 s32 qrdecomp_square(const double *a, u32 rows, double *qt, double *r);
 s32 qrdecomp(const double *a, u32 rows, u32 cols, double *qt, double *r);
 void qtmult(const double *qt, u32 n, const double *b, double *x);

--- a/src/coord_system.c
+++ b/src/coord_system.c
@@ -217,15 +217,15 @@ void wgsecef2llh(const double ecef[3], double llh[3]) {
   llh[2] = (p*e_c*C + fabs(ecef[2])*S - WGS84_A*e_c*A_n) / sqrt(e_c*e_c*C*C + S*S);
 }
 
-/** Helper function which populates a provided 3x3 matrix with the
- * appropriate rotation matrix to transform from ECEF to NED coordinates,
- * given the provided ECEF reference vector.
+/** Populates a provided 3x3 matrix with the appropriate rotation
+ * matrix to transform from ECEF to NED coordinates, given the
+ * provided ECEF reference vector.
  *
  * \param ref_ecef Cartesian coordinates of reference vector, passed as
  *                 [X, Y, Z], all in meters.
  * \param M        3x3 matrix to be populated with rotation matrix.
  */
-static void ecef2ned_matrix(const double ref_ecef[3], double M[3][3]) {
+void ecef2ned_matrix(const double ref_ecef[3], double M[3][3]) {
   double hyp_az, hyp_el;
   double sin_el, cos_el, sin_az, cos_az;
 

--- a/src/linear_algebra.c
+++ b/src/linear_algebra.c
@@ -70,6 +70,24 @@ void submatrix(u32 new_rows, u32 new_cols, u32 old_cols, const double *old,
   }
 }
 
+/** Extract the submatrix B at the upper-left corner of matrix A.
+ *
+ *  \param new_rows     How many rows in B
+ *  \param new_cols     How many cols in B
+ *  \param old_cols     How many cols in A
+ *  \param old          Input matrix A
+ *  \param new          Output matrix B
+ */
+void submatrix_ul(u32 new_rows, u32 new_cols, u32 old_cols, const double *old,
+                  double *new)
+{
+  for (u32 i = 0; i < new_rows; i++) {
+    for (u32 j = 0; j < new_cols; j++) {
+      new[i*new_cols + j] = old[i*old_cols + j];
+    }
+  }
+}
+
 /** QR decomposition of a square matrix.
  * Compute the QR decomposition of a square matrix \f$ A \in
  * \mathbb{R}^{N \times N} \f$: \f$ A = Q \cdot R \f$ where \f$ Q \in


### PR DESCRIPTION
We were doing two things wrong in our calculations of HDOP and VDOP:
1. Mistakenly squaring the diagonal elements of H_ned before square rooting
2. Rotating only the main diagonal of H to form H_ned.  This isn't legit, because H isn't orthonormal[1].  You have to transform the whole matrix, then look at the diagonal of the result.

This is verified to match SimGEN's idea of all the DOPs to within 1% (remainder probably explained by different original convariance matrices, plus perhaps different representations of NED frame).

cc @fnoble @imh @kovach 

[1] Did I use that linear algebra vocabulary correctly? I mean, the covariance is ellipsoidal, not spherical.