### PR TITLE
Remove newlines from logs

### DIFF
--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -324,7 +324,7 @@ void update_ambiguity_test(double ref_ecef[3], double phase_var, double code_var
 
   /* Error */
   if (valid_sdiffs != 0) {
-    log_error("update_ambiguity_test: invalid sdiffs. return code: %i\n", valid_sdiffs);
+    log_error("update_ambiguity_test: invalid sdiffs. return code: %i", valid_sdiffs);
     DEBUG_EXIT();
     return;
   }
@@ -509,7 +509,7 @@ void test_ambiguities(ambiguity_test_t *amb_test, double *dd_measurements)
   memory_pool_filter(amb_test->pool, (void *) &x, &update_and_get_max_ll);
   memory_pool_filter(amb_test->pool, (void *) &x, &filter_and_renormalize);
   if (memory_pool_empty(amb_test->pool)) {
-    log_debug("Ambiguity pool empty\n");
+    log_debug("Ambiguity pool empty");
     /* Initialize pool with single element with num_dds = 0, i.e.
      * zero length N vector, i.e. no satellites. When we take the
      * product of this single element with the set of new satellites
@@ -583,7 +583,7 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
     printf("}\n");
   }
   if (amb_test->sats.num_sats != num_sdiffs) {
-    log_debug("sats don't match (different length)\n");
+    log_debug("sats don't match (different length)");
     DEBUG_EXIT();
     return 0;
   }
@@ -592,7 +592,7 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
   u8 j=0;
   for (u8 i = 1; i<amb_test->sats.num_sats; i++) { //TODO will not having a j condition cause le fault du seg?
     if (j >= num_sdiffs) {
-      log_debug("sats don't match\n");
+      log_debug("sats don't match");
       DEBUG_EXIT();
       return 0;
     }
@@ -604,7 +604,7 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
       i--;
     }
     else {
-      log_debug("sats don't match\n");
+      log_debug("sats don't match");
       DEBUG_EXIT();
       return 0;
     }
@@ -675,7 +675,7 @@ u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, c
 
   s8 sats_management_code = rebase_sats_management(&amb_test->sats, num_sdiffs, sdiffs, sdiffs_with_ref_first);
   if (sats_management_code != OLD_REF) {
-    log_debug("updating iar reference sat\n");
+    log_debug("updating iar reference sat");
     changed_ref = 1;
     if (sats_management_code == NEW_REF_START_OVER) {
       create_ambiguity_test(amb_test);
@@ -752,7 +752,7 @@ u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_inte
 
   u8 num_dds_before_proj = CLAMP_DIFF(amb_test->sats.num_sats, 1);
   if (num_dds_before_proj == num_dds_in_intersection) {
-    log_debug("no need for projection\n");
+    log_debug("no need for projection");
     DEBUG_EXIT();
     return 0;
   }
@@ -761,13 +761,13 @@ u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_inte
   memcpy(intersection.intersection_ndxs, dd_intersection_ndxs, num_dds_in_intersection * sizeof(u8));
 
 
-  log_info("IAR: %"PRIu32" hypotheses before projection\n", memory_pool_n_allocated(amb_test->pool));
+  log_info("IAR: %"PRIu32" hypotheses before projection", memory_pool_n_allocated(amb_test->pool));
   memory_pool_group_by(amb_test->pool,
                        &intersection, &projection_comparator,
                        &intersection, sizeof(intersection),
                        &projection_aggregator);
-  log_info("IAR: updates to %"PRIu32"\n", memory_pool_n_allocated(amb_test->pool));
-  log_info("After projection, num_sats = %d\n", num_dds_in_intersection + 1);
+  log_info("IAR: updates to %"PRIu32"", memory_pool_n_allocated(amb_test->pool));
+  log_info("After projection, num_sats = %d", num_dds_in_intersection + 1);
   u8 work_prns[MAX_CHANNELS];
   memcpy(work_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
   for (u8 i=0; i<num_dds_in_intersection; i++) {
@@ -902,7 +902,7 @@ static void remap_prns(ambiguity_test_t *amb_test, u8 ref_prn,
       j++;
       k++;
     } else {
-      log_error("remap_prns: impossible condition reached.\n");
+      log_error("remap_prns: impossible condition reached.");
       printf("old_prns = [");
       for (u8 ii=0; ii < x->old_dim; ii++) {
         printf("%d, ",old_prns[ii]);
@@ -1001,8 +1001,8 @@ static s32 add_sats(ambiguity_test_t *amb_test,
                   &intersection_hypothesis_prod);
   (void) count;
   s32 num_hyps = memory_pool_n_allocated(amb_test->pool);
-  log_info("IAR: updates to %"PRIu32"\n", num_hyps);
-  log_info("add_sats. num sats: %i\n", amb_test->sats.num_sats);
+  log_info("IAR: updates to %"PRIu32"", num_hyps);
+  log_info("add_sats. num sats: %i", amb_test->sats.num_sats);
   return num_hyps;
 }
 
@@ -1071,18 +1071,18 @@ static u8 inclusion_loop_body(
   compute_Z(num_current_dds, num_dds_to_add, x->Z1, x->Z2_inv, x->Z);
 
   if (full_size <= max_num_hyps) {
-    log_debug("BRANCH 1: num dds: %i. full size: %"PRIu32", itr size: %"PRIu32"\n", num_dds_to_add, full_size, box_size);
+    log_debug("BRANCH 1: num dds: %i. full size: %"PRIu32", itr size: %"PRIu32"", num_dds_to_add, full_size, box_size);
     /* The hypotheses generated for these double-differences fit. */
     return 1;
   } else if (box_size * current_num_hyps <= max_iteration_size) {
-    log_debug("BRANCH 2: num dds: %i. full size: %"PRIu32", itr size: %"PRIu32"\n", num_dds_to_add, full_size, box_size);
+    log_debug("BRANCH 2: num dds: %i. full size: %"PRIu32", itr size: %"PRIu32"", num_dds_to_add, full_size, box_size);
 
     x->intersection_size = 0;
 
     /* Do intersection */
     memory_pool_fold(pool, (void *)x, &fold_intersection_count);
 
-    log_debug("intersection size: %i\n", x->intersection_size);
+    log_debug("intersection size: %i", x->intersection_size);
 
     if (x->intersection_size < max_num_hyps) {
       /* The hypotheses generated for these double-differences fit. */
@@ -1264,7 +1264,7 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
       }
     }
   }
-  log_debug("BRANCH 3: covariance too large. full: %"PRIu32"\n", full_size);
+  log_debug("BRANCH 3: covariance too large. full: %"PRIu32"", full_size);
   /* Covariance too large, nothing added. */
   return 0;
 }
@@ -1277,7 +1277,7 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
   DEBUG_ENTRY();
 
   if (float_sats->num_sats <= num_dds_in_intersection + 1 || float_sats->num_sats < 2) {
-    log_debug("no need for inclusion\n");
+    log_debug("no need for inclusion");
     DEBUG_EXIT();
     return 0;
   }
@@ -1340,11 +1340,11 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
                                             Z_inv);
   if (add_any_sats == 1) {
     add_sats_old(amb_test, float_prns[0], num_dds_to_add, new_dd_prns, lower_bounds, upper_bounds, Z_inv);
-    log_debug("adding sats\n");
+    log_debug("adding sats");
     DEBUG_EXIT();
     return 1;
   } else {
-    log_debug("not adding sats\n");
+    log_debug("not adding sats");
     DEBUG_EXIT();
     return 0;
   }
@@ -1484,7 +1484,7 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
 
   if (num_sdiffs < 2) {
     create_ambiguity_test(amb_test);
-    log_debug("< 2 sdiffs, starting over\n");
+    log_debug("< 2 sdiffs, starting over");
     DEBUG_EXIT();
     return 0; // I chose 0 because it doesn't lead to anything dynamic
   }
@@ -1526,7 +1526,7 @@ u8 ambiguity_update_sats(ambiguity_test_t *amb_test, const u8 num_sdiffs,
       changed_sats = 1;
     }
   }
-  log_debug("changed_sats = %u\n", changed_sats);
+  log_debug("changed_sats = %u", changed_sats);
 
   DEBUG_EXIT();
   return changed_sats;
@@ -1559,7 +1559,7 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
   u8 k = 0;
   while (i < amb_test->sats.num_sats && j < num_sdiffs) {
     if (amb_test->sats.prns[i] == sdiffs_with_ref_first[j].prn) {
-      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] == sdiffs_with_ref_first[j].prn; i,j,k++\n",
+      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] == sdiffs_with_ref_first[j].prn; i,j,k++",
                 i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
       intersection_ndxs[k] = i-1;
       i++;
@@ -1567,12 +1567,12 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
       k++;
     }
     else if (amb_test->sats.prns[i] < sdiffs_with_ref_first[j].prn) {
-      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] <  sdiffs_with_ref_first[j].prn; i++\n",
+      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] <  sdiffs_with_ref_first[j].prn; i++",
                 i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
       i++;
     }
     else {
-      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] >  sdiffs_with_ref_first[j].prn; j++\n",
+      log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] >  sdiffs_with_ref_first[j].prn; j++",
                 i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
       j++;
     }
@@ -1685,7 +1685,7 @@ void add_sats_old(ambiguity_test_t *amb_test,
       j++;
       k++;
     } else {
-      log_error("add_sats_old: impossible condition reached.\n");
+      log_error("add_sats_old: impossible condition reached.");
       printf("old_prns = [");
       for (u8 ii=0; ii < x0.num_old_dds; ii++) {
         printf("%d, ",old_prns[ii]);
@@ -1708,7 +1708,7 @@ void add_sats_old(ambiguity_test_t *amb_test,
     empty_element->ll = 0; // only in init
   }
 
-  log_info("IAR: %"PRIu32" hypotheses before inclusion\n", memory_pool_n_allocated(amb_test->pool));
+  log_info("IAR: %"PRIu32" hypotheses before inclusion", memory_pool_n_allocated(amb_test->pool));
   if (DEBUG) {
     memory_pool_map(amb_test->pool, &x0.num_old_dds, &print_hyp);
   }
@@ -1716,7 +1716,7 @@ void add_sats_old(ambiguity_test_t *amb_test,
   /* Take the product of our current hypothesis state with the generator, recorrelating the new ones as we go. */
   memory_pool_product_generator(amb_test->pool, &x0, MAX_HYPOTHESES, sizeof(x0),
                                 &no_init, &generate_next_hypothesis, &hypothesis_prod);
-  log_info("IAR: updates to %"PRIu32"\n", memory_pool_n_allocated(amb_test->pool));
+  log_info("IAR: updates to %"PRIu32"", memory_pool_n_allocated(amb_test->pool));
   if (DEBUG) {
     memory_pool_map(amb_test->pool, &k, &print_hyp);
   }

--- a/src/baseline.c
+++ b/src/baseline.c
@@ -299,7 +299,7 @@ s8 lesq_solution_float(u8 num_dds_u8, const double *dd_obs, const double *N,
           &info);                 /* INFO. */
 
   if (info != 0) {
-    log_error("dgelsy returned error %"PRId32"\n", info);
+    log_error("dgelsy returned error %"PRId32"", info);
     return -2;
   }
 
@@ -592,7 +592,7 @@ s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
 
   if (valid_sdiffs < 0) {
     if (valid_sdiffs != -1) {
-      log_error("baseline: Invalid sdiffs\n");
+      log_error("baseline: Invalid sdiffs");
     }
     return -2;
   }

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -138,7 +138,7 @@ void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double receiver_ecef[3], u
   /* all the ref sat stuff */
   s8 sats_management_code = rebase_sats_management(&sats_management, num_sdiffs, sdiffs, corrected_sdiffs);
   if (sats_management_code == NEW_REF_START_OVER) {
-    log_info("Unable to rebase to new ref, resetting filters and starting over\n");
+    log_info("Unable to rebase to new ref, resetting filters and starting over");
     dgnss_init(num_sdiffs, sdiffs, receiver_ecef);
     memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
     if (num_sdiffs >= 1) {
@@ -297,7 +297,7 @@ void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3],
         disable_raim, raim_threshold);
 
     if (code < 0) {
-      log_warn("dgnss_update. baseline estimate error: %d\n", code);
+      log_warn("dgnss_update. baseline estimate error: %d", code);
       /* Use b = 0, continue */
       memset(b2, 0, sizeof(b2));
     }
@@ -420,8 +420,8 @@ s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                     disable_raim, raim_threshold);
   if (ret >= 0) {
     if (ret == 1) /* TODO: Export this rather than just printing */
-      log_warn("dgnss_baseline: Fixed baseline RAIM repair\n");
-    log_debug("fixed solution\n");
+      log_warn("dgnss_baseline: Fixed baseline RAIM repair");
+    log_debug("fixed solution");
     DEBUG_EXIT();
     return 1;
   }
@@ -431,12 +431,12 @@ s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                       disable_raim, raim_threshold))
         >= 0) {
     if (ret == 1) /* TODO: Export this rather than just printing */
-      log_warn("dgnss_baseline: Float baseline RAIM repair\n");
-    log_debug("float solution\n");
+      log_warn("dgnss_baseline: Float baseline RAIM repair");
+    log_debug("float solution");
     DEBUG_EXIT();
     return 2;
   }
-  log_debug("no baseline solution\n");
+  log_debug("no baseline solution");
   DEBUG_EXIT();
   return ret;
 }
@@ -597,7 +597,7 @@ static u8 get_de_and_phase(sats_management_t *sats_man,
     }
     else if (sdiffs[j].prn > sats_man->prns[i]) {
       /* This should never happen. */
-      log_warn("sdiffs should be a super set of sats_man prns\n");
+      log_warn("sdiffs should be a super set of sats_man prns");
       i++;
     }
     else {  /* else they match */

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -63,7 +63,7 @@ s8 calc_sat_state(const ephemeris_t *ephemeris, gps_time_t t,
 
   /* If dt is greater than 4 hours our ephemeris isn't valid. */
   if (fabs(dt) > EPHEMERIS_VALID_TIME) {
-    log_error("Using ephemeris outside validity period, dt = %+.0f\n", dt);
+    log_error("Using ephemeris outside validity period, dt = %+.0f", dt);
     return -1;
   }
 

--- a/src/filter_utils.c
+++ b/src/filter_utils.c
@@ -52,7 +52,7 @@ s8 assign_de_mtx(u8 num_sats, const sdiff_t *sats_with_ref_first,
   assert(DE != NULL);
 
   if (num_sats <= 1) {
-    log_debug("assign_de_mtx: not enough sats\n");
+    log_debug("assign_de_mtx: not enough sats");
     return -1;
   }
 

--- a/src/lambda.c
+++ b/src/lambda.c
@@ -51,7 +51,7 @@ static int LD(int n, const double *Q, double *L, double *D)
     }
     if (info) {
         log_error("%s : LD factorization error, trying UD from Gibbs "
-                  "(col major UD = LD)\n", __FILE__);
+                  "(col major UD = LD)", __FILE__);
         double Qcopy[n * n];
         memcpy(Qcopy, Q, n * n * sizeof(double));
         matrix_udu(n, Qcopy, L, D);
@@ -163,7 +163,7 @@ static int search(int n, int m, const double *L, const double *D,
     }
 
     if (c>=LOOPMAX) {
-        log_error("LAMBDA search loop count overflow\n");
+        log_error("LAMBDA search loop count overflow");
         return -1;
     }
     return 0;

--- a/src/nav_msg.c
+++ b/src/nav_msg.c
@@ -202,7 +202,7 @@ s32 nav_msg_update(nav_msg_t *n, s32 corr_prompt_real, u8 ms)
   }
 
   if (n->subframe_bit_index >= NAV_MSG_SUBFRAME_BITS_LEN*32) {
-    log_error("subframe bit index gone wild %d\n", (int)n->subframe_bit_index);
+    log_error("subframe bit index gone wild %d", (int)n->subframe_bit_index);
     return -22;
   }
 
@@ -326,7 +326,7 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
   // Check parity and parse out the ephemeris from the most recently received subframe
 
   if (!e) {
-    log_error("process_subframe: CALLED WITH e = NULL!\n");
+    log_error("process_subframe: CALLED WITH e = NULL!");
     n->subframe_start_index = 0;  // Mark the subframe as processed
     n->next_subframe_id = 1;      // Make sure we start again next time
     return -1;
@@ -342,20 +342,20 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
   if ((prev_bit_polarity != BIT_POLARITY_UNKNOWN)
       && (prev_bit_polarity != n->bit_polarity)) {
     log_error("PRN %02d Nav phase flip - half cycle slip detected, "
-              "but not corrected\n", e->prn+1);
+              "but not corrected", e->prn+1);
     /* TODO: declare phase ambiguity to IAR */
   }
 
   /* Complain if buffer overrun */
   if (n->overrun) {
-    log_error("PRN %02d nav_msg subframe buffer overrun!\n", e->prn+1);
+    log_error("PRN %02d nav_msg subframe buffer overrun!", e->prn+1);
     n->overrun = false;
   }
 
   /* Extract word 2, and the last two parity bits of word 1 */
   u32 sf_word2 = extract_word(n, 28, 32, 0);
   if (nav_parity(&sf_word2)) {
-    log_info("PRN %02d subframe parity mismatch (word 2)\n", e->prn+1);
+    log_info("PRN %02d subframe parity mismatch (word 2)", e->prn+1);
     n->subframe_start_index = 0;  // Mark the subframe as processed
     n->next_subframe_id = 1;      // Make sure we start again next time
     return -2;
@@ -369,7 +369,7 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
       n->frame_words[sf_id-1][w] = extract_word(n, 30*(w+2) - 2, 32, 0);    // Get the bits
       // MSBs are D29* and D30*.  LSBs are D1...D30
       if (nav_parity(&n->frame_words[sf_id-1][w])) {  // Check parity and invert bits if D30*
-        log_info("PRN %02d subframe parity mismatch (word %d)\n", e->prn+1, w+3);
+        log_info("PRN %02d subframe parity mismatch (word %d)", e->prn+1, w+3);
         n->next_subframe_id = 1;      // Make sure we start again next time
         n->subframe_start_index = 0;  // Mark the subframe as processed
         return -3;

--- a/src/observation.c
+++ b/src/observation.c
@@ -309,7 +309,7 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
   }
 
   if (!is_prn_set(num_dds, non_ref_prns)) {
-    log_error("There is disorder in the amb_test sats.\n");
+    log_error("There is disorder in the amb_test sats.");
     printf("amb_test sat prns = {%u, ", ref_prn);
     for (u8 k=0; k < num_dds; k++) {
       printf("%u, ", non_ref_prns[k]);
@@ -444,7 +444,7 @@ u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop, u8 *sats_t
  */
 void debug_sdiff(sdiff_t sd)
 {
-  log_debug("sdiff_t:\n"
+  log_debug("sdiff_t:"
     "\tprn = %u\n"
     "\tsnr = %f\n"
     "\tpseudorange   = %f\n"
@@ -464,11 +464,11 @@ void debug_sdiff(sdiff_t sd)
  */
 void debug_sdiffs(u8 n, sdiff_t *sds)
 {
-  log_debug("[\n");
+  log_debug("[");
   for (u8 i=0; i<n; i++) {
     debug_sdiff(sds[i]);
   }
-  log_debug("]\n");
+  log_debug("]");
 }
 
 /** \} */

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -55,15 +55,15 @@ static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats
   /* Loop over sats1 and sdffs and check if a PRN is present in both. */
   for (i=0, j=0; i<num_sats1 && j<num_sdiffs; i++, j++) {
     if (sats1[i] < sdiffs[j].prn) {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 < prn2  i++\n", n, i, sats1[i], j, sdiffs[j].prn);
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 < prn2  i++", n, i, sats1[i], j, sdiffs[j].prn);
       j--;
     }
     else if (sats1[i] > sdiffs[j].prn) {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 > prn2  j++\n", n, i, sats1[i], j, sdiffs[j].prn);
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 > prn2  j++", n, i, sats1[i], j, sdiffs[j].prn);
       i--;
     }
     else {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 = prn2  i,j,n++\n", n, i, sats1[i], j, sdiffs[j].prn);
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 = prn2  i,j,n++", n, i, sats1[i], j, sdiffs[j].prn);
       memcpy(&intersection_sats[n], &sdiffs[j], sizeof(sdiff_t));
       n++;
     }
@@ -127,8 +127,8 @@ static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_manageme
   DEBUG_ENTRY();
 
   u8 old_ref = sats_management->prns[0];
-  log_debug("ref_prn = %u\n", ref_prn);
-  log_debug("old_ref = %u\n", old_ref);
+  log_debug("ref_prn = %u", ref_prn);
+  log_debug("old_ref = %u", old_ref);
   u8 j;
   if (old_ref != ref_prn) {
     j = 1;
@@ -160,11 +160,11 @@ static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_manageme
   j=1;
   for (u8 i=0; i<num_sdiffs; i++) {
     if (sdiffs[i].prn != ref_prn) {
-      log_debug("prn[%u] = %u\n", j, sdiffs[i].prn);
+      log_debug("prn[%u] = %u", j, sdiffs[i].prn);
       memcpy(&sdiffs_with_ref_first[j], &sdiffs[i], sizeof(sdiff_t));
       j++;
     } else {
-      log_debug("prn[0] = %u\n", sdiffs[i].prn);
+      log_debug("prn[0] = %u", sdiffs[i].prn);
       memcpy(&sdiffs_with_ref_first[0], &sdiffs[i], sizeof(sdiff_t));
     }
   }


### PR DESCRIPTION
Used:

```
perl -pi -e 's/(log_.*)\\n"/\1"/' *.c
```

to strip the newlines out of the logging for most cases. Did the rest by hand. Left out the `printf`'s.

/cc @gsmcmullin 