### PR TITLE
Refactor make_dds

### DIFF
--- a/checks/run-coverage.sh
+++ b/checks/run-coverage.sh
@@ -1,6 +1,7 @@
 # requires gcovr and diff-cover
 # pip install gcovr diff-cover
 set -e
+unset GIT_DIR
 base="$(git rev-parse --show-toplevel)"
 echo "running coverage check from ${base}"
 gcovr -r "${base}" --object-directory . --xml -o "${base}/.coverage.xml"

--- a/checks/setup-hooks.sh
+++ b/checks/setup-hooks.sh
@@ -8,3 +8,4 @@ hooks="$(git rev-parse --git-dir)/hooks"
 echo "Installing hook at: ${hooks}"
 # insert value of builddir as first line of pre-commit
 echo "subdir=$builddir" | cat - checks/pre-commit > "$hooks/pre-commit"
+chmod +x "$hooks/pre-commit"

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -129,4 +129,8 @@ void assign_r_vec(residual_mtxs_t *res_mtxs, u8 num_dds, double *dd_measurements
 void assign_r_mean(residual_mtxs_t *res_mtxs, u8 num_dds, double *hypothesis, double *r_mean);
 double get_quadratic_term(residual_mtxs_t *res_mtxs, u8 num_dds, double *hypothesis, double *r_vec);
 
+void print_hyp(void *arg, element_t *elem);
+void print_intersection_state(intersection_count_t *x);
+
+
 #endif /* LIBSWIFTNAV_AMBIGUITY_TEST_H */

--- a/include/libswiftnav/baseline.h
+++ b/include/libswiftnav/baseline.h
@@ -49,9 +49,14 @@ s8 least_squares_solve_b_external_ambs(u8 num_dds, const double *ambs,
 s8 baseline(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
             const ambiguities_t *ambs, u8 *num_used, double b[3],
             bool disable_raim, double raim_threshold);
+//TODO(dsk) remove
+//s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
+//             u8 num_ambs, const u8 *amb_prns, const double *ambs,
+//             u8 *num_used, double b[3], bool disable_raim, double raim_threshold);
 s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
-             u8 num_ambs, const u8 *amb_prns, const double *ambs,
-             u8 *num_used, double b[3], bool disable_raim, double raim_threshold);
+             u8 num_ambs, const ambiguity_t *single_ambs,
+             u8 *num_used, double b[3],
+             bool disable_raim, double raim_threshold);
 
 void ambiguities_init(ambiguities_t *ambs);
 s8 lesq_solve_raim(u8 num_dds_u8, const double *dd_obs,

--- a/include/libswiftnav/baseline.h
+++ b/include/libswiftnav/baseline.h
@@ -21,6 +21,11 @@
  * \{ */
 
 typedef struct {
+  double amb;
+  u8 prn;
+} ambiguity_t;
+
+typedef struct {
   double ambs[MAX_CHANNELS-1];
   u8 prns[MAX_CHANNELS];
   u8 n;
@@ -46,17 +51,15 @@ s8 least_squares_solve_b_external_ambs(u8 num_dds, const double *ambs,
          const double ref_ecef[3], double b[3],
          bool disable_raim, double raim_threshold);
 
-s8 baseline(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
-            const ambiguities_t *ambs, u8 *num_used, double b[3],
-            bool disable_raim, double raim_threshold);
-//TODO(dsk) remove
-//s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
-//             u8 num_ambs, const u8 *amb_prns, const double *ambs,
-//             u8 *num_used, double b[3], bool disable_raim, double raim_threshold);
+void diff_ambs(u8 ref_prn, u8 num_ambs, const ambiguity_t *amb_set,
+               double *dd_ambs);
 s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
              u8 num_ambs, const ambiguity_t *single_ambs,
              u8 *num_used, double b[3],
              bool disable_raim, double raim_threshold);
+s8 baseline(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
+            const ambiguities_t *ambs, u8 *num_used, double b[3],
+            bool disable_raim, double raim_threshold);
 
 void ambiguities_init(ambiguities_t *ambs);
 s8 lesq_solve_raim(u8 num_dds_u8, const double *dd_obs,

--- a/include/libswiftnav/memory_pool.h
+++ b/include/libswiftnav/memory_pool.h
@@ -84,6 +84,5 @@ s32 memory_pool_product_generator(memory_pool_t *pool, void *x0, u32 n_xs, size_
                                   s8 (*init)(void *x, element_t *elem),
                                   s8 (*next)(void *x, u32 n),
                                   void (*prod)(element_t *new, void *x, u32 n, element_t *elem));
-
 #endif /* LIBSWIFTNAV_MEMORY_POOL_H */
 

--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -19,6 +19,12 @@
 #include "ephemeris.h"
 #include "gpstime.h"
 
+// TODO(dsk) right file?
+typedef struct {
+  u8 prn;
+  double amb;
+} ambiguity_t;
+
 typedef struct {
   double pseudorange;
   double carrier_phase;
@@ -30,7 +36,11 @@ typedef struct {
   u8 prn;
 } sdiff_t;
 
+int cmp_sdiff(const void *a_, const void *b_);
+int cmp_amb(const void *a_, const void *b_);
+int cmp_amb_sdiff(const void *a_, const void *b_);
 int cmp_sdiff_prn(const void *a_, const void *b_);
+int cmp_amb_prn(const void *a_, const void *b_);
 
 u8 single_diff(u8 n_a, navigation_measurement_t *m_a,
                u8 n_b, navigation_measurement_t *m_b,

--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -19,12 +19,6 @@
 #include "ephemeris.h"
 #include "gpstime.h"
 
-// TODO(dsk) right file?
-typedef struct {
-  u8 prn;
-  double amb;
-} ambiguity_t;
-
 typedef struct {
   double pseudorange;
   double carrier_phase;

--- a/include/libswiftnav/printing_utils.h
+++ b/include/libswiftnav/printing_utils.h
@@ -14,13 +14,10 @@
 #define LIBSWIFTNAV_PRINTING_UTILS_H
 
 void print_s32_mtx_diff(u32 m, u32 n, s32 *mat1, s32 *mat2);
-void print_hyp(void *arg, element_t *elem);
 void print_double_mtx(double *m, u32 _r, u32 _c);
 void print_pearson_mtx(double *m, u32 dim);
 void print_s32_mtx_diff(u32 m, u32 n, s32 *mat1, s32 *mat2);
 void print_s32_mtx(s32 *mat, u32 m, u32 n);
 void print_s32_gemv(u32 m, u32 n, s32 *M, s32 *v);
-void print_intersection_state(intersection_count_t *x);
-
 
 #endif /* LIBSWIFTNAV_PRINTING_UTILS_H */

--- a/include/libswiftnav/sats_management.h
+++ b/include/libswiftnav/sats_management.h
@@ -30,7 +30,6 @@ typedef struct {
   u8 prns[MAX_CHANNELS];
 } sats_management_t;
 
-// TODO(dsk) used in baseline.c; move to different file?
 u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats);
 
 void init_sats_management(sats_management_t *sats_management,

--- a/include/libswiftnav/sats_management.h
+++ b/include/libswiftnav/sats_management.h
@@ -30,6 +30,9 @@ typedef struct {
   u8 prns[MAX_CHANNELS];
 } sats_management_t;
 
+// TODO(dsk) used in baseline.c; move to different file?
+u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats);
+
 void init_sats_management(sats_management_t *sats_management,
                           const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 void print_sats_management(sats_management_t *sats_management);

--- a/include/libswiftnav/set.h
+++ b/include/libswiftnav/set.h
@@ -48,5 +48,10 @@ s32 intersection(u32 na, size_t sa, const void *as, void *a_out,
                  u32 nb, size_t sb, const void *bs, void *b_out,
                  cmp_fn cmp);
 
+u32 insertion_index(u32 na, size_t sa, const void *as, void *b, cmp_fn cmp);
+u32 remove_element(u32 na, size_t sa, const void *as, void *a_out,
+                   void *b, cmp_fn cmp);
+u32 insert_element(u32 na, size_t sa, const void *as, void *a_out,
+                   void *b, cmp_fn cmp);
 #endif /* LIBSWIFTNAV_SET_H */
 

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -1831,4 +1831,68 @@ double get_quadratic_term(residual_mtxs_t *res_mtxs, u8 num_dds, double *hypothe
   return quad_term;
 }
 
+void print_hyp(void *arg, element_t *elem)
+{
+  u8 num_dds = *( (u8 *) arg );
+
+  hypothesis_t *hyp = (hypothesis_t *)elem;
+  printf("[");
+  for (u8 i=0; i< num_dds; i++) {
+    printf("%"PRId32", ", hyp->N[i]);
+  }
+  printf("]: %f\n", hyp->ll);
+}
+
+/** Prints a s64 valued matrix.
+ *
+ * \param m     The number of rows to be printed in the matrices.
+ * \param n     The number of columns in the matrix.
+ * \param mat1  The matrix to be printed.
+ */
+static void print_s64_mtx(s64 *mat, u32 m, u32 n)
+{
+  for (u32 i=0; i < m; i++) {
+    for (u32 j=0; j < n; j++) {
+      printf("%"PRId64", ", mat[i*n + j]);
+    }
+    printf("\n");
+  }
+  printf("\n");
+}
+
+/* Utilities for debugging inclusion algorithm in ambiguity_test.c */
+static void print_Z(s8 label, u8 full_dim, u8 new_dim, z_t * Z)
+{
+  printf("Z %i:\n", label);
+  print_s64_mtx(Z, full_dim, new_dim);
+}
+
+void print_intersection_state(intersection_count_t *x)
+{
+  u8 full_dim = x->old_dim + x->new_dim;
+
+  printf("itr lower bounds:\n");
+  for (u8 i = 0; i < x->new_dim; i++) {
+    printf("%"PRIi64"\n", x->itr_lower_bounds[i]);
+  }
+  printf("itr upper bounds:\n");
+  for (u8 i = 0; i < x->new_dim; i++) {
+    printf("%"PRIi64"\n", x->itr_upper_bounds[i]);
+  }
+  printf("box lower bounds:\n");
+  for (u8 i = 0; i < full_dim; i++) {
+    printf("%"PRIi64"\n", x->box_lower_bounds[i]);
+  }
+  printf("box upper bounds:\n");
+  for (u8 i = 0; i < full_dim; i++) {
+    printf("%"PRIi64"\n", x->box_upper_bounds[i]);
+  }
+  printf("transformation matrix:\n");
+  print_Z(68, full_dim, x->new_dim, x->Z);
+  printf("z1:\n");
+  print_Z(0, full_dim, full_dim, x->Z1);
+  printf("z2_inv:\n");
+  print_Z(0, x->new_dim, x->new_dim, x->Z2_inv);
+}
+
 /** \} */

--- a/src/baseline.c
+++ b/src/baseline.c
@@ -24,6 +24,7 @@
 #include "linear_algebra.h"
 #include "filter_utils.h"
 #include "set.h"
+#include "sats_management.h" /* choose_reference_sat */
 
 /** \defgroup baseline Baseline calculations
  * Functions for relating the baseline vector with carrier phase observations
@@ -385,12 +386,12 @@ static bool chi_test(double threshold, u8 num_dds,
 /** Calculate lesq baseline with raim check/repair
  *
  * \param num_dds_u8 Number of double difference observations
- * \param dd_obs  Double differenced carrier phase observations in cycles,
- *                length `num_dds_u8`
- * \param N       Carrier phase ambiguity vector, length `num_dds`
- * \param DE      Double differenced matrix of unit vectors to the satellites,
- *                length `3 * num_dds`
- * \param b       The output baseline in meters.
+ * \param dd_obs     Double differenced carrier phase observations in cycles,
+ *                   length `num_dds_u8`
+ * \param N          Carrier phase ambiguity vector, length `num_dds_u8`
+ * \param DE         Double differenced matrix of unit vectors to the satellites,
+ *                   length `3 * num_dds`
+ * \param b          The output baseline in meters.
  * \param disable_raim if true raim check/repair will not be performed
  * \param raim_threshold test threshold for check
  * \param n_used if not null, outputs num obs used in solution
@@ -541,24 +542,26 @@ s8 least_squares_solve_b_external_ambs(u8 num_dds_u8, const double *state_mean,
   return code;
 }
 
+// TODO:
+//void diff_ambiguities(u8 ref_prn, u8 intersection_size,
+//                      ambiguity_t *intersection_ambs, double *dd_ambs);
+//void diff_measurements(u8 ref_prn, u8 intersection_size, sdiff_t *intersection_sdiffs, double *dd_meas);
+
 /** Calculate least squares baseline solution from a set of single difference
  * observations and carrier phase ambiguities.
  *
  * \param num_sdiffs Number of single difference observations
- * \param sdiffs     Set of single differenced observations, length
- *                   `num_sdiffs`, sorted by PRN
- * \param ref_ecef   The reference position in ECEF frame, for computing the
- *                   sat direction vectors
- * \param num_ambs   Number of carrier phase ambiguities
- * \param amb_prns   Element zero is the reference PRN and the subsequent
- *                   elements are the set of PRNs corresponding to the
- *                   ambiguities, length `num_ambs+1`, sorted by PRN
- * \param ambs       Array of double differenced carrier phase ambiguities,
- *                   length `num_ambs`
- * \param num_used   Pointer to where to store number of satellites used in the
- *                   baseline solution
- * \param b          The output baseline in meters
- * \param disable_raim True disables raim check/repair
+ * \param sdiffs      Set of single differenced observations, length
+ *                    `num_sdiffs`, sorted by PRN
+ * \param ref_ecef    The reference position in ECEF frame, for computing the
+ *                    sat direction vectors
+ * \param num_ambs    Number of carrier phase ambiguities
+ * \param single_ambs Array of (carrier phase ambiguitie, prn) pairs.
+ *                    length `num_ambs`
+ * \param num_used    Pointer to where to store number of satellites used in the
+ *                    baseline solution
+ * \param b           The output baseline in meters
+ * \param disable_raim   True disables raim check/repair
  * \param raim_threshold Threshold for raim checks.
  * \return            0 on success,
  *                   -1 if there were insufficient observations to calculate the
@@ -566,48 +569,86 @@ s8 least_squares_solve_b_external_ambs(u8 num_dds_u8, const double *state_mean,
  *                   -2 if an error occurred
  */
 s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
-             u8 num_ambs, const u8 *amb_prns, const double *ambs,
+             u8 num_ambs, const ambiguity_t *single_ambs,
              u8 *num_used, double b[3],
              bool disable_raim, double raim_threshold)
 {
-  assert(sdiffs != NULL);
-  assert(ref_ecef != NULL);
-  assert(amb_prns != NULL);
-  assert(ambs != NULL);
-  assert(num_used != NULL);
-  assert(b != NULL);
+  // TODO
+  //  - look into where rebases happen 
+  //  - vlad's prn changes?
+  //    - probably just cmp fn change
+  //  - unit testing
+  //
+  // TODO(also): error msg array
+  // also: clean up sats_man?
 
-  assert(is_prn_set(num_ambs, &amb_prns[1]));
-  assert(is_set(num_sdiffs, sizeof(sdiff_t), sdiffs, cmp_sdiff_prn));
-
-  if (num_sdiffs < 4 || (num_ambs+1) < 4) {
+  if (num_sdiffs < 4 || num_ambs < 4) {
     /* For a position solution, we need at least 4 sats. */
     return -1;
   }
 
+  assert(sdiffs != NULL);
+  assert(ref_ecef != NULL);
+  assert(single_ambs != NULL);
+  assert(num_used != NULL);
+  assert(b != NULL);
+
+  assert(is_set(num_ambs, sizeof(ambiguity_t), single_ambs, cmp_amb));
+  assert(is_set(num_sdiffs, sizeof(sdiff_t), sdiffs, cmp_sdiff));
+
   assert(num_sdiffs <= MAX_CHANNELS);
 
-  double dd_meas[2 * num_ambs];
-  sdiff_t matched_sdiffs[num_ambs+1];
+  // TODO could use min(num_ambs, num_sdiffs)
+  ambiguity_t intersection_ambs[num_ambs];
+  sdiff_t intersection_sdiffs[num_ambs];
 
-  s8 valid_sdiffs = make_dd_measurements_and_sdiffs(
-             amb_prns[0], &amb_prns[1], num_ambs,
-             num_sdiffs, sdiffs,
-             dd_meas, matched_sdiffs);
+  s32 intersection_size = intersection(
+      num_ambs,   sizeof(ambiguity_t), single_ambs, intersection_ambs,
+      num_sdiffs, sizeof(sdiff_t),     sdiffs,      intersection_sdiffs,
+      cmp_amb_sdiff);
 
-  if (valid_sdiffs < 0) {
-    if (valid_sdiffs != -1) {
-      log_error("baseline: Invalid sdiffs");
-    }
-    return -2;
+  if (intersection_size < 4) {
+    /* For a position solution, we need at least 4 sats. */
+    return -1;
   }
 
-  double DE[num_ambs * 3];
-  assign_de_mtx(num_ambs+1, matched_sdiffs, ref_ecef, DE);
+  /* Calculate double differences. */
+  u8 ref_prn = choose_reference_sat(intersection_size, intersection_sdiffs);
 
-  *num_used = num_ambs + 1;
+  u8 num_dds = intersection_size - 1;
+  ambiguity_t amb_no_ref[num_dds];
+  sdiff_t sdiff_ref_first[intersection_size];
 
-  return lesq_solve_raim(num_ambs, dd_meas, ambs, DE, b, disable_raim, raim_threshold, 0, 0, 0);
+  u32 sdiff_ref_index = remove_element(intersection_size, sizeof(sdiff_t),
+                                       intersection_sdiffs,
+                                       &(sdiff_ref_first[1]),  /* New set */
+                                       &ref_prn, cmp_sdiff_prn);
+  u32 amb_ref_index = remove_element(intersection_size, sizeof(ambiguity_t),
+                                     intersection_ambs,
+                                     amb_no_ref,  /* New set */
+                                     &ref_prn, cmp_amb_prn);
+  memcpy(sdiff_ref_first, &intersection_sdiffs[sdiff_ref_index],
+         sizeof(sdiff_t));
+
+  double dd_ambs[num_dds];
+  double dd_meas[2 * num_dds];
+
+  /* Actually calculate double differences. */
+  for (u32 i = 0; i < num_dds; i++) {
+    dd_ambs[i] = amb_no_ref[i].amb - intersection_ambs[amb_ref_index].amb;
+    dd_meas[i] =
+      sdiff_ref_first[i+1].carrier_phase - sdiff_ref_first[0].carrier_phase;
+    dd_meas[i + num_dds] =
+      sdiff_ref_first[i+1].pseudorange - sdiff_ref_first[0].pseudorange;
+  }
+
+  double DE[num_dds * 3];
+  assign_de_mtx(intersection_size, sdiff_ref_first, ref_ecef, DE);
+
+  *num_used = intersection_size;
+
+  return lesq_solve_raim(num_dds, dd_meas, dd_ambs, DE, b,
+                         disable_raim, raim_threshold, 0, 0, 0);
 }
 
 /** Calculate least squares baseline solution from a set of single difference
@@ -634,8 +675,27 @@ s8 baseline(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
             const ambiguities_t *ambs, u8 *num_used, double b[3],
             bool disable_raim, double raim_threshold)
 {
+  u8 num = ambs->n + 1;
+  ambiguity_t ambts[ambs->n];
+  ambiguity_t single_ambs[num];
+  u8 ref_prn = ambs->prns[0];
+  ambiguity_t ref_amb = {.prn = ref_prn, .amb = 0};
+
+  /* TODO(dsk) convert ambiguities_t to have an ambiguity_t array? */
+  for (s32 i = 0; i < ambs->n; i ++) {
+    /* ambs contains ambiguities for all non-ref prns */
+    ambts[i].amb = ambs->ambs[i];
+    /* prns contains ref prn followed by the rest */
+    ambts[i].prn = ambs->prns[i+1];
+  }
+
+  insert_element(ambs->n, sizeof(ambiguity_t), ambts, single_ambs,
+                 &ref_amb, cmp_amb);
+
+  /* single_ambs is now an ambiguity_t set */
   return baseline_(num_sdiffs, sdiffs, ref_ecef,
-                   ambs->n, ambs->prns, ambs->ambs, num_used, b,
+                   num, single_ambs,
+                   num_used, b,
                    disable_raim, raim_threshold);
 }
 

--- a/src/observation.c
+++ b/src/observation.c
@@ -27,11 +27,41 @@
 
 /** Comparison function for `sdiff_t` by PRN.
  * See `cmp_fn`. */
-int cmp_sdiff_prn(const void *a_, const void *b_)
+int cmp_sdiff(const void *a_, const void *b_)
 {
   const sdiff_t *a = (const sdiff_t *)a_;
   const sdiff_t *b = (const sdiff_t *)b_;
   return cmp_u8_u8(&(a->prn), &(b->prn));
+}
+
+/** Comparison function for `ambiguity_t` by PRN.
+ * See `cmp_fn`. */
+int cmp_amb(const void *a_, const void *b_)
+{
+  const ambiguity_t *a = (const ambiguity_t *)a_;
+  const ambiguity_t *b = (const ambiguity_t *)b_;
+  return cmp_u8_u8(&(a->prn), &(b->prn));
+}
+
+int cmp_amb_sdiff(const void *a_, const void *b_)
+{
+  const ambiguity_t *a = (const ambiguity_t *)a_;
+  const sdiff_t *b = (const sdiff_t *)b_;
+  return cmp_u8_u8(&(a->prn), &(b->prn));
+}
+
+int cmp_sdiff_prn(const void *a_, const void *b_)
+{
+  const sdiff_t *a = (const sdiff_t *)a_;
+  const u8 *b = (const u8 *)b_;
+  return cmp_u8_u8(&(a->prn), b);
+}
+
+int cmp_amb_prn(const void *a_, const void *b_)
+{
+  const ambiguity_t *a = (const ambiguity_t *)a_;
+  const u8 *b = (const u8 *)b_;
+  return cmp_u8_u8(&(a->prn), b);
 }
 
 /** Create a single difference from two observations.

--- a/src/observation.c
+++ b/src/observation.c
@@ -34,32 +34,9 @@ int cmp_sdiff(const void *a_, const void *b_)
   return cmp_u8_u8(&(a->prn), &(b->prn));
 }
 
-/** Comparison function for `ambiguity_t` by PRN.
- * See `cmp_fn`. */
-int cmp_amb(const void *a_, const void *b_)
-{
-  const ambiguity_t *a = (const ambiguity_t *)a_;
-  const ambiguity_t *b = (const ambiguity_t *)b_;
-  return cmp_u8_u8(&(a->prn), &(b->prn));
-}
-
-int cmp_amb_sdiff(const void *a_, const void *b_)
-{
-  const ambiguity_t *a = (const ambiguity_t *)a_;
-  const sdiff_t *b = (const sdiff_t *)b_;
-  return cmp_u8_u8(&(a->prn), &(b->prn));
-}
-
 int cmp_sdiff_prn(const void *a_, const void *b_)
 {
   const sdiff_t *a = (const sdiff_t *)a_;
-  const u8 *b = (const u8 *)b_;
-  return cmp_u8_u8(&(a->prn), b);
-}
-
-int cmp_amb_prn(const void *a_, const void *b_)
-{
-  const ambiguity_t *a = (const ambiguity_t *)a_;
   const u8 *b = (const u8 *)b_;
   return cmp_u8_u8(&(a->prn), b);
 }
@@ -309,7 +286,7 @@ u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
  *                                   (length of non_ref_prns).
  * \param num_sdiffs                 The number of sdiffs being passed in.
  * \param sdiffs                     The sdiffs to pull measurements out of.
- * \param dd_meas  The output vector of DD measurements
+ * \param dd_meas                    The output vector of DD measurements
  *                                   to be used to update the IAR.
  * \param sdiffs_out                 The sdiffs that correspond to the IAR PRNs.
  *                                   Should have length = num_dds+1.

--- a/src/printing_utils.c
+++ b/src/printing_utils.c
@@ -96,23 +96,6 @@ void print_s32_mtx(s32 *mat, u32 m, u32 n)
   printf("\n");
 }
 
-/** Prints a s64 valued matrix.
- *
- * \param m     The number of rows to be printed in the matrices.
- * \param n     The number of columns in the matrix.
- * \param mat1  The matrix to be printed.
- */
-static void print_s64_mtx(s64 *mat, u32 m, u32 n)
-{
-  for (u32 i=0; i < m; i++) {
-    for (u32 j=0; j < n; j++) {
-      printf("%"PRId64", ", mat[i*n + j]);
-    }
-    printf("\n");
-  }
-  printf("\n");
-}
-
 /** Prints the result of a matrix-vector product of s32's.
  * Given a matrix M and vector v of s32's, prints the result of M*v.
  *
@@ -139,51 +122,4 @@ void print_s32_gemv(u32 m, u32 n, s32 *M, s32 *v)
   }
 }
 
-
-void print_hyp(void *arg, element_t *elem)
-{
-  u8 num_dds = *( (u8 *) arg );
-
-  hypothesis_t *hyp = (hypothesis_t *)elem;
-  printf("[");
-  for (u8 i=0; i< num_dds; i++) {
-    printf("%"PRId32", ", hyp->N[i]);
-  }
-  printf("]: %f\n", hyp->ll);
-}
-
-/* Utilities for debugging inclusion algorithm in ambiguity_test.c */
-static void print_Z(s8 label, u8 full_dim, u8 new_dim, z_t * Z)
-{
-  printf("Z %i:\n", label);
-  print_s64_mtx(Z, full_dim, new_dim);
-}
-
-void print_intersection_state(intersection_count_t *x)
-{
-  u8 full_dim = x->old_dim + x->new_dim;
-
-  printf("itr lower bounds:\n");
-  for (u8 i = 0; i < x->new_dim; i++) {
-    printf("%"PRIi64"\n", x->itr_lower_bounds[i]);
-  }
-  printf("itr upper bounds:\n");
-  for (u8 i = 0; i < x->new_dim; i++) {
-    printf("%"PRIi64"\n", x->itr_upper_bounds[i]);
-  }
-  printf("box lower bounds:\n");
-  for (u8 i = 0; i < full_dim; i++) {
-    printf("%"PRIi64"\n", x->box_lower_bounds[i]);
-  }
-  printf("box upper bounds:\n");
-  for (u8 i = 0; i < full_dim; i++) {
-    printf("%"PRIi64"\n", x->box_upper_bounds[i]);
-  }
-  printf("transformation matrix:\n");
-  print_Z(68, full_dim, x->new_dim, x->Z);
-  printf("z1:\n");
-  print_Z(0, full_dim, full_dim, x->Z1);
-  printf("z2_inv:\n");
-  print_Z(0, x->new_dim, x->new_dim, x->Z2_inv);
-}
 

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -19,7 +19,7 @@
 #include "sats_management.h"
 #include "linear_algebra.h"
 
-static u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats)
+u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats)
 {
   double best_snr=sats[0].snr;
   u8 best_prn=sats[0].prn;

--- a/src/set.c
+++ b/src/set.c
@@ -101,13 +101,12 @@ s32 intersection_map(u32 na, size_t sa, const void *as,
   assert(cmp != NULL);
   assert(f != NULL);
 
-  if (!is_set(na, sa, as, cmp)) {
-    return -1;
-
-  }
-  if (!is_set(nb, sb, bs, cmp)) {
-    return -2;
-  }
+  //if (!is_set(na, sa, as, cmp)) {
+  //  return -1;
+  //}
+  //if (!is_set(nb, sb, bs, cmp)) {
+  //  return -2;
+  //}
 
   u32 ia, ib, n = 0;
 
@@ -185,6 +184,73 @@ s32 intersection(u32 na, size_t sa, const void *as, void *a_out,
 
   return intersection_map(na, sa, as, nb, sb, bs,
                           cmp, &ctxt, intersection_function);
+}
+
+/** Given set and element, returns index where the element should be inserted.
+ *
+ * \param na    Number of elements in set A
+ * \param sa    Size of each element of set A
+ * \param as    Array of elements in set A
+ * \param b     Element of interest
+ * \param cmp   Pointer to a comparison function
+ *
+ * \return      Index where b belongs
+ *              (points past end of as if b is largest.)
+ */
+u32 insertion_index(u32 na, size_t sa, const void *as, void *b, cmp_fn cmp)
+{
+  u32 index;
+  for (index = 0; index < na && cmp(as + index * sa, b) < 0; index++);
+  return index;
+}
+
+/** Removes first element that isn't less than b.
+ *
+ * \param na    Number of elements in set A
+ * \param sa    Size of each element of set A
+ * \param as    Array of elements in set A
+ * \param a_out Output array
+ * \param b     Element of interest
+ * \param cmp   Pointer to a comparison function
+ *
+ * \return      Old index of removed element
+ */
+u32 remove_element(u32 na, size_t sa, const void *as, void *a_out,
+                   void *b, cmp_fn cmp)
+{
+  /* Index of first element that isn't less than b.
+   * This element will be removed. 
+   * If b is larger than all of as, the last element of as will be removed. */
+  u32 index = insertion_index(na, sa, as, b, cmp);
+
+  memcpy(a_out, as, index * sa);
+  memcpy(a_out + index * sa, as + (index + 1) * sa, (na - index - 1) * sa);
+
+  return index;
+}
+
+/** Inserts element into set.
+ *
+ * \param na    Number of elements in set A
+ * \param sa    Size of each element of set A
+ * \param as    Array of elements in set A
+ * \param a_out Output array
+ * \param b     Element of interest
+ * \param cmp   Pointer to a comparison function
+ *
+ * \return      Index of inserted element in as
+ *              (may point past end of as)
+ */
+u32 insert_element(u32 na, size_t sa, const void *as, void *a_out,
+                   void *b, cmp_fn cmp)
+{
+  u32 index = insertion_index(na, sa, as, b, cmp);
+
+  memcpy(a_out, as, index * sa);
+  memcpy(a_out + index * sa, b, sa);
+  memcpy(a_out + (index + 1) * sa, as + index * sa, (na - index) * sa);
+
+  return index;
 }
 
 /** \} */

--- a/src/set.c
+++ b/src/set.c
@@ -101,13 +101,6 @@ s32 intersection_map(u32 na, size_t sa, const void *as,
   assert(cmp != NULL);
   assert(f != NULL);
 
-  //if (!is_set(na, sa, as, cmp)) {
-  //  return -1;
-  //}
-  //if (!is_set(nb, sb, bs, cmp)) {
-  //  return -2;
-  //}
-
   u32 ia, ib, n = 0;
 
   for (ia=0, ib=0; ia<na && ib<nb; ia++, ib++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,7 +76,7 @@ else (CMAKE_CROSSCOMPILING)
     add_custom_command(
       DEPENDS test
       OUTPUT diffreport.html
-      COMMAND ../checks/run-coverage.sh
+      COMMAND "${PROJECT_SOURCE_DIR}/checks/run-coverage.sh"
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
     add_custom_target(check-coverage DEPENDS diffreport.html)

--- a/tests/check_baseline.c
+++ b/tests/check_baseline.c
@@ -7,6 +7,7 @@
 #include <baseline.h>
 
 #include "check_utils.h"
+#include "printing_utils.h"
 
 START_TEST(test_predict_carrier_obs)
 {
@@ -260,30 +261,35 @@ static void check_baseline_setup()
   sdiffs[0].sat_pos[1] = 1;
   sdiffs[0].sat_pos[2] = 0;
   sdiffs[0].carrier_phase = 1;
+  sdiffs[0].snr = 0.0;
 
   sdiffs[1].prn = 2;
   sdiffs[1].sat_pos[0] = 1;
   sdiffs[1].sat_pos[1] = 0;
   sdiffs[1].sat_pos[2] = 0;
   sdiffs[1].carrier_phase = 2;
+  sdiffs[1].snr = 0.0;
 
   sdiffs[2].prn = 3;
   sdiffs[2].sat_pos[0] = 0;
   sdiffs[2].sat_pos[1] = 1;
   sdiffs[2].sat_pos[2] = 0;
   sdiffs[2].carrier_phase = 3;
+  sdiffs[2].snr = 0.0;
 
   sdiffs[3].prn = 4;
   sdiffs[3].sat_pos[0] = 0;
   sdiffs[3].sat_pos[1] = 1;
   sdiffs[3].sat_pos[2] = 1;
   sdiffs[3].carrier_phase = 4;
+  sdiffs[3].snr = 0.0;
 
   sdiffs[4].prn = 5;
   sdiffs[4].sat_pos[0] = 0;
   sdiffs[4].sat_pos[1] = 0;
   sdiffs[4].sat_pos[2] = 1;
   sdiffs[4].carrier_phase = 5;
+  sdiffs[4].snr = 0.0;
 }
 
 /* No teardown required. */
@@ -319,9 +325,12 @@ START_TEST(test_baseline_ref_middle)
    * This should verify that the induction works. */
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {2, 1, 3, 4, 5},
+    .prns = {1, 2, 3, 4, 5},
     .ambs = {0, 0, 0, 0}
   };
+
+  double old_snr_2 = sdiffs[1].snr;
+  sdiffs[1].snr = 22;
 
   double b[3];
   u8 num_used;
@@ -334,6 +343,8 @@ START_TEST(test_baseline_ref_middle)
   fail_unless(within_epsilon(b[0], -0.622609));
   fail_unless(within_epsilon(b[1], -0.432371));
   fail_unless(within_epsilon(b[2], -0.00461595));
+
+  sdiffs[1].snr = old_snr_2;
 }
 END_TEST
 
@@ -343,9 +354,13 @@ START_TEST(test_baseline_ref_end)
    * This should verify that the loop can terminate correctly.*/
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {5, 1, 2, 3, 4},
+    .prns = {1, 2, 3, 4, 5},
     .ambs = {0, 0, 0, 0}
   };
+
+  u8 index = ambs.n;
+  double old_snr_2 = sdiffs[index].snr;
+  sdiffs[index].snr = 22;
 
   double b[3];
   u8 num_used;
@@ -358,6 +373,8 @@ START_TEST(test_baseline_ref_end)
   fail_unless(within_epsilon(b[0], -0.589178));
   fail_unless(within_epsilon(b[1], -0.35166));
   fail_unless(within_epsilon(b[2], 0.0288157));
+
+  sdiffs[index].snr = old_snr_2;
 }
 END_TEST
 

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -224,8 +224,6 @@ START_TEST(test_dgnss_baseline_1)
     false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == 1);
   fail_unless(num_used == 5);
-  printf("yep: \n");
-  print_double_mtx(b, 3, 1);
   fail_unless(within_epsilon(b[0], -0.417486));
   fail_unless(within_epsilon(b[1], -0.358386));
   fail_unless(within_epsilon(b[2],  0.271427));

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -6,6 +6,7 @@
 #include "dgnss_management.h"
 #include "ambiguity_test.h"
 #include "amb_kf.h"
+#include "printing_utils.h"
 
 extern sats_management_t sats_management;
 extern nkf_t nkf;
@@ -155,30 +156,35 @@ static void check_dgnss_baseline_setup()
   sdiffs[0].sat_pos[1] = 1;
   sdiffs[0].sat_pos[2] = 0;
   sdiffs[0].carrier_phase = 1;
+  sdiffs[0].snr = 1.0;
 
   sdiffs[1].prn = 2;
   sdiffs[1].sat_pos[0] = 1;
   sdiffs[1].sat_pos[1] = 0;
   sdiffs[1].sat_pos[2] = 0;
   sdiffs[1].carrier_phase = 2;
+  sdiffs[1].snr = 0.0;
 
   sdiffs[2].prn = 3;
   sdiffs[2].sat_pos[0] = 0;
   sdiffs[2].sat_pos[1] = 1;
   sdiffs[2].sat_pos[2] = 0;
   sdiffs[2].carrier_phase = 3;
+  sdiffs[2].snr = 0.0;
 
   sdiffs[3].prn = 4;
   sdiffs[3].sat_pos[0] = 0;
   sdiffs[3].sat_pos[1] = 1;
   sdiffs[3].sat_pos[2] = 1;
   sdiffs[3].carrier_phase = 4;
+  sdiffs[3].snr = 0.0;
 
   sdiffs[4].prn = 5;
   sdiffs[4].sat_pos[0] = 0;
   sdiffs[4].sat_pos[1] = 0;
   sdiffs[4].sat_pos[2] = 1;
   sdiffs[4].carrier_phase = 5;
+  sdiffs[4].snr = 0.0;
 }
 
 /* No teardown required. */
@@ -195,7 +201,7 @@ START_TEST(test_dgnss_baseline_1)
     .fixed_ambs = {
       .n = 4,
       .prns = {2, 1, 3, 4, 5},
-      .ambs = {0, 0, 0, 0}
+      .ambs = {0, 1, 0, 0}
     }
   };
 
@@ -218,9 +224,11 @@ START_TEST(test_dgnss_baseline_1)
     false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == 1);
   fail_unless(num_used == 5);
-  fail_unless(within_epsilon(b[0], -0.622609));
-  fail_unless(within_epsilon(b[1], -0.432371));
-  fail_unless(within_epsilon(b[2], -0.00461595));
+  printf("yep: \n");
+  print_double_mtx(b, 3, 1);
+  fail_unless(within_epsilon(b[0], -0.417486));
+  fail_unless(within_epsilon(b[1], -0.358386));
+  fail_unless(within_epsilon(b[2],  0.271427));
 
   /* No solution possible */
   s.fixed_ambs.n = 0;
@@ -229,9 +237,9 @@ START_TEST(test_dgnss_baseline_1)
     false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == -1);
   fail_unless(num_used == 5);
-  fail_unless(within_epsilon(b[0], -0.622609));
-  fail_unless(within_epsilon(b[1], -0.432371));
-  fail_unless(within_epsilon(b[2], -0.00461595));
+  fail_unless(within_epsilon(b[0], -0.417486));
+  fail_unless(within_epsilon(b[1], -0.358386));
+  fail_unless(within_epsilon(b[2],  0.271427));
 }
 END_TEST
 

--- a/tests/check_set.c
+++ b/tests/check_set.c
@@ -159,34 +159,6 @@ START_TEST(test_intersection_map_10)
 }
 END_TEST
 
-START_TEST(test_intersection_map_11)
-{
-  /* Invalid first set */
-  s32 a[] = {1, 1};
-  s32 b[] = {1, 2, 3};
-  s32 c[LEN(a)];
-
-  s32 ret = intersection_map(LEN(a), sizeof(a[0]), a,
-                             LEN(b), sizeof(b[0]), b,
-                             cmp_s32_s32, c, test_map_f);
-  fail_unless(ret == -1);
-}
-END_TEST
-
-START_TEST(test_intersection_map_12)
-{
-  /* Invalid second set */
-  s32 a[] = {1, 2, 3};
-  s32 b[] = {1, 2, 1};
-  s32 c[LEN(a)];
-
-  s32 ret = intersection_map(LEN(a), sizeof(a[0]), a,
-                             LEN(b), sizeof(b[0]), b,
-                             cmp_s32_s32, c, test_map_f);
-  fail_unless(ret == -2);
-}
-END_TEST
-
 START_TEST(test_is_prn_set)
 {
 
@@ -244,8 +216,6 @@ Suite* set_suite(void)
   tcase_add_test(tc_intersection, test_intersection_map_8);
   tcase_add_test(tc_intersection, test_intersection_map_9);
   tcase_add_test(tc_intersection, test_intersection_map_10);
-  tcase_add_test(tc_intersection, test_intersection_map_11);
-  tcase_add_test(tc_intersection, test_intersection_map_12);
   TCase *tc_set = tcase_create("Set");
   tcase_add_test(tc_set, test_is_prn_set);
   suite_add_tcase(s, tc_intersection);


### PR DESCRIPTION
This PR changes baseline_ to compute the intersection between the observation and estimated ambiguity sets, and choose a reference for double differencing based on current SNR.

It also fixes a minor problem with the pre-commit hook.