### PR TITLE
Define gnss_signal_t structure and use in place of 8-bit prns.

### DIFF
--- a/include/libswiftnav/amb_kf.h
+++ b/include/libswiftnav/amb_kf.h
@@ -70,8 +70,8 @@ void set_nkf(nkf_t *kf, double amb_drift_var, double phase_var, double code_var,
             u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double *dd_measurements, double ref_ecef[3]);
 void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
                      u8 num_sdiffs, sdiff_t *sdiffs_with_ref_first, double ref_ecef[3]);
-s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list);
-void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns);
+s32 find_index_of_signal(const u32 num_elements, const gnss_signal_t x, const gnss_signal_t *list);
+void rebase_nkf(nkf_t *kf, u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids);
 
 void nkf_state_projection(nkf_t *kf,
                                     u8 num_old_non_ref_sats,
@@ -84,11 +84,10 @@ void nkf_state_inclusion(nkf_t *kf,
                          double *estimates,
                          double int_init_var);
 
-void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns);
-void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats, u8 *old_prns, u8 *new_prns);
+void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids);
 
-void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
-void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns);
+void rebase_mean_N(double *mean, const u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids);
+void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids);
 
 double get_sos_innov(const nkf_t *kf, const double *decor_obs);
 double compute_innovation_terms(u32 state_dim, const double *h,

--- a/include/libswiftnav/ambiguity_test.h
+++ b/include/libswiftnav/ambiguity_test.h
@@ -119,8 +119,8 @@ s8 determine_sats_addition(ambiguity_test_t *amb_test,
                            z_t *Z_inv);
 // TODO(dsk) delete
 void add_sats_old(ambiguity_test_t *amb_test,
-                  u8 ref_prn,
-                  u32 num_added_dds, u8 *added_prns,
+                  gnss_signal_t ref_sid,
+                  u32 num_added_dds, gnss_signal_t *added_sids,
                   z_t *lower_bounds, z_t *upper_bounds,
                   z_t *Z_inv);
 void init_residual_matrices(residual_mtxs_t *res_mtxs, u8 num_dds, double *DE_mtx, double *obs_cov);

--- a/include/libswiftnav/baseline.h
+++ b/include/libswiftnav/baseline.h
@@ -22,12 +22,12 @@
 
 typedef struct {
   double amb;
-  u8 prn;
+  gnss_signal_t sid;
 } ambiguity_t;
 
 typedef struct {
   double ambs[MAX_CHANNELS-1];
-  u8 prns[MAX_CHANNELS];
+  gnss_signal_t sids[MAX_CHANNELS];
   u8 n;
 } ambiguities_t;
 
@@ -51,7 +51,7 @@ s8 least_squares_solve_b_external_ambs(u8 num_dds, const double *ambs,
          const double ref_ecef[3], double b[3],
          bool disable_raim, double raim_threshold);
 
-void diff_ambs(u8 ref_prn, u8 num_ambs, const ambiguity_t *amb_set,
+void diff_ambs(gnss_signal_t ref_sid, u8 num_ambs, const ambiguity_t *amb_set,
                double *dd_ambs);
 s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
              u8 num_ambs, const ambiguity_t *single_ambs,

--- a/include/libswiftnav/dgnss_management.h
+++ b/include/libswiftnav/dgnss_management.h
@@ -50,7 +50,7 @@ void dgnss_init(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3]);
 void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3],
                   bool disable_raim, double raim_threshold);
 void dgnss_rebase_ref(u8 num_sats, sdiff_t *sdiffs, double reciever_ecef[3],
-                      u8 old_prns[MAX_CHANNELS], sdiff_t *corrected_sdiffs);
+                      gnss_signal_t old_sids[MAX_CHANNELS], sdiff_t *corrected_sdiffs);
 nkf_t * get_dgnss_nkf(void);
 sats_management_t * get_sats_management(void);
 ambiguity_test_t* get_ambiguity_test(void);
@@ -86,8 +86,8 @@ double dgnss_iar_pool_ll(u8 num_ambs, double *ambs);
 double dgnss_iar_pool_prob(u8 num_ambs, double *ambs);
 u8 get_amb_kf_mean(double *ambs);
 u8 get_amb_kf_cov(double *cov);
-u8 get_amb_kf_prns(u8 *prns);
-u8 get_amb_test_prns(u8 *prns);
+u8 get_amb_kf_sids(gnss_signal_t *sids);
+u8 get_amb_test_sids(gnss_signal_t *sids);
 u8 dgnss_iar_MLE_ambs(s32 *ambs);
 
 #endif /* LIBSWIFTNAV_DGNSS_MANAGEMENT_H */

--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -14,6 +14,7 @@
 #ifndef LIBSWIFTNAV_EPHEMERIS_H
 #define LIBSWIFTNAV_EPHEMERIS_H
 
+#include "signal.h"
 #include "gpstime.h"
 #include "common.h"
 
@@ -25,7 +26,7 @@ typedef struct {
   gps_time_t toe, toc;
   u8 valid;
   u8 healthy;
-  u8 prn;
+  gnss_signal_t sid;
   u8 iode;
 } ephemeris_t;
 

--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -27,20 +27,20 @@ typedef struct {
   double sat_vel[3];
   double snr;
   u16 lock_counter;
-  u8 prn;
+  gnss_signal_t sid;
 } sdiff_t;
 
 int cmp_sdiff(const void *a_, const void *b_);
 int cmp_amb(const void *a_, const void *b_);
 int cmp_amb_sdiff(const void *a_, const void *b_);
-int cmp_sdiff_prn(const void *a_, const void *b_);
-int cmp_amb_prn(const void *a_, const void *b_);
+int cmp_sdiff_sid(const void *a_, const void *b_);
+int cmp_amb_sid(const void *a_, const void *b_);
 
 u8 single_diff(u8 n_a, navigation_measurement_t *m_a,
                u8 n_b, navigation_measurement_t *m_b,
                sdiff_t *sds);
 
-int sdiff_search_prn(const void *a, const void *b);
+int cmp_sid_sdiff(const void *a, const void *b);
 
 u8 make_propagated_sdiffs_wip(u8 n_local, navigation_measurement_t *m_local,
                               u8 n_remote, navigation_measurement_t *m_remote,
@@ -51,19 +51,19 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           ephemeris_t *es, gps_time_t t,
                           sdiff_t *sds);
 
-s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dds,
+s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids, u8 num_dds,
                                    u8 num_sdiffs, const sdiff_t *sdiffs_in,
                                    double *dd_meas, sdiff_t *sdiffs_out);
 
 u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
-                       u8 *sats_to_drop);
+                       gnss_signal_t *sats_to_drop);
 
-s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs,
+s8 copy_sdiffs_put_ref_first(const gnss_signal_t ref_sid, const u8 num_sdiffs,
                              const sdiff_t *sdiffs,
                              sdiff_t *sdiffs_with_ref_first);
 
 u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop,
-                 u8 *sats_to_drop);
+                 gnss_signal_t *sats_to_drop);
 
 void debug_sdiff(sdiff_t sd);
 void debug_sdiffs(u8 n, sdiff_t *sds);

--- a/include/libswiftnav/sats_management.h
+++ b/include/libswiftnav/sats_management.h
@@ -27,10 +27,10 @@
  */
 typedef struct {
   u8 num_sats;
-  u8 prns[MAX_CHANNELS];
+  gnss_signal_t sids[MAX_CHANNELS];
 } sats_management_t;
 
-u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats);
+gnss_signal_t choose_reference_sat(const u8 num_sats, const sdiff_t *sats);
 
 void init_sats_management(sats_management_t *sats_management,
                           const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
@@ -40,7 +40,7 @@ s8 rebase_sats_management(sats_management_t *sats_management,
                           const u8 num_sats, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_ref_sdiffs, sdiff_t *non_ref_sdiffs);
 
-void set_reference_sat_of_prns(u8 ref_prn, u8 num_sats, u8 *prns);
+void set_reference_sat_of_sids(gnss_signal_t ref_sid, u8 num_sats, gnss_signal_t *sids);
 s8 match_sdiffs_to_sats_man(sats_management_t *sats, u8 num_sdiffs, sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first);
 
 #endif /* LIBSWIFTNAV_SATS_MANAGEMENT_H */

--- a/include/libswiftnav/set.h
+++ b/include/libswiftnav/set.h
@@ -14,6 +14,7 @@
 #define LIBSWIFTNAV_SET_H
 
 #include "common.h"
+#include "signal.h"
 
 /** \addtogroup set
  * \{ */
@@ -32,11 +33,10 @@ typedef int (*cmp_fn) (const void* a, const void* b);
 
 /** \} */
 
-int cmp_u8_u8(const void * a, const void * b);
 int cmp_s32_s32(const void * a, const void * b);
 
 bool is_set(u8 n, size_t sz, const void *set, cmp_fn cmp);
-bool is_prn_set(u8 len, const u8 *prns);
+bool is_sid_set(u8 len, const gnss_signal_t *sids);
 
 s32 intersection_map(u32 na, size_t sa, const void *as,
                      u32 nb, size_t sb, const void *bs,

--- a/include/libswiftnav/signal.h
+++ b/include/libswiftnav/signal.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015 Swift Navigation Inc.
+ * Contact: Vlad Ungureanu <vvu@vdev.ro>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef LIBSWIFTNAV_SIGNAL_H
+#define LIBSWIFTNAV_SIGNAL_H
+
+#include "common.h"
+
+#define GPS_L1_SATS 32
+#define WAAS_SATS 3
+#define EGNOS_SATS 3
+#define GAGAN_SATS 2
+#define MSAS_SATS 2
+#define SDCM_SATS 2
+#define SBAS_SATS (WAAS_SATS + EGNOS_SATS + GAGAN_SATS + MSAS_SATS + SDCM_SATS)
+#define ALL_SATS (GPS_L1_SATS + SBAS_SATS)
+
+#define CONSTELLATION_GPS 0
+#define CONSTELLATION_SBAS 1
+
+#define BAND_L1 0
+
+typedef struct __attribute__((packed)) {
+  u16 sat;
+  u8 band;
+  u8 constellation;
+} gnss_signal_t;
+
+static inline int sid_compare(const gnss_signal_t a, const gnss_signal_t b)
+{
+  s32 x;
+  if ((x = a.constellation - b.constellation))
+    return x;
+  if ((x = a.band - b.band))
+    return x;
+  return a.sat - b.sat;
+}
+
+static inline int cmp_sid_sid(const void *a, const void *b)
+{
+  return sid_compare(*(gnss_signal_t *)a, *(gnss_signal_t*)b);
+}
+
+static inline bool sid_is_equal(const gnss_signal_t a, const gnss_signal_t b)
+{
+  return sid_compare(a, b) == 0;
+}
+
+#endif /* LIBSWIFTNAV_SIGNAL_H */
+

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -15,6 +15,7 @@
 
 #include "common.h"
 #include "ephemeris.h"
+#include "signal.h"
 
 /** \addtogroup track
  * \{ */
@@ -138,7 +139,7 @@ typedef struct {
  * \see calc_navigation_measurement()
  */
 typedef struct {
-  u8 prn;                  /**< Satellite PRN. */
+  gnss_signal_t sid;       /**< Satellite signal. */
   double code_phase_chips; /**< The code-phase in chips at `receiver_time`. */
   double code_phase_rate;  /**< Code phase rate in chips/s. */
   double carrier_phase;    /**< Carrier phase in cycles. */
@@ -167,7 +168,7 @@ typedef struct {
   double snr;
   double lock_time;
   gps_time_t tot;
-  u8 prn;
+  gnss_signal_t sid;
   u16 lock_counter;
 } navigation_measurement_t;
 

--- a/src/amb_kf.c
+++ b/src/amb_kf.c
@@ -33,6 +33,7 @@
 #include "baseline.h"
 #include "filter_utils.h"
 #include "amb_kf.h"
+#include "set.h"
 
 
 /** \defgroup amb_kf Float Ambiguity Resolution
@@ -676,10 +677,10 @@ void set_nkf_matrices(nkf_t *kf, double phase_var, double code_var,
  *  \param list the prn list to search
  *  \return index of x in list, or -1 if no element is equal to x
  */
-s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *list)
+s32 find_index_of_signal(const u32 num_elements, const gnss_signal_t x, const gnss_signal_t *list)
 {
   for (u32 i=0; i<num_elements; i++) {
-    if (x == list[i]) {
+    if (sid_is_equal(x, list[i])) {
       return i;
     }
   }
@@ -687,31 +688,31 @@ s32 find_index_of_element_in_u8s(const u32 num_elements, const u8 x, const u8 *l
 }
 
 /* REQUIRES num_sats > 1 */
-void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8 *new_prns)
+void rebase_mean_N(double *mean, const u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
 
-  u8 old_ref = old_prns[0];
-  u8 new_ref = new_prns[0];
+  gnss_signal_t old_ref = old_sids[0];
+  gnss_signal_t new_ref = new_sids[0];
 
-  if (old_ref == new_ref) {
+  if (sid_is_equal(old_ref, new_ref)) {
     /* Nothing needs to be done; same basis. */
     return;
   }
 
   double new_mean[state_dim];
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  s32 index_of_new_ref_in_old = find_index_of_signal(num_sats-1, new_ref, &old_sids[1]);
   assert(index_of_new_ref_in_old != -1);
 
   double val_for_new_ref_in_old_basis = mean[index_of_new_ref_in_old];
   for (u8 i=0; i<state_dim; i++) {
-    u8 new_prn = new_prns[1+i];
-    if (new_prn == old_ref) {
+    gnss_signal_t new_prn = new_sids[1+i];
+    if (sid_is_equal(new_prn, old_ref)) {
       new_mean[i] = - val_for_new_ref_in_old_basis;
     }
     else {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prn, &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_signal(num_sats-1, new_prn, &old_sids[1]);
       assert(index_of_this_sat_in_old_basis != -1);
       new_mean[i] = mean[index_of_this_sat_in_old_basis] - val_for_new_ref_in_old_basis;
     }
@@ -720,31 +721,31 @@ void rebase_mean_N(double *mean, const u8 num_sats, const u8 *old_prns, const u8
 }
 
 /* REQUIRES num_sats > 1 */
-static void assign_state_rebase_mtx(const u8 num_sats, const u8 *old_prns,
-                                    const u8 *new_prns, double *rebase_mtx)
+static void assign_state_rebase_mtx(const u8 num_sats, const gnss_signal_t *old_sids,
+                                    const gnss_signal_t *new_sids, double *rebase_mtx)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
 
   memset(rebase_mtx, 0, state_dim * state_dim * sizeof(double));
-  u8 old_ref = old_prns[0];
-  u8 new_ref = new_prns[0];
+  gnss_signal_t old_ref = old_sids[0];
+  gnss_signal_t new_ref = new_sids[0];
 
-  if (old_ref == new_ref) {
+  if (sid_is_equal(old_ref, new_ref)) {
     /* No rebase needs to occur, return identity. */
     matrix_eye(state_dim, rebase_mtx);
     return;
   }
 
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  s32 index_of_new_ref_in_old = find_index_of_signal(num_sats-1, new_ref, &old_sids[1]);
   assert(index_of_new_ref_in_old != -1);
-  s32 index_of_old_ref_in_new = find_index_of_element_in_u8s(num_sats-1, old_ref, &new_prns[1]);
+  s32 index_of_old_ref_in_new = find_index_of_signal(num_sats-1, old_ref, &new_sids[1]);
   assert(index_of_old_ref_in_new != -1);
 
   for (u8 i=0; i<state_dim; i++) {
     rebase_mtx[i*state_dim + index_of_new_ref_in_old] = -1;
     if (i != (u8) index_of_old_ref_in_new) {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prns[i+1], &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_signal(num_sats-1, new_sids[i+1], &old_sids[1]);
       assert(index_of_this_sat_in_old_basis != -1);
       rebase_mtx[i*state_dim + index_of_this_sat_in_old_basis] = 1;
     }
@@ -752,13 +753,13 @@ static void assign_state_rebase_mtx(const u8 num_sats, const u8 *old_prns,
 }
 
 /* REQUIRES num_sats > 1 */
-void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old_prns, const u8 *new_prns)
+void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
 
   double rebase_mtx[state_dim * state_dim];
-  assign_state_rebase_mtx(num_sats, old_prns, new_prns, rebase_mtx);
+  assign_state_rebase_mtx(num_sats, old_sids, new_sids, rebase_mtx);
 
   double intermediate_cov[state_dim * state_dim];
   /* TODO make more efficient via structure of rebase_mtx. */
@@ -777,24 +778,24 @@ void rebase_covariance_sigma(double *state_cov, const u8 num_sats, const u8 *old
 }
 
 /* REQUIRES num_sats > 1 */
-void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats, u8 *old_prns, u8 *new_prns)
+void rebase_covariance_udu(double *state_cov_U, double *state_cov_D, u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids)
 {
   assert(num_sats > 1);
   u8 state_dim = num_sats - 1;
 
   double state_cov[state_dim * state_dim];
   matrix_reconstruct_udu(state_dim, state_cov_U, state_cov_D, state_cov);
-  rebase_covariance_sigma(state_cov, num_sats, old_prns, new_prns);
+  rebase_covariance_sigma(state_cov, num_sats, old_sids, new_sids);
   matrix_udu(state_dim, state_cov, state_cov_U, state_cov_D);
 }
 
 
 /* REQUIRES num_sats > 1 */
-void rebase_nkf(nkf_t *kf, u8 num_sats, u8 *old_prns, u8 *new_prns)
+void rebase_nkf(nkf_t *kf, u8 num_sats, const gnss_signal_t *old_sids, const gnss_signal_t *new_sids)
 {
   assert(num_sats > 1);
-  rebase_mean_N(kf->state_mean, num_sats, old_prns, new_prns);
-  rebase_covariance_udu(kf->state_cov_U, kf->state_cov_D, num_sats, old_prns, new_prns);
+  rebase_mean_N(kf->state_mean, num_sats, old_sids, new_sids);
+  rebase_covariance_udu(kf->state_cov_U, kf->state_cov_D, num_sats, old_sids, new_sids);
 }
 
 void nkf_state_projection(nkf_t *kf,

--- a/src/ambiguity_test.c
+++ b/src/ambiguity_test.c
@@ -552,10 +552,10 @@ s8 make_ambiguity_dd_measurements_and_sdiffs(ambiguity_test_t *amb_test, u8 num_
 {
   DEBUG_ENTRY();
 
-  u8 ref_prn = amb_test->sats.prns[0];
-  u8 *non_ref_prns = &amb_test->sats.prns[1];
+  gnss_signal_t ref_sid = amb_test->sats.sids[0];
+  gnss_signal_t *non_ref_sids = &amb_test->sats.sids[1];
   u8 num_dds = CLAMP_DIFF(amb_test->sats.num_sats, 1);
-  s8 valid_sdiffs = make_dd_measurements_and_sdiffs(ref_prn, non_ref_prns,
+  s8 valid_sdiffs = make_dd_measurements_and_sdiffs(ref_sid, non_ref_sids,
                                   num_dds, num_sdiffs, sdiffs,
                                   ambiguity_dd_measurements, amb_sdiffs);
 
@@ -571,11 +571,11 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
   if (DEBUG) {
     printf("amb_test.sats.prns = {");
     for (u8 i=0; i< amb_test->sats.num_sats; i++) {
-      printf("%u, ", amb_test->sats.prns[i]);
+      printf("%u, ", amb_test->sats.sids[i].sat);
     }
     printf("}\nsdiffs[*].prn      = {");
     for (u8 i=0; i < num_sdiffs; i++) {
-      printf("%u, ", sdiffs[i].prn);
+      printf("%u, ", sdiffs[i].sid.sat);
     }
     printf("}\n");
   }
@@ -584,8 +584,8 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
     DEBUG_EXIT();
     return 0;
   }
-  const u8 *prns = amb_test->sats.prns;
-  const u8 amb_ref = amb_test->sats.prns[0];
+  const gnss_signal_t *sids = amb_test->sats.sids;
+  const gnss_signal_t amb_ref = amb_test->sats.sids[0];
   u8 j=0;
   for (u8 i = 1; i<amb_test->sats.num_sats; i++) { //TODO will not having a j condition cause le fault du seg?
     if (j >= num_sdiffs) {
@@ -593,10 +593,10 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
       DEBUG_EXIT();
       return 0;
     }
-    if (prns[i] == sdiffs[j].prn) {
+    if (sid_is_equal(sids[i], sdiffs[j].sid)) {
       j++;
     }
-    else if (amb_ref == sdiffs[j].prn) {
+    else if (sid_is_equal(amb_ref, sdiffs[j].sid)) {
       j++;
       i--;
     }
@@ -613,34 +613,34 @@ s8 sats_match(const ambiguity_test_t *amb_test, const u8 num_sdiffs, const sdiff
 
 typedef struct {
   u8 num_sats;
-  u8 old_prns[MAX_CHANNELS];
-  u8 new_prns[MAX_CHANNELS];
+  gnss_signal_t old_sids[MAX_CHANNELS];
+  gnss_signal_t new_sids[MAX_CHANNELS];
 } rebase_prns_t;
 
 static void rebase_hypothesis(void *arg, element_t *elem) //TODO make it so it doesn't have to do all these lookups every time
 {
-  rebase_prns_t *prns = (rebase_prns_t *) arg;
-  u8 num_sats = prns->num_sats;
-  u8 *old_prns = prns->old_prns;
-  u8 *new_prns = prns->new_prns;
+  rebase_prns_t *sids = (rebase_prns_t *) arg;
+  u8 num_sats = sids->num_sats;
+  gnss_signal_t *old_sids = sids->old_sids;
+  gnss_signal_t *new_sids = sids->new_sids;
 
   hypothesis_t *hypothesis = (hypothesis_t *)elem;
 
-  u8 old_ref = old_prns[0];
-  u8 new_ref = new_prns[0];
+  gnss_signal_t old_ref = old_sids[0];
+  gnss_signal_t new_ref = new_sids[0];
 
   s32 new_N[num_sats-1];
-  s32 index_of_new_ref_in_old = find_index_of_element_in_u8s(num_sats-1, new_ref, &old_prns[1]);
+  s32 index_of_new_ref_in_old = find_index_of_signal(num_sats-1, new_ref, &old_sids[1]);
   assert(index_of_new_ref_in_old != -1);
 
   s32 val_for_new_ref_in_old_basis = hypothesis->N[index_of_new_ref_in_old];
   for (u8 i=0; i<num_sats-1; i++) {
-    u8 new_prn = new_prns[1+i];
-    if (new_prn == old_ref) {
+    gnss_signal_t new_sid = new_sids[1+i];
+    if (sid_is_equal(new_sid, old_ref)) {
       new_N[i] = - val_for_new_ref_in_old_basis;
     }
     else {
-      s32 index_of_this_sat_in_old_basis = find_index_of_element_in_u8s(num_sats-1, new_prn, &old_prns[1]);
+      s32 index_of_this_sat_in_old_basis = find_index_of_signal(num_sats-1, new_sid, &old_sids[1]);
       assert(index_of_this_sat_in_old_basis != -1);
       new_N[i] = hypothesis->N[index_of_this_sat_in_old_basis] - val_for_new_ref_in_old_basis;
     }
@@ -667,8 +667,8 @@ u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, c
   DEBUG_ENTRY();
 
   u8 changed_ref = 0;
-  u8 old_prns[amb_test->sats.num_sats];
-  memcpy(old_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
+  gnss_signal_t old_sids[amb_test->sats.num_sats];
+  memcpy(old_sids, amb_test->sats.sids, amb_test->sats.num_sats * sizeof(gnss_signal_t));
 
   s8 sats_management_code = rebase_sats_management(&amb_test->sats, num_sdiffs, sdiffs, sdiffs_with_ref_first);
   if (sats_management_code != OLD_REF) {
@@ -678,13 +678,13 @@ u8 ambiguity_update_reference(ambiguity_test_t *amb_test, const u8 num_sdiffs, c
       create_ambiguity_test(amb_test);
     }
     else {
-      u8 new_prns[amb_test->sats.num_sats];
-      memcpy(new_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
+      gnss_signal_t new_sids[amb_test->sats.num_sats];
+      memcpy(new_sids, amb_test->sats.sids, amb_test->sats.num_sats * sizeof(gnss_signal_t));
 
-      rebase_prns_t prns = {.num_sats = amb_test->sats.num_sats};
-      memcpy(prns.old_prns, old_prns, amb_test->sats.num_sats * sizeof(u8));
-      memcpy(prns.new_prns, new_prns, amb_test->sats.num_sats * sizeof(u8));
-      memory_pool_map(amb_test->pool, &prns, &rebase_hypothesis);
+      rebase_prns_t sids = {.num_sats = amb_test->sats.num_sats};
+      memcpy(sids.old_sids, old_sids, amb_test->sats.num_sats * sizeof(gnss_signal_t));
+      memcpy(sids.new_sids, new_sids, amb_test->sats.num_sats * sizeof(gnss_signal_t));
+      memory_pool_map(amb_test->pool, &sids, &rebase_hypothesis);
     }
   }
 
@@ -765,10 +765,10 @@ u8 ambiguity_sat_projection(ambiguity_test_t *amb_test, const u8 num_dds_in_inte
                        &projection_aggregator);
   log_info("IAR: updates to %"PRIu32"", memory_pool_n_allocated(amb_test->pool));
   log_info("After projection, num_sats = %d", num_dds_in_intersection + 1);
-  u8 work_prns[MAX_CHANNELS];
-  memcpy(work_prns, amb_test->sats.prns, amb_test->sats.num_sats * sizeof(u8));
+  gnss_signal_t work_sids[MAX_CHANNELS];
+  memcpy(work_sids, amb_test->sats.sids, amb_test->sats.num_sats * sizeof(gnss_signal_t));
   for (u8 i=0; i<num_dds_in_intersection; i++) {
-    amb_test->sats.prns[i+1] = work_prns[dd_intersection_ndxs[i]+1];
+    amb_test->sats.sids[i+1] = work_sids[dd_intersection_ndxs[i]+1];
   }
   amb_test->sats.num_sats = num_dds_in_intersection+1;
 
@@ -877,43 +877,43 @@ static void compute_Z(u8 old_dim, u8 new_dim, const z_t *Z1, const z_t * Z2_inv,
 }
 
 /* TODO(dsk) Use submatrix for this instead? */
-static void remap_prns(ambiguity_test_t *amb_test, u8 ref_prn,
-                       u32 num_added_dds, u8 *added_prns,
+static void remap_sids(ambiguity_test_t *amb_test, gnss_signal_t ref_sid,
+                       u32 num_added_dds, gnss_signal_t *added_sids,
                        generate_hypothesis_state_t2 *s)
 {
   intersection_count_t *x = s->x;
   u8 i = 0;
   u8 j = 0;
   u8 k = 0;
-  u8 old_prns[x->old_dim];
-  memcpy(old_prns, &amb_test->sats.prns[1], x->old_dim * sizeof(u8));
+  gnss_signal_t old_sids[x->old_dim];
+  memcpy(old_sids, &amb_test->sats.sids[1], x->old_dim * sizeof(gnss_signal_t));
   while (k < x->old_dim + num_added_dds) {
-    if (j == x->new_dim || (old_prns[i] < added_prns[j] && i != x->old_dim)) {
+    if (j == x->new_dim || ((sid_compare(old_sids[i], added_sids[j]) < 0) && i != x->old_dim)) {
       s->ndxs_of_old_in_new[i] = k;
-      amb_test->sats.prns[k+1] = old_prns[i];
+      amb_test->sats.sids[k+1] = old_sids[i];
       i++;
       k++;
-    } else if (i == x->old_dim || old_prns[i] > added_prns[j]) {
+    } else if (i == x->old_dim || (sid_compare(old_sids[i], added_sids[j]) > 0)) {
       s->ndxs_of_added_in_new[j] = k;
-      amb_test->sats.prns[k+1] = added_prns[j];
+      amb_test->sats.sids[k+1] = added_sids[j];
       j++;
       k++;
     } else {
-      log_error("remap_prns: impossible condition reached.");
-      printf("old_prns = [");
+      log_error("remap_sids: impossible condition reached.");
+      printf("old_sids = [");
       for (u8 ii=0; ii < x->old_dim; ii++) {
-        printf("%d, ",old_prns[ii]);
+        printf("%d, ",old_sids[ii].sat);
       }
       printf("]\n");
-      printf("added_prns = [");
+      printf("added_sids = [");
       for (u8 jj=0; jj < x->old_dim; jj++) {
-        printf("%d, ", added_prns[jj]);
+        printf("%d, ", added_sids[jj].sat);
       }
       printf("]\n");
       break;
     }
   }
-  amb_test->sats.prns[0] = ref_prn;
+  amb_test->sats.sids[0] = ref_sid;
   amb_test->sats.num_sats = k+1;
 }
 
@@ -985,13 +985,13 @@ static void intersection_hypothesis_prod(element_t *new_, void *x_, u32 n, eleme
 }
 
 static s32 add_sats(ambiguity_test_t *amb_test,
-                    u8 ref_prn, u8 *added_prns,
+                    gnss_signal_t ref_sid, gnss_signal_t *added_sids,
                     intersection_count_t *x)
 {
   generate_hypothesis_state_t2 s;
   s.x = x;
   s.Z_new_inv = x->Z2_inv;
-  remap_prns(amb_test, ref_prn, x->new_dim, added_prns, &s);
+  remap_sids(amb_test, ref_sid, x->new_dim, added_sids, &s);
   s32 count = memory_pool_product_generator(amb_test->pool, &s, MAX_HYPOTHESES, sizeof(s),
                   &intersection_init,
                   &intersection_generate_next_hypothesis1,
@@ -1121,24 +1121,24 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
 
   u8 state_dim = float_sats->num_sats-1;
   double float_cov[state_dim * state_dim];
-  u8 float_prns[float_sats->num_sats];
+  gnss_signal_t float_sids[float_sats->num_sats];
   double N_mean[state_dim];
 
   matrix_reconstruct_udu(state_dim, float_cov_U, float_cov_D, float_cov);
-  memcpy(float_prns, float_sats->prns, float_sats->num_sats * sizeof(u8));
+  memcpy(float_sids, float_sats->sids, float_sats->num_sats * sizeof(gnss_signal_t));
   memcpy(N_mean, float_mean, (float_sats->num_sats-1) * sizeof(double));
 
-  /* After this block, float_prns will have the correct reference,
+  /* After this block, float_sids will have the correct reference,
    * as will N_cov and N_mean */
   if (amb_test->sats.num_sats >= 2 &&
-      amb_test->sats.prns[0] != float_sats->prns[0]) {
-    u8 old_prns[float_sats->num_sats];
-    memcpy(old_prns, float_sats->prns, float_sats->num_sats * sizeof(u8));
-    set_reference_sat_of_prns(amb_test->sats.prns[0], float_sats->num_sats, float_prns);
-    rebase_mean_N(N_mean, float_sats->num_sats, old_prns, float_prns);
-    rebase_covariance_sigma(float_cov, float_sats->num_sats, old_prns, float_prns);
+      !sid_is_equal(amb_test->sats.sids[0], float_sats->sids[0])) {
+    gnss_signal_t old_sids[float_sats->num_sats];
+    memcpy(old_sids, float_sats->sids, float_sats->num_sats * sizeof(gnss_signal_t));
+    set_reference_sat_of_sids(amb_test->sats.sids[0], float_sats->num_sats, float_sids);
+    rebase_mean_N(N_mean, float_sats->num_sats, old_sids, float_sids);
+    rebase_covariance_sigma(float_cov, float_sats->num_sats, old_sids, float_sids);
   }
-  u8 ref_prn = float_prns[0];
+  gnss_signal_t ref_sid = float_sids[0];
 
   double N_cov[state_dim * state_dim];
   memcpy(N_cov, float_cov, state_dim * state_dim * sizeof(double));
@@ -1150,15 +1150,16 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
   u32 ndxs_of_new_dds_in_float[MAX_CHANNELS-1];
   u8 num_old_dds = 0;
   u32 ndxs_of_old_dds_in_float[MAX_CHANNELS-1];
-  u8 new_dd_prns[MAX_CHANNELS-1];
+  gnss_signal_t new_dd_sids[MAX_CHANNELS-1];
   while (j < float_sats->num_sats) {
-    if (i < amb_test->sats.num_sats && amb_test->sats.prns[i] == float_prns[j]) {
+    if (i < amb_test->sats.num_sats &&
+        sid_is_equal(amb_test->sats.sids[i], float_sids[j])) {
       ndxs_of_old_dds_in_float[num_old_dds++] = j-1;
       i++;
       j++;
     } else { //else float_sats[j] is a new one
       ndxs_of_new_dds_in_float[num_addible_dds] = j-1;
-      new_dd_prns[num_addible_dds] = float_prns[j];
+      new_dd_sids[num_addible_dds] = float_sids[j];
       num_addible_dds++;
       j++;
     }
@@ -1253,7 +1254,7 @@ u8 ambiguity_sat_inclusion(ambiguity_test_t *amb_test, const u8 num_dds_in_inter
     if (fits == 1) {
       /* Sats should be added. The struct x contains new_dim, the correct
        * number to add, along with the matrices needed to do so . */
-      s32 num_hyps = add_sats(amb_test, ref_prn, new_dd_prns, &x);
+      s32 num_hyps = add_sats(amb_test, ref_sid, new_dd_sids, &x);
       if (num_hyps == 0) {
         return 2;
       } else {
@@ -1282,18 +1283,19 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
   u32 state_dim = float_sats->num_sats-1;
   double float_cov[state_dim * state_dim];
   matrix_reconstruct_udu(state_dim, float_cov_U, float_cov_D, float_cov);
-  u8 float_prns[float_sats->num_sats];
-  memcpy(float_prns, float_sats->prns, float_sats->num_sats * sizeof(u8));
+  gnss_signal_t float_sids[float_sats->num_sats];
+  memcpy(float_sids, float_sats->sids, float_sats->num_sats * sizeof(gnss_signal_t));
   double N_mean[float_sats->num_sats-1];
   memcpy(N_mean, float_mean, (float_sats->num_sats-1) * sizeof(double));
   /* After this block, float_prns will have the correct reference,
    * as will N_cov and N_mean */
-  if (amb_test->sats.num_sats >= 2 && amb_test->sats.prns[0] != float_sats->prns[0]) {
-    u8 old_prns[float_sats->num_sats];
-    memcpy(old_prns, float_sats->prns, float_sats->num_sats * sizeof(u8));
-    set_reference_sat_of_prns(amb_test->sats.prns[0], float_sats->num_sats, float_prns);
-    rebase_mean_N(N_mean, float_sats->num_sats, old_prns, float_prns);
-    rebase_covariance_sigma(float_cov, float_sats->num_sats, old_prns, float_prns);
+  if (amb_test->sats.num_sats >= 2 &&
+      !sid_is_equal(amb_test->sats.sids[0], float_sats->sids[0])) {
+    gnss_signal_t old_sids[float_sats->num_sats];
+    memcpy(old_sids, float_sats->sids, float_sats->num_sats * sizeof(gnss_signal_t));
+    set_reference_sat_of_sids(amb_test->sats.sids[0], float_sats->num_sats, float_sids);
+    rebase_mean_N(N_mean, float_sats->num_sats, old_sids, float_sids);
+    rebase_covariance_sigma(float_cov, float_sats->num_sats, old_sids, float_sids);
   }
   double N_cov[(float_sats->num_sats-1) * (float_sats->num_sats-1)];
   memcpy(N_cov, float_cov, state_dim * state_dim * sizeof(double)); //TODO we can just use N_cov throughout
@@ -1303,14 +1305,15 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
   u8 j = 1;
   u8 num_addible_dds = 0;
   u8 ndxs_of_new_dds_in_float[MAX_CHANNELS-1];
-  u8 new_dd_prns[MAX_CHANNELS-1];
+  gnss_signal_t new_dd_sids[MAX_CHANNELS-1];
   while (j < float_sats->num_sats) {
-    if (i < amb_test->sats.num_sats && amb_test->sats.prns[i] == float_prns[j]) {
+    if (i < amb_test->sats.num_sats &&
+        sid_is_equal(amb_test->sats.sids[i], float_sids[j])) {
       i++;
       j++;
     } else { //else float_sats[j] is a new one
       ndxs_of_new_dds_in_float[num_addible_dds] = j-1;
-      new_dd_prns[num_addible_dds] = float_prns[j];
+      new_dd_sids[num_addible_dds] = float_sids[j];
       num_addible_dds++;
       j++;
     }
@@ -1336,7 +1339,7 @@ u8 ambiguity_sat_inclusion_old(ambiguity_test_t *amb_test, u8 num_dds_in_interse
                                             lower_bounds, upper_bounds, &num_dds_to_add,
                                             Z_inv);
   if (add_any_sats == 1) {
-    add_sats_old(amb_test, float_prns[0], num_dds_to_add, new_dd_prns, lower_bounds, upper_bounds, Z_inv);
+    add_sats_old(amb_test, float_sids[0], num_dds_to_add, new_dd_sids, lower_bounds, upper_bounds, Z_inv);
     log_debug("adding sats");
     DEBUG_EXIT();
     return 1;
@@ -1537,7 +1540,7 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
   if (DEBUG) {
     printf("amb_test->sats.prns          = {");
     for (u8 i = 0; i < amb_test->sats.num_sats; i++) {
-      printf("%u, ", amb_test->sats.prns[i]);
+      printf("%u, ", amb_test->sats.sids[i].sat);
     }
     if (amb_test->sats.num_sats < 2) {
       printf("}\nsdiffs_with_ref_first not populated\n");
@@ -1545,7 +1548,7 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
     else {
       printf("}\nsdiffs_with_ref_first[*].prn = {");
       for (u8 i = 0; i < num_sdiffs; i++) {
-        printf("%u, ", sdiffs_with_ref_first[i].prn);
+        printf("%u, ", sdiffs_with_ref_first[i].sid.sat);
       }
       printf("}\n");
     }
@@ -1555,22 +1558,22 @@ u8 find_indices_of_intersection_sats(const ambiguity_test_t *amb_test, const u8 
   u8 j = 1;
   u8 k = 0;
   while (i < amb_test->sats.num_sats && j < num_sdiffs) {
-    if (amb_test->sats.prns[i] == sdiffs_with_ref_first[j].prn) {
+    if (sid_is_equal(amb_test->sats.sids[i], sdiffs_with_ref_first[j].sid)) {
       log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] == sdiffs_with_ref_first[j].prn; i,j,k++",
-                i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
+                i, j, k, amb_test->sats.sids[i], sdiffs_with_ref_first[j].sid.sat);
       intersection_ndxs[k] = i-1;
       i++;
       j++;
       k++;
     }
-    else if (amb_test->sats.prns[i] < sdiffs_with_ref_first[j].prn) {
+    else if (sid_compare(amb_test->sats.sids[i], sdiffs_with_ref_first[j].sid) < 0) {
       log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] <  sdiffs_with_ref_first[j].prn; i++",
-                i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
+                i, j, k, amb_test->sats.sids[i], sdiffs_with_ref_first[j].sid.sat);
       i++;
     }
     else {
       log_debug("(%u, \t%u, \t%u, \t%u, \t%u)\t\t\tamb_test->sats.prns[i] >  sdiffs_with_ref_first[j].prn; j++",
-                i, j, k, amb_test->sats.prns[i], sdiffs_with_ref_first[j].prn);
+                i, j, k, amb_test->sats.sids[i], sdiffs_with_ref_first[j].sid.sat);
       j++;
     }
   }
@@ -1649,8 +1652,8 @@ static s8 no_init(void *x, element_t *elem) {
   return 1;
 }
 void add_sats_old(ambiguity_test_t *amb_test,
-                  u8 ref_prn,
-                  u32 num_added_dds, u8 *added_prns,
+                  gnss_signal_t ref_sid,
+                  u32 num_added_dds, gnss_signal_t *added_sids,
                   z_t *lower_bounds, z_t *upper_bounds,
                   z_t *Z_inv)
 {
@@ -1668,35 +1671,37 @@ void add_sats_old(ambiguity_test_t *amb_test,
   u8 i = 0;
   u8 j = 0;
   u8 k = 0;
-  u8 old_prns[x0.num_old_dds];
-  memcpy(old_prns, &amb_test->sats.prns[1], x0.num_old_dds * sizeof(u8));
+  gnss_signal_t old_sids[x0.num_old_dds];
+  memcpy(old_sids, &amb_test->sats.sids[1], x0.num_old_dds * sizeof(gnss_signal_t));
   while (k < x0.num_old_dds + num_added_dds) { //TODO should this be one less, since its just DDs?
-    if (j == x0.num_added_dds || (old_prns[i] < added_prns[j] && i != x0.num_old_dds)) {
+    if (j == x0.num_added_dds ||
+        ((sid_compare(old_sids[i], added_sids[j]) < 0) && i != x0.num_old_dds)) {
       x0.ndxs_of_old_in_new[i] = k;
-      amb_test->sats.prns[k+1] = old_prns[i];
+      amb_test->sats.sids[k+1] = old_sids[i];
       i++;
       k++;
-    } else if (i == x0.num_old_dds || old_prns[i] > added_prns[j]) {
+    } else if (i == x0.num_old_dds ||
+               (sid_compare(old_sids[i], added_sids[j]) > 0)) {
       x0.ndxs_of_added_in_new[j] = k;
-      amb_test->sats.prns[k+1] = added_prns[j];
+      amb_test->sats.sids[k+1] = added_sids[j];
       j++;
       k++;
     } else {
       log_error("add_sats_old: impossible condition reached.");
       printf("old_prns = [");
       for (u8 ii=0; ii < x0.num_old_dds; ii++) {
-        printf("%d, ",old_prns[ii]);
+        printf("%d, ",old_sids[ii].sat);
       }
       printf("]\n");
-      printf("added_prns = [");
+      printf("added_sids = [");
       for (u8 jj=0; jj < x0.num_old_dds; jj++) {
-        printf("%d, ", added_prns[jj]);
+        printf("%d, ", added_sids[jj].sat);
       }
       printf("]\n");
       break;
     }
   }
-  amb_test->sats.prns[0] = ref_prn;
+  amb_test->sats.sids[0] = ref_sid;
   amb_test->sats.num_sats = k+1;
 
   if (x0.num_old_dds == 0 && memory_pool_n_allocated(amb_test->pool) == 0) {

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -64,7 +64,7 @@ void make_measurements(u8 num_double_diffs, const sdiff_t *sdiffs, double *raw_m
   DEBUG_EXIT();
 }
 
-static bool prns_match(const u8 *old_non_ref_prns, u8 num_non_ref_sdiffs,
+static bool sids_match(const gnss_signal_t *old_non_ref_sids, u16 num_non_ref_sdiffs,
                        const sdiff_t *non_ref_sdiffs)
 {
   if (sats_management.num_sats-1 != num_non_ref_sdiffs) {
@@ -73,7 +73,7 @@ static bool prns_match(const u8 *old_non_ref_prns, u8 num_non_ref_sdiffs,
   }
   for (u8 i=0; i<num_non_ref_sdiffs; i++) {
     /* iterate through the non-reference_sats, checking they match. */
-    if (old_non_ref_prns[i] != non_ref_sdiffs[i].prn) {
+    if (!sid_is_equal(old_non_ref_sids[i], non_ref_sdiffs[i].sid)) {
       return false;
     }
   }
@@ -83,17 +83,17 @@ static bool prns_match(const u8 *old_non_ref_prns, u8 num_non_ref_sdiffs,
 /** Finds the prns of the intersection between old prns and new measurements.
  * It returns the length of the intersection
  */
-static u8 dgnss_intersect_sats(u8 num_old_prns, const u8 *old_prns,
+static u8 dgnss_intersect_sats(u8 num_old_sids, const gnss_signal_t *old_sids,
                                u8 num_sdiffs, const sdiff_t *sdiffs,
                                u8 *ndx_of_intersection_in_old,
                                u8 *ndx_of_intersection_in_new)
 {
   u8 i, j, n = 0;
-  /* Loop over old_prns and sdiffs and check if a PRN is present in both. */
-  for (i=0, j=0; i<num_old_prns && j<num_sdiffs; i++, j++) {
-    if (old_prns[i] < sdiffs[j].prn)
+  /* Loop over old_sids and sdiffs and check if a PRN is present in both. */
+  for (i=0, j=0; i<num_old_sids && j<num_sdiffs; i++, j++) {
+    if (sid_compare(old_sids[i], sdiffs[j].sid) < 0)
       j--;
-    else if (old_prns[i] > sdiffs[j].prn)
+    else if (sid_compare(old_sids[i], sdiffs[j].sid) > 0)
       i--;
     else {
       ndx_of_intersection_in_old[n] = i;
@@ -132,7 +132,7 @@ void dgnss_init(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3])
   DEBUG_EXIT();
 }
 
-void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double receiver_ecef[3], u8 old_prns[MAX_CHANNELS], sdiff_t *corrected_sdiffs)
+void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double receiver_ecef[3], gnss_signal_t old_sids[MAX_CHANNELS], sdiff_t *corrected_sdiffs)
 {
   (void)receiver_ecef;
   /* all the ref sat stuff */
@@ -140,24 +140,24 @@ void dgnss_rebase_ref(u8 num_sdiffs, sdiff_t *sdiffs, double receiver_ecef[3], u
   if (sats_management_code == NEW_REF_START_OVER) {
     log_info("Unable to rebase to new ref, resetting filters and starting over");
     dgnss_init(num_sdiffs, sdiffs, receiver_ecef);
-    memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+    memcpy(old_sids, sats_management.sids, sats_management.num_sats * sizeof(gnss_signal_t));
     if (num_sdiffs >= 1) {
-      copy_sdiffs_put_ref_first(old_prns[0], num_sdiffs, sdiffs, corrected_sdiffs);
+      copy_sdiffs_put_ref_first(old_sids[0], num_sdiffs, sdiffs, corrected_sdiffs);
     }
     /*dgnss_init(num_sdiffs, sdiffs, receiver_ecef); //TODO use current baseline state*/
     return;
   }
   else if (sats_management_code == NEW_REF) {
     /* do everything related to changing the reference sat here */
-    rebase_nkf(&nkf, sats_management.num_sats, &old_prns[0], &sats_management.prns[0]);
+    rebase_nkf(&nkf, sats_management.num_sats, &old_sids[0], &sats_management.sids[0]);
   }
 }
 
 
-static void sdiffs_to_prns(u8 n, sdiff_t *sdiffs, u8 *prns)
+static void sdiffs_to_sids(u8 n, sdiff_t *sdiffs, gnss_signal_t *sids)
 {
   for (u8 i=0; i<n; i++) {
-    prns[i] = sdiffs[i].prn;
+    sids[i] = sdiffs[i].sid;
   }
 }
 
@@ -191,19 +191,19 @@ static void dgnss_update_sats(u8 num_sdiffs, double receiver_ecef[3],
   DEBUG_ENTRY();
 
   (void)dd_measurements;
-  u8 new_prns[num_sdiffs];
-  sdiffs_to_prns(num_sdiffs, sdiffs_with_ref_first, new_prns);
+  gnss_signal_t new_sids[num_sdiffs];
+  sdiffs_to_sids(num_sdiffs, sdiffs_with_ref_first, new_sids);
 
-  u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  gnss_signal_t old_sids[MAX_CHANNELS];
+  memcpy(old_sids, sats_management.sids, sats_management.num_sats * sizeof(gnss_signal_t));
 
-  if (!prns_match(&old_prns[1], num_sdiffs-1, &sdiffs_with_ref_first[1])) {
+  if (!sids_match(&old_sids[1], num_sdiffs-1, &sdiffs_with_ref_first[1])) {
     u8 ndx_of_intersection_in_old[sats_management.num_sats];
     u8 ndx_of_intersection_in_new[sats_management.num_sats];
     ndx_of_intersection_in_old[0] = 0;
     ndx_of_intersection_in_new[0] = 0;
     u8 num_intersection_sats = dgnss_intersect_sats(
-        sats_management.num_sats-1, &old_prns[1],
+        sats_management.num_sats-1, &old_sids[1],
         num_sdiffs-1, &sdiffs_with_ref_first[1],
         &ndx_of_intersection_in_old[1],
         &ndx_of_intersection_in_new[1]) + 1;
@@ -252,7 +252,7 @@ void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3],
   if (DEBUG) {
     printf("sdiff[*].prn = {");
     for (u8 i=0; i < num_sats; i++) {
-      printf("%u, ",sdiffs[i].prn);
+      printf("%u, ", sdiffs[i].sid.sat);
     }
     printf("}\n");
   }
@@ -260,7 +260,7 @@ void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3],
   if (num_sats <= 1) {
     sats_management.num_sats = num_sats;
     if (num_sats == 1) {
-      sats_management.prns[0] = sdiffs[0].prn;
+      sats_management.sids[0] = sdiffs[0].sid;
     }
     create_ambiguity_test(&ambiguity_test);
     DEBUG_EXIT();
@@ -273,12 +273,12 @@ void dgnss_update(u8 num_sats, sdiff_t *sdiffs, double receiver_ecef[3],
 
   sdiff_t sdiffs_with_ref_first[num_sats];
 
-  u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  gnss_signal_t old_sids[MAX_CHANNELS];
+  memcpy(old_sids, sats_management.sids, sats_management.num_sats * sizeof(gnss_signal_t));
 
   /* rebase globals to a new reference sat
    * (permutes sdiffs_with_ref_first accordingly) */
-  dgnss_rebase_ref(num_sats, sdiffs, receiver_ecef, old_prns, sdiffs_with_ref_first);
+  dgnss_rebase_ref(num_sats, sdiffs, receiver_ecef, old_sids, sdiffs_with_ref_first);
 
   double dd_measurements[2*(num_sats-1)];
   make_measurements(num_sats-1, sdiffs_with_ref_first, dd_measurements);
@@ -373,8 +373,8 @@ void dgnss_update_ambiguity_state(ambiguity_state_t *s)
   if (sats_management.num_sats > 1) {
     assert(sats_management.num_sats == nkf.state_dim+1);
     s->float_ambs.n = nkf.state_dim;
-    memcpy(s->float_ambs.prns, sats_management.prns,
-           (nkf.state_dim+1) * sizeof(u8));
+    memcpy(s->float_ambs.sids, sats_management.sids,
+           (nkf.state_dim+1) * sizeof(gnss_signal_t));
     memcpy(s->float_ambs.ambs, nkf.state_mean,
            nkf.state_dim * sizeof(double));
   } else {
@@ -384,9 +384,9 @@ void dgnss_update_ambiguity_state(ambiguity_state_t *s)
   /* Fixed filter */
   if (ambiguity_iar_can_solve(&ambiguity_test)) {
     s->fixed_ambs.n = ambiguity_test.amb_check.num_matching_ndxs;
-    s->fixed_ambs.prns [0] = ambiguity_test.sats.prns[0];
+    s->fixed_ambs.sids[0] = ambiguity_test.sats.sids[0];
     for (u8 i=0; i < s->fixed_ambs.n; i++) {
-      s->fixed_ambs.prns[i + 1] = ambiguity_test.sats.prns[1 +
+      s->fixed_ambs.sids[i + 1] = ambiguity_test.sats.sids[1 +
           ambiguity_test.amb_check.matching_ndxs[i]];
       s->fixed_ambs.ambs[i] = ambiguity_test.amb_check.ambs[i];
     }
@@ -457,11 +457,11 @@ void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs,
 
   sdiff_t corrected_sdiffs[num_sats];
 
-  u8 old_prns[MAX_CHANNELS];
-  memcpy(old_prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  gnss_signal_t old_sids[MAX_CHANNELS];
+  memcpy(old_sids, sats_management.sids, sats_management.num_sats * sizeof(gnss_signal_t));
   /* rebase globals to a new reference sat
    * (permutes corrected_sdiffs accordingly) */
-  dgnss_rebase_ref(num_sats, sdiffs, ref_ecef, old_prns, corrected_sdiffs);
+  dgnss_rebase_ref(num_sats, sdiffs, ref_ecef, old_sids, corrected_sdiffs);
 
   double dds[2*(num_sats-1)];
   make_measurements(num_sats-1, corrected_sdiffs, dds);
@@ -531,8 +531,8 @@ void measure_b_with_external_ambs(u8 state_dim, const double *state_mean,
 
   sdiff_t sdiffs_with_ref_first[num_sdiffs];
   /* We require the sats updating has already been done with these sdiffs */
-  u8 ref_prn = sats_management.prns[0];
-  copy_sdiffs_put_ref_first(ref_prn, num_sdiffs, sdiffs, sdiffs_with_ref_first);
+  gnss_signal_t ref_sid = sats_management.sids[0];
+  copy_sdiffs_put_ref_first(ref_sid, num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
   measure_b(state_dim, state_mean, num_sdiffs, sdiffs_with_ref_first, receiver_ecef, b);
 
@@ -546,8 +546,8 @@ void measure_amb_kf_b(u8 num_sdiffs, sdiff_t *sdiffs,
 
   sdiff_t sdiffs_with_ref_first[num_sdiffs];
   /* We require the sats updating has already been done with these sdiffs */
-  u8 ref_prn = sats_management.prns[0];
-  copy_sdiffs_put_ref_first(ref_prn, num_sdiffs, sdiffs, sdiffs_with_ref_first);
+  gnss_signal_t ref_sid = sats_management.sids[0];
+  copy_sdiffs_put_ref_first(ref_sid, num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
   measure_b( nkf.state_dim, nkf.state_mean,
       num_sdiffs, sdiffs_with_ref_first, receiver_ecef, b);
@@ -576,14 +576,14 @@ static u8 get_de_and_phase(sats_management_t *sats_man,
                            double ref_ecef[3],
                            double *de, double *phase)
 {
-  u8 ref_prn = sats_man->prns[0];
+  gnss_signal_t ref_sid = sats_man->sids[0];
   u8 num_sats = sats_man->num_sats;
   double e0[3];
   double phi0 = 0;
-  /* TODO: Detect if ref_prn is not in prns and return error? */
+  /* TODO: Detect if ref_sid is not in sids and return error? */
   u8 i;
   for (i=0; i<num_sdiffs; i++) {
-    if (sdiffs[i].prn == ref_prn) {
+    if (sid_is_equal(sdiffs[i].sid, ref_sid)) {
       e0[0] = sdiffs[i].sat_pos[0] - ref_ecef[0];
       e0[1] = sdiffs[i].sat_pos[1] - ref_ecef[1];
       e0[2] = sdiffs[i].sat_pos[2] - ref_ecef[2];
@@ -595,12 +595,12 @@ static u8 get_de_and_phase(sats_management_t *sats_man,
   i=1;
   u8 j = 0;
   while (i < num_sats) {
-    if (sdiffs[j].prn < sats_man->prns[i]) {
+    if (sid_compare(sdiffs[j].sid, sats_man->sids[i]) < 0) {
       j++;
     }
-    else if (sdiffs[j].prn > sats_man->prns[i]) {
+    else if (sid_compare(sdiffs[j].sid, sats_man->sids[i]) > 0) {
       /* This should never happen. */
-      log_warn("sdiffs should be a super set of sats_man prns");
+      log_warn("sdiffs should be a super set of sats_man sids");
       i++;
     }
     else {  /* else they match */
@@ -654,15 +654,15 @@ u8 get_amb_kf_cov(double *cov)
   return num_dds;
 }
 
-u8 get_amb_kf_prns(u8 *prns)
+u8 get_amb_kf_sids(gnss_signal_t *sids)
 {
-  memcpy(prns, sats_management.prns, sats_management.num_sats * sizeof(u8));
+  memcpy(sids, sats_management.sids, sats_management.num_sats * sizeof(gnss_signal_t));
   return sats_management.num_sats;
 }
 
-u8 get_amb_test_prns(u8 *prns)
+u8 get_amb_test_sids(gnss_signal_t *sids)
 {
-  memcpy(prns, ambiguity_test.sats.prns, ambiguity_test.sats.num_sats * sizeof(u8));
+  memcpy(sids, ambiguity_test.sats.sids, ambiguity_test.sats.num_sats * sizeof(gnss_signal_t));
   return ambiguity_test.sats.num_sats;
 }
 

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -334,7 +334,7 @@ bool ephemeris_equal(ephemeris_t *a, ephemeris_t *b)
 {
   return (a->valid == b->valid) &&
          (a->healthy == b->healthy) &&
-         (a->prn == b->prn) &&
+         sid_is_equal(a->sid, b->sid) &&
          (a->iode == b->iode) &&
          (a->tgd == b->tgd) &&
          (a->crs == b->crs) &&

--- a/src/nav_msg.c
+++ b/src/nav_msg.c
@@ -342,20 +342,20 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
   if ((prev_bit_polarity != BIT_POLARITY_UNKNOWN)
       && (prev_bit_polarity != n->bit_polarity)) {
     log_error("PRN %02d Nav phase flip - half cycle slip detected, "
-              "but not corrected", e->prn+1);
+              "but not corrected", e->sid.sat+1);
     /* TODO: declare phase ambiguity to IAR */
   }
 
   /* Complain if buffer overrun */
   if (n->overrun) {
-    log_error("PRN %02d nav_msg subframe buffer overrun!", e->prn+1);
+    log_error("PRN %02d nav_msg subframe buffer overrun!", e->sid.sat + 1);
     n->overrun = false;
   }
 
   /* Extract word 2, and the last two parity bits of word 1 */
   u32 sf_word2 = extract_word(n, 28, 32, 0);
   if (nav_parity(&sf_word2)) {
-    log_info("PRN %02d subframe parity mismatch (word 2)", e->prn+1);
+    log_info("PRN %02d subframe parity mismatch (word 2)", e->sid.sat + 1);
     n->subframe_start_index = 0;  // Mark the subframe as processed
     n->next_subframe_id = 1;      // Make sure we start again next time
     return -2;
@@ -369,7 +369,7 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
       n->frame_words[sf_id-1][w] = extract_word(n, 30*(w+2) - 2, 32, 0);    // Get the bits
       // MSBs are D29* and D30*.  LSBs are D1...D30
       if (nav_parity(&n->frame_words[sf_id-1][w])) {  // Check parity and invert bits if D30*
-        log_info("PRN %02d subframe parity mismatch (word %d)", e->prn+1, w+3);
+        log_info("PRN %02d subframe parity mismatch (word %d)", e->sid.sat + 1, w+3);
         n->next_subframe_id = 1;      // Make sure we start again next time
         n->subframe_start_index = 0;  // Mark the subframe as processed
         return -3;

--- a/src/observation.c
+++ b/src/observation.c
@@ -31,14 +31,15 @@ int cmp_sdiff(const void *a_, const void *b_)
 {
   const sdiff_t *a = (const sdiff_t *)a_;
   const sdiff_t *b = (const sdiff_t *)b_;
-  return cmp_u8_u8(&(a->prn), &(b->prn));
+
+  return sid_compare(a->sid, b->sid);
 }
 
-int cmp_sdiff_prn(const void *a_, const void *b_)
+int cmp_sdiff_sid(const void *a_, const void *b_)
 {
   const sdiff_t *a = (const sdiff_t *)a_;
-  const u8 *b = (const u8 *)b_;
-  return cmp_u8_u8(&(a->prn), b);
+  const gnss_signal_t *b = (const gnss_signal_t *)b_;
+  return sid_compare(a->sid, *b);
 }
 
 /** Create a single difference from two observations.
@@ -57,7 +58,7 @@ static void single_diff_(void *context, u32 n, const void *a, const void *b)
   const navigation_measurement_t *m_b = (const navigation_measurement_t *)b;
   sdiff_t *sds = (sdiff_t *)context;
 
-  sds[n].prn = m_a->prn;
+  sds[n].sid.sat = m_a->sid.sat;
   sds[n].pseudorange = m_a->raw_pseudorange - m_b->raw_pseudorange;
   sds[n].carrier_phase = m_a->carrier_phase - m_b->carrier_phase;
   sds[n].doppler = m_a->raw_doppler - m_b->raw_doppler;
@@ -136,9 +137,9 @@ u8 make_propagated_sdiffs_wip(u8 n_local, navigation_measurement_t *m_local,
                           nav_meas_cmp, &ctxt, make_propagated_sdiff_);
 }
 
-int sdiff_search_prn(const void *a, const void *b)
+int cmp_sid_sdiff(const void *a, const void *b)
 {
-  return (*(u8*)a - ((sdiff_t *)b)->prn);
+  return sid_compare(*(gnss_signal_t*)a, ((sdiff_t *)b)->sid);
 }
 
 /** Propagates remote measurements to a local time and makes sdiffs.
@@ -182,18 +183,18 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
 
   /* Loop over m_a and m_b and check if a PRN is present in both. */
   for (i=0, j=0; i<n_local && j<n_remote; i++, j++) {
-    if (m_local[i].prn < m_remote[j].prn)
+    if (sid_compare(m_local[i].sid, m_remote[j].sid) < 0)
       j--;
-    else if (m_local[i].prn > m_remote[j].prn)
+    else if (sid_compare(m_local[i].sid, m_remote[j].sid) > 0)
       i--;
-    else if (ephemeris_good(&es[m_local[i].prn], t)) {
+    else if (ephemeris_good(&es[m_local[i].sid.sat], t)) {
       double clock_err;
       double clock_rate_err;
       double local_sat_pos[3];
       double local_sat_vel[3];
-      calc_sat_state(&es[m_local[i].prn], t, local_sat_pos, local_sat_vel,
+      calc_sat_state(&es[m_local[i].sid.sat], t, local_sat_pos, local_sat_vel,
                      &clock_err, &clock_rate_err);
-      sds[n].prn = m_local[i].prn;
+      sds[n].sid = m_local[i].sid;
       double dx = local_sat_pos[0] - remote_pos_ecef[0];
       double dy = local_sat_pos[1] - remote_pos_ecef[1];
       double dz = local_sat_pos[2] - remote_pos_ecef[2];
@@ -252,7 +253,7 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
  * \return Number of sats with changed lock counter
  */
 u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
-                       u8 *sats_to_drop)
+                       gnss_signal_t *sats_to_drop)
 {
   assert(sds != NULL);
   assert(lock_counters != NULL);
@@ -260,11 +261,11 @@ u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
 
   u8 num_sats_to_drop = 0;
   for (u8 i = 0; i<n_sds; i++) {
-    u8 prn = sds[i].prn;
+    gnss_signal_t sid = sds[i].sid;
     u16 new_count = sds[i].lock_counter;
-    if (new_count != lock_counters[prn]) {
-      sats_to_drop[num_sats_to_drop++] = prn;
-      lock_counters[prn] = new_count;
+    if (new_count != lock_counters[sid.sat]) {
+      sats_to_drop[num_sats_to_drop++] = sid;
+      lock_counters[sid.sat] = new_count;
     }
   }
   return num_sats_to_drop;
@@ -294,7 +295,7 @@ u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
  *        -1 if they are not,
  *        -2 if non_ref_prns is not an ordered set.
  */
-s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dds,
+s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids, u8 num_dds,
                                    u8 num_sdiffs, const sdiff_t *sdiffs_in,
                                    double *dd_meas, sdiff_t *sdiffs_out)
 {
@@ -306,22 +307,22 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
   }
 
   if (DEBUG) {
-    printf("ref_prn = %u\nnon_ref_prns = {", ref_prn);
+    printf("ref_sid = %u\nnon_ref_sids = {", ref_sid.sat);
     for (u8 i=0; i < num_dds; i++) {
-      printf("%d, ", non_ref_prns[i]);
+      printf("%d, ", non_ref_sids[i].sat);
     }
     printf("}\nnum_dds = %u\nnum_sdiffs = %u\nsdiffs[*].prn = {", num_dds, num_sdiffs);
     for (u8 i=0; i < num_sdiffs; i++) {
-      printf("%d, ", sdiffs_in[i].prn);
+      printf("%d, ", sdiffs_in[i].sid.sat);
     }
     printf("}\n");
   }
 
-  if (!is_prn_set(num_dds, non_ref_prns)) {
+  if (!is_sid_set(num_dds, non_ref_sids)) {
     log_error("There is disorder in the amb_test sats.");
-    printf("amb_test sat prns = {%u, ", ref_prn);
+    printf("amb_test sat prns = {%u, ", ref_sid.sat);
     for (u8 k=0; k < num_dds; k++) {
-      printf("%u, ", non_ref_prns[k]);
+      printf("%u, ", non_ref_sids[k].sat);
     }
     printf("}\n");
     DEBUG_EXIT();
@@ -336,14 +337,14 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
   /* Go through the sdiffs, pulling out the measurements of the non-ref amb sats
    * and the reference sat. */
   while (i < num_dds) {
-    if (non_ref_prns[i] == sdiffs_in[j].prn) {
+    if (sid_is_equal(non_ref_sids[i], sdiffs_in[j].sid)) {
       /* When we find a non-ref sat, we fill in the next measurement. */
       memcpy(&sdiffs_out[i+1], &sdiffs_in[j], sizeof(sdiff_t));
       dd_meas[i] = sdiffs_in[j].carrier_phase;
       dd_meas[i+num_dds] = sdiffs_in[j].pseudorange;
       i++;
       j++;
-    } else if (ref_prn == sdiffs_in[j].prn) {
+    } else if (sid_is_equal(ref_sid, sdiffs_in[j].sid)) {
       /* when we find the ref sat, we copy it over and raise the FOUND flag */
       memcpy(&sdiffs_out[0], &sdiffs_in[j], sizeof(sdiff_t));
       ref_phase =  sdiffs_in[j].carrier_phase;
@@ -351,7 +352,7 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
       j++;
       found_ref = 1;
     }
-    else if (non_ref_prns[i] > sdiffs_in[j].prn) {
+    else if (sid_compare(non_ref_sids[i], sdiffs_in[j].sid) > 0) {
       /* If both sets are ordered, and we increase j (and possibly i), and the
        * i prn is higher than the j one, it means that the i one might be in the
        * j set for higher j, and that the current j prn isn't in the i set. */
@@ -371,7 +372,7 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
    * This case is never checked for j = num_dds as i only runs to num_dds-1. */
   /* TODO: This function could be refactored to be a lot clearer. */
   while (!found_ref && j < num_sdiffs ) {
-    if (ref_prn == sdiffs_in[j].prn) {
+    if (sid_is_equal(ref_sid, sdiffs_in[j].sid)) {
       memcpy(&sdiffs_out[0], &sdiffs_in[j], sizeof(sdiff_t));
       ref_phase =  sdiffs_in[j].carrier_phase;
       ref_pseudorange = sdiffs_in[j].pseudorange;
@@ -391,7 +392,7 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
   if (DEBUG) {
     printf("amb_sdiff_prns = {");
     for (i = 0; i < num_dds+1; i++) {
-      printf("%u, ", sdiffs_out[i].prn);
+      printf("%u, ", sdiffs_out[i].sid.sat);
     }
     printf("}\ndd_measurements = {");
     for (i=0; i < 2 * num_dds; i++) {
@@ -404,12 +405,12 @@ s8 make_dd_measurements_and_sdiffs(u8 ref_prn, const u8 *non_ref_prns, u8 num_dd
   return 0;
 }
 
-s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
+s8 copy_sdiffs_put_ref_first(const gnss_signal_t ref_sid, const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   s8 not_found = -1;
   u8 j = 1;
   for (u8 i=0; i<num_sdiffs; i++) {
-    if (sdiffs[i].prn == ref_prn) {
+    if (sid_is_equal(sdiffs[i].sid, ref_sid)) {
       memcpy(sdiffs_with_ref_first, &sdiffs[i], sizeof(sdiff_t));
       not_found = 0;
     }
@@ -424,21 +425,21 @@ s8 copy_sdiffs_put_ref_first(const u8 ref_prn, const u8 num_sdiffs, const sdiff_
   return not_found;
 }
 
-static bool contains_prn(u8 len, u8 *prns, u8 prn)
+static bool contains_sid(u8 len, gnss_signal_t *sids, gnss_signal_t sid)
 {
   for (u8 i = 0; i < len; i++) {
-    if (prns[i] == prn) {
+    if (sid_is_equal(sids[i], sid)) {
       return true;
     }
   }
   return false;
 }
 
-u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop, u8 *sats_to_drop)
+u8 filter_sdiffs(u8 num_sdiffs, sdiff_t *sdiffs, u8 num_sats_to_drop, gnss_signal_t *sats_to_drop)
 {
   u8 new_num_sdiffs = 0;
   for (u8 i = 0; i < num_sdiffs; i++) {
-    if (!contains_prn(num_sats_to_drop, sats_to_drop, sdiffs[i].prn)) {
+    if (!contains_sid(num_sats_to_drop, sats_to_drop, sdiffs[i].sid)) {
       if (new_num_sdiffs != i) {
         memcpy(&sdiffs[new_num_sdiffs], &sdiffs[i], sizeof(sdiff_t));
       }
@@ -461,7 +462,7 @@ void debug_sdiff(sdiff_t sd)
     "\tdoppler       = %f\n"
     "\tsat_pos = [%f, %f, %f]\n"
     "\tsat_vel = [%f, %f, %f]\n",
-    sd.prn, sd.snr,
+    sd.sid.sat, sd.snr,
     sd.pseudorange, sd.carrier_phase, sd.doppler,
     sd.sat_pos[0], sd.sat_pos[1], sd.sat_pos[2],
     sd.sat_vel[0], sd.sat_vel[1], sd.sat_vel[2]);

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -307,7 +307,7 @@ u16 rtcm3_encode_1002(u8 *buff, u16 id, gps_time_t t, u8 n_sat,
   for (u8 i=0; i<n_sat; i++) {
     gen_obs_gps(&nm[i], &amb, &pr, &ppr, &lock, &cnr);
 
-    setbitu(buff, bit, 6,  nm[i].prn + 1); bit += 6;
+    setbitu(buff, bit, 6, nm[i].sid.sat + 1); bit += 6;
     /* TODO: set GPS code indicator if we ever support P(Y) code measurements. */
     setbitu(buff, bit, 1,  0);    bit += 1;
     setbitu(buff, bit, 24, pr);   bit += 24;
@@ -356,7 +356,7 @@ s8 rtcm3_decode_1002(u8 *buff, u16 *id, double *tow, u8 *n_sat,
   u16 bit = 64;
   for (u8 i=0; i<*n_sat; i++) {
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    nm[i].prn = getbitu(buff, bit, 6) - 1; bit += 6;
+    nm[i].sid.sat = getbitu(buff, bit, 6) - 1; bit += 6;
 
     u8 code = getbitu(buff, bit, 1); bit += 1;
     /* TODO: When we start storing the signal/system etc. properly we can

--- a/src/sats_management.c
+++ b/src/sats_management.c
@@ -19,21 +19,21 @@
 #include "sats_management.h"
 #include "linear_algebra.h"
 
-u8 choose_reference_sat(const u8 num_sats, const sdiff_t *sats)
+gnss_signal_t choose_reference_sat(const u8 num_sats, const sdiff_t *sats)
 {
   double best_snr=sats[0].snr;
-  u8 best_prn=sats[0].prn;
+  gnss_signal_t best_sid = sats[0].sid;
   for (u8 i=1; i<num_sats; i++) {
     if (sats[i].snr > best_snr) {
       best_snr = sats[i].snr;
-      best_prn = sats[i].prn;
+      best_sid = sats[i].sid;
     }
   }
-  return best_prn;
+  return best_sid;
 }
 
 //assumes both sets are ordered
-static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats1,
+static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const gnss_signal_t *sats1,
                          const sdiff_t *sdiffs, sdiff_t *intersection_sats)
 {
   DEBUG_ENTRY();
@@ -42,28 +42,28 @@ static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats
   if(DEBUG) {
     printf("sdiff prns= {");
     for (u8 k=0; k< num_sdiffs; k++) {
-      printf("%u, ", sdiffs[k].prn);
+      printf("%u, ", sdiffs[k].sid.sat);
     }
     printf("}\n");
     printf("sats= {");
     for (u8 k=0; k< num_sats1; k++) {
-      printf("%u, ", sats1[k]);
+      printf("%u, ", sats1[k].sat);
     }
     printf("}\n");
     printf("(n, i, prn1[i],\t j, prn2[j])\n");
   }
   /* Loop over sats1 and sdffs and check if a PRN is present in both. */
   for (i=0, j=0; i<num_sats1 && j<num_sdiffs; i++, j++) {
-    if (sats1[i] < sdiffs[j].prn) {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 < prn2  i++", n, i, sats1[i], j, sdiffs[j].prn);
+    if (sid_compare(sats1[i], sdiffs[j].sid) < 0) {
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 < prn2  i++", n, i, sats1[i], j, sdiffs[j].sid.sat);
       j--;
     }
-    else if (sats1[i] > sdiffs[j].prn) {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 > prn2  j++", n, i, sats1[i], j, sdiffs[j].prn);
+    else if (sid_compare(sats1[i], sdiffs[j].sid) > 0) {
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 > prn2  j++", n, i, sats1[i], j, sdiffs[j].sid.sat);
       i--;
     }
     else {
-      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 = prn2  i,j,n++", n, i, sats1[i], j, sdiffs[j].prn);
+      log_debug("(%u, %u, prn1=%u,\t %u, prn2=%u)\t\t prn1 = prn2  i,j,n++", n, i, sats1[i], j, sdiffs[j].sid.sat);
       memcpy(&intersection_sats[n], &sdiffs[j], sizeof(sdiff_t));
       n++;
     }
@@ -71,7 +71,7 @@ static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats
   if (DEBUG) {
     printf("intersection_sats= {");
     for (u8 k=0; k< n; k++) {
-      printf("%u, ", intersection_sats[k].prn);
+      printf("%u, ", intersection_sats[k].sid.sat);
     }
     printf("}\n");
   }
@@ -84,32 +84,33 @@ static u8 intersect_sats(const u8 num_sats1, const u8 num_sdiffs, const u8 *sats
  *  Inserts the old ref prn so the tail of the array is sorted.
  */
 /* TODO use the set abstraction fnoble is working on. */
-void set_reference_sat_of_prns(const u8 ref_prn, const u8 num_sats, u8 *prns)
+void set_reference_sat_of_sids(const gnss_signal_t ref_sid, const u8 num_sats, gnss_signal_t *sids)
 {
-  u8 old_ref = prns[0];
+  gnss_signal_t old_ref = sids[0];
   u8 j;
-  if (old_ref != ref_prn) {
+  if (!sid_is_equal(old_ref, ref_sid)) {
     j = 1;
-    u8 old_prns[num_sats];
-    memcpy(old_prns, prns, num_sats * sizeof(u8));
+    gnss_signal_t old_sids[num_sats];
+    memcpy(old_sids, sids, num_sats * sizeof(gnss_signal_t));
     u8 set_old_yet = 0;
-    prns[0] = ref_prn;
+    sids[0] = ref_sid;
     for (u8 i=1; i<num_sats; i++) {
-      if (old_prns[i] != ref_prn) {
-        if (old_prns[i]>old_ref && set_old_yet == 0) {
-          prns[j] = old_ref;
+      if (!sid_is_equal(old_sids[i], ref_sid)) {
+        if ((sid_compare(old_sids[i], old_ref) > 0) &&
+            set_old_yet == 0) {
+          sids[j] = old_ref;
           j++;
           i--;
           set_old_yet++;
         }
         else {
-          prns[j] = old_prns[i];
+          sids[j] = old_sids[i];
           j++;
         }
       }
     }
     if (set_old_yet == 0) {
-      prns[j] = old_ref;
+      sids[j] = old_ref;
       set_old_yet++;
     }
     assert(set_old_yet == 1);
@@ -121,37 +122,37 @@ void set_reference_sat_of_prns(const u8 ref_prn, const u8 num_sats, u8 *prns)
  *  Inserts the old ref prn so the tail of the sats_management array is sorted.
  */
 /* TODO use the set abstraction fnoble is working on. */
-static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_management,
+static void set_reference_sat(const gnss_signal_t ref_sid, sats_management_t *sats_management,
                               const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   DEBUG_ENTRY();
 
-  u8 old_ref = sats_management->prns[0];
-  log_debug("ref_prn = %u", ref_prn);
+  gnss_signal_t old_ref = sats_management->sids[0];
+  log_debug("ref_sid = %u", ref_sid);
   log_debug("old_ref = %u", old_ref);
   u8 j;
-  if (old_ref != ref_prn) {
+  if (!sid_is_equal(old_ref, ref_sid)) {
     j = 1;
-    u8 old_prns[sats_management->num_sats];
-    memcpy(old_prns, sats_management->prns, sats_management->num_sats * sizeof(u8));
+    gnss_signal_t old_sids[sats_management->num_sats];
+    memcpy(old_sids, sats_management->sids, sats_management->num_sats * sizeof(gnss_signal_t));
     u8 set_old_yet = 0;
-    sats_management->prns[0] = ref_prn;
+    sats_management->sids[0] = ref_sid;
     for (u8 i=1; i<sats_management->num_sats; i++) {
-      if (old_prns[i] != ref_prn) {
-        if (old_prns[i]>old_ref && set_old_yet == 0) {
-          sats_management->prns[j] = old_ref;
+      if (!sid_is_equal(old_sids[i], ref_sid)) {
+        if ((sid_compare(old_sids[i], old_ref) > 0) && set_old_yet == 0) {
+          sats_management->sids[j] = old_ref;
           j++;
           i--;
           set_old_yet++;
         }
         else {
-          sats_management->prns[j] = old_prns[i];
+          sats_management->sids[j] = old_sids[i];
           j++;
         }
       }
     }
     if (set_old_yet == 0) {
-      sats_management->prns[j] = old_ref;
+      sats_management->sids[j] = old_ref;
       set_old_yet++;
     }
     assert(set_old_yet == 1);
@@ -159,12 +160,12 @@ static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_manageme
 
   j=1;
   for (u8 i=0; i<num_sdiffs; i++) {
-    if (sdiffs[i].prn != ref_prn) {
-      log_debug("prn[%u] = %u", j, sdiffs[i].prn);
+    if (!sid_is_equal(sdiffs[i].sid, ref_sid)) {
+      log_debug("prn[%u] = %u", j, sdiffs[i].sid.sat);
       memcpy(&sdiffs_with_ref_first[j], &sdiffs[i], sizeof(sdiff_t));
       j++;
     } else {
-      log_debug("prn[0] = %u", sdiffs[i].prn);
+      log_debug("prn[0] = %u", sdiffs[i].sid.sat);
       memcpy(&sdiffs_with_ref_first[0], &sdiffs[i], sizeof(sdiff_t));
     }
   }
@@ -172,15 +173,15 @@ static void set_reference_sat(const u8 ref_prn, sats_management_t *sats_manageme
   DEBUG_EXIT();
 }
 
-static void set_reference_sat_and_prns(const u8 ref_prn, sats_management_t *sats_management,
+static void set_reference_sat_and_sids(const gnss_signal_t ref_sid, sats_management_t *sats_management,
                                        const u8 num_sdiffs, const sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   sats_management->num_sats = num_sdiffs;
-  sats_management->prns[0] = ref_prn;
+  sats_management->sids[0] = ref_sid;
   u8 j=1;
   for (u8 i=0; i<num_sdiffs; i++) {
-    if (sdiffs[i].prn != ref_prn) {
-      sats_management->prns[j] = sdiffs[i].prn;
+    if (!sid_is_equal(sdiffs[i].sid, ref_sid)) {
+      sats_management->sids[j] = sdiffs[i].sid;
       if (sdiffs_with_ref_first) {
         memcpy(&sdiffs_with_ref_first[j], &sdiffs[i], sizeof(sdiff_t));
       }
@@ -204,8 +205,8 @@ void init_sats_management(sats_management_t *sats_management,
     return;
   }
 
-  u8 ref_prn = choose_reference_sat(num_sdiffs, sdiffs);
-  set_reference_sat_and_prns(ref_prn, sats_management,
+  gnss_signal_t ref_sid = choose_reference_sat(num_sdiffs, sdiffs);
+  set_reference_sat_and_sids(ref_sid, sats_management,
                              num_sdiffs, sdiffs, sdiffs_with_ref_first);
   DEBUG_EXIT();
 }
@@ -215,14 +216,14 @@ void print_sats_management(sats_management_t *sats_management)
 {
   printf("sats_management->num_sats=%u\n", sats_management->num_sats);
   for (u8 i=0; i<sats_management->num_sats; i++) {
-    printf("sats_management->prns[%u]= %u\n", i, sats_management->prns[i]);
+    printf("sats_management->prns[%u]= %u\n", i, sats_management->sids[i].sat);
   }
 }
 /** Prints all prns on one line */
 void print_sats_management_short(sats_management_t *sats_man) {
   printf("sats_management sats: ");
   for (u8 i=0; i<sats_man->num_sats; i++) {
-    printf("%d,", sats_man->prns[i]);
+    printf("%d,", sats_man->sids[i].sat);
   }
   printf("\n");
 }
@@ -236,7 +237,7 @@ s8 rebase_sats_management(sats_management_t *sats_management,
   DEBUG_ENTRY();
 
   s8 return_code;
-  u8 ref_prn;
+  gnss_signal_t ref_sid;
 
   if (sats_management->num_sats <= 1) {
     // Need to init first.
@@ -244,14 +245,14 @@ s8 rebase_sats_management(sats_management_t *sats_management,
   }
 
   // Check if old reference is in sdiffs
-  if (bsearch(&(sats_management->prns[0]), sdiffs, num_sdiffs, sizeof(sdiff_t), &sdiff_search_prn)) {
-    ref_prn = sats_management->prns[0];
+  if (bsearch(&(sats_management->sids[0]), sdiffs, num_sdiffs, sizeof(sdiff_t), cmp_sid_sdiff)) {
+    ref_sid = sats_management->sids[0];
     return_code = OLD_REF;
   }
   else {
     sdiff_t intersection_sats[num_sdiffs];
     u8 num_intersection = intersect_sats(sats_management->num_sats-1, num_sdiffs,
-                                         &(sats_management->prns[1]), sdiffs, intersection_sats);
+                                         &(sats_management->sids[1]), sdiffs, intersection_sats);
     if (num_intersection < INTERSECTION_SATS_THRESHOLD_SIZE) {
       DEBUG_EXIT();
       return NEW_REF_START_OVER;
@@ -260,25 +261,25 @@ s8 rebase_sats_management(sats_management_t *sats_management,
       if (DEBUG) {
         printf("sdiff prns= {");
         for (u8 yo_mama=0; yo_mama< num_sdiffs; yo_mama++) {
-          printf("%u, ", sdiffs[yo_mama].prn);
+          printf("%u, ", sdiffs[yo_mama].sid.sat);
         }
         printf("}\n");
         printf("sats_man_prns= {");
         for (u8 so_fetch=0; so_fetch < sats_management->num_sats; so_fetch++) {
-          printf("%u, ", sats_management->prns[so_fetch]);
+          printf("%u, ", sats_management->sids[so_fetch].sat);
         }
         printf("}\n");
         printf("num intersect_sats= %u\nintersection= {", num_intersection);
         for (u8 bork=0; bork<num_intersection; bork++) {
-          printf("%u, ", intersection_sats[bork].prn);
+          printf("%u, ", intersection_sats[bork].sid.sat);
         }
         printf("}\n");
       }
-      ref_prn = choose_reference_sat(num_intersection, intersection_sats);
+      ref_sid = choose_reference_sat(num_intersection, intersection_sats);
       return_code = NEW_REF;
     }
   }
-  set_reference_sat(ref_prn, sats_management,
+  set_reference_sat(ref_sid, sats_management,
                     num_sdiffs, sdiffs, sdiffs_with_ref_first);
 
   DEBUG_EXIT();
@@ -289,7 +290,7 @@ void update_sats_sats_management(sats_management_t *sats_management, u8 num_non_
 {
   sats_management->num_sats = num_non_ref_sdiffs + 1;
   for (u8 i=1; i<num_non_ref_sdiffs+1; i++) {
-    sats_management->prns[i] = non_ref_sdiffs[i-1].prn;
+    sats_management->sids[i] = non_ref_sdiffs[i-1].sid;
   }
 }
 
@@ -299,16 +300,16 @@ s8 match_sdiffs_to_sats_man(sats_management_t *sats, u8 num_sdiffs,
                             sdiff_t *sdiffs, sdiff_t *sdiffs_with_ref_first)
 {
   u8 j = 1;
-  u8 ref_prn = sats->prns[0];
+  gnss_signal_t ref_sid = sats->sids[0];
   for (u8 i=0; i<num_sdiffs && j<sats->num_sats; i++) {
-    if (sdiffs[i].prn == ref_prn) {
+    if (sid_is_equal(sdiffs[i].sid, ref_sid)) {
       memcpy(sdiffs_with_ref_first, &sdiffs[i], sizeof(sdiff_t));
     }
-    else if (sdiffs[i].prn == sats->prns[j]) {
+    else if (sid_is_equal(sdiffs[i].sid, sats->sids[j])) {
       memcpy(&sdiffs_with_ref_first[j], &sdiffs[i], sizeof(sdiff_t));
       j++;
     }
-    else if (sdiffs[i].prn > sats->prns[j]) {
+    else if (sid_compare(sdiffs[i].sid, sats->sids[j]) > 0) {
       return -1;
     }
   }

--- a/src/set.c
+++ b/src/set.c
@@ -26,7 +26,6 @@ int cmp_##ta##_##tb(const void * a, const void * b) \
   return (*da > *db) - (*da < *db);                 \
 }
 
-CMP_FUNCTION(u8, u8)
 CMP_FUNCTION(s32, s32)
 
 /* Tests if an array of PRNs form a sorted set with no duplicate elements.
@@ -35,9 +34,9 @@ CMP_FUNCTION(s32, s32)
  * \param prns Array of PRNs
  * \return `TRUE` if the PRNs form an ordered set, else `FALSE`
  */
-bool is_prn_set(u8 n, const u8 *prns)
+bool is_sid_set(u8 n, const gnss_signal_t *sids)
 {
-  return is_set(n, sizeof(u8), prns, cmp_u8_u8);
+  return is_set(n, sizeof(gnss_signal_t), sids, cmp_sid_sid);
 }
 
 /* Tests if an array forms a sorted set with no duplicate elements.

--- a/src/track.c
+++ b/src/track.c
@@ -756,7 +756,7 @@ void calc_navigation_measurement(u8 n_channels, channel_measurement_t meas[],
   for (u8 i=0; i<n_channels; i++) {
     meas_ptrs[i] = &meas[i];
     nav_meas_ptrs[i] = &nav_meas[i];
-    ephemerides_ptrs[i] = &ephemerides[meas[i].prn];
+    ephemerides_ptrs[i] = &ephemerides[meas[i].sid.sat];
   }
 
   calc_navigation_measurement_(n_channels, meas_ptrs, nav_meas_ptrs, nav_time, ephemerides_ptrs);
@@ -780,13 +780,13 @@ void calc_navigation_measurement_(u8 n_channels, channel_measurement_t* meas[], 
 
     nav_meas[i]->raw_doppler = meas[i]->carrier_freq;
     nav_meas[i]->snr = meas[i]->snr;
-    nav_meas[i]->prn = meas[i]->prn;
+    nav_meas[i]->sid.sat = meas[i]->sid.sat;
 
     nav_meas[i]->carrier_phase = meas[i]->carrier_phase;
     nav_meas[i]->carrier_phase += (nav_time - meas[i]->receiver_time) * meas[i]->carrier_freq;
 
     nav_meas[i]->lock_counter = meas[i]->lock_counter;
-	
+
     /* calc sat clock error */
     calc_sat_state(ephemerides[i], nav_meas[i]->tot,
                    nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
@@ -814,8 +814,8 @@ void calc_navigation_measurement_(u8 n_channels, channel_measurement_t* meas[], 
  */
 int nav_meas_cmp(const void *a, const void *b)
 {
-  return (s8)((navigation_measurement_t*)a)->prn
-       - (s8)((navigation_measurement_t*)b)->prn;
+  return sid_compare(((navigation_measurement_t*)a)->sid,
+                     ((navigation_measurement_t*)b)->sid);
 }
 
 /** Set measurement precise Doppler using time difference of carrier phase.
@@ -841,9 +841,9 @@ u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
 
   /* Loop over m_new and m_old and check if a PRN is present in both. */
   for (i=0, j=0; i<n_new && j<n_old; i++, j++) {
-    if (m_new[i].prn < m_old[j].prn)
+    if (sid_compare(m_new[i].sid, m_old[j].sid) < 0)
       j--;
-    else if (m_new[i].prn > m_old[j].prn)
+    else if (sid_compare(m_new[i].sid, m_old[j].sid) > 0)
       i--;
     else {
       /* Copy m_new to m_corrected. */

--- a/tests/check_amb_kf.c
+++ b/tests/check_amb_kf.c
@@ -298,8 +298,8 @@ START_TEST(test_kf_update)
 }
 END_TEST
 
-void assign_state_rebase_mtx(const u8 num_sats, const u8 *old_prns,
-                             const u8 *new_prns, double *rebase_mtx);
+void assign_state_rebase_mtx(const u8 num_sats, const gnss_signal_t *old_prns,
+                             const gnss_signal_t *new_prns, double *rebase_mtx);
 
 START_TEST(test_rebase_state)
 {
@@ -313,8 +313,23 @@ START_TEST(test_rebase_state)
   double m4[dim*dim];
   double id[dim*dim];
 
-  u8 prns1[] = {2,1,3,4,5,6};
-  u8 prns2[] = {5,1,2,3,4,6};
+  gnss_signal_t prns1[] = {
+    {.sat = 2},
+    {.sat = 1},
+    {.sat = 3},
+    {.sat = 4},
+    {.sat = 5},
+    {.sat = 6}
+  };
+
+  gnss_signal_t prns2[] = {
+    {.sat = 5},
+    {.sat = 1},
+    {.sat = 2},
+    {.sat = 3},
+    {.sat = 4},
+    {.sat = 6}
+  };
 
   assign_state_rebase_mtx(num_sats, prns1, prns2, m1);
   assign_state_rebase_mtx(num_sats, prns2, prns1, m2);

--- a/tests/check_ambiguity_test.c
+++ b/tests/check_ambiguity_test.c
@@ -14,19 +14,19 @@
 START_TEST(test_update_sats_same_sats)
 {
   ambiguity_test_t amb_test = {.sats = {.num_sats = 4,
-                                        .prns = {3,1,2,4}}};
-  sdiff_t sdiffs[4] = {{.prn = 1},
-                       {.prn = 2},
-                       {.prn = 3},
-                       {.prn = 4}};
+                                        {{.sat = 3},{.sat = 1},{.sat = 2},{.sat = 4}}}};
+  sdiff_t sdiffs[4] = {{.sid = {.sat = 1}},
+                       {.sid = {.sat = 2}},
+                       {.sid = {.sat = 3}},
+                       {.sid = {.sat = 4}}};
   u8 num_sdiffs = 4;
 
   ambiguity_update_sats(&amb_test, num_sdiffs, sdiffs, NULL, NULL, NULL, NULL, false);
 
-  fail_unless(amb_test.sats.prns[0] == 3);
-  fail_unless(amb_test.sats.prns[1] == 1);
-  fail_unless(amb_test.sats.prns[2] == 2);
-  fail_unless(amb_test.sats.prns[3] == 4);
+  fail_unless(amb_test.sats.sids[0].sat == 3);
+  fail_unless(amb_test.sats.sids[1].sat == 1);
+  fail_unless(amb_test.sats.sids[2].sat == 2);
+  fail_unless(amb_test.sats.sids[3].sat == 4);
 }
 END_TEST
 
@@ -35,23 +35,23 @@ START_TEST(test_bad_measurements)
 {
   ambiguity_test_t amb_test;
 
-  sdiff_t sdiffs[5] = {{.prn = 1},
-                       {.prn = 2},
-                       {.prn = 3},
-                       {.prn = 5},
-                       {.prn = 6}};
+  sdiff_t sdiffs[5] = {{.sid = {.sat = 1}},
+                       {.sid = {.sat = 2}},
+                       {.sid = {.sat = 3}},
+                       {.sid = {.sat = 5}},
+                       {.sid = {.sat = 6}}};
   u8 num_sdiffs = 5;
 
 
   sats_management_t float_sats = {.num_sats = 5,
-                                  .prns = {3, 1, 2, 5, 6}};
+                                  .sids = {{.sat = 3}, {.sat = 1}, {.sat = 2}, {.sat = 5}, {.sat = 6}}};
   double U[16];
   matrix_eye(4, U);
   double D[4] = {1, 1, 1, 1};
   double est[5] = {1, 2, 5, 6};
 
   sats_management_t amb_sats_init = {.num_sats = 5,
-                                     .prns = {3, 1, 2, 4, 5}};
+                                     .sids = {{.sat = 3}, {.sat = 1}, {.sat = 2}, {.sat = 4}, {.sat = 5}}};
   hypothesis_t hyp_init = {.N = {1,2,4,5}};
 
   create_empty_ambiguity_test(&amb_test);
@@ -62,11 +62,11 @@ START_TEST(test_bad_measurements)
    * It should have dropped PRN 4 and include PRN 6. */
   ambiguity_update_sats(&amb_test, num_sdiffs, sdiffs, &float_sats, est, U, D, false);
   fail_unless(amb_test.sats.num_sats == 5);
-  fail_unless(amb_test.sats.prns[0] == 3);
-  fail_unless(amb_test.sats.prns[1] == 1);
-  fail_unless(amb_test.sats.prns[2] == 2);
-  fail_unless(amb_test.sats.prns[3] == 5);
-  fail_unless(amb_test.sats.prns[4] == 6);
+  fail_unless(amb_test.sats.sids[0].sat == 3);
+  fail_unless(amb_test.sats.sids[1].sat == 1);
+  fail_unless(amb_test.sats.sids[2].sat == 2);
+  fail_unless(amb_test.sats.sids[3].sat == 5);
+  fail_unless(amb_test.sats.sids[4].sat == 6);
   /* Reset the amb_test to what it was before ambiguity_update_sats */
   create_empty_ambiguity_test(&amb_test);
   memcpy(&amb_test.sats, &amb_sats_init, sizeof(sats_management_t));
@@ -76,10 +76,10 @@ START_TEST(test_bad_measurements)
    * It should have dropped PRN 4 and NOT include PRN 6. */
   ambiguity_update_sats(&amb_test, num_sdiffs, sdiffs, &float_sats, est, U, D, true);
   fail_unless(amb_test.sats.num_sats == 4);
-  fail_unless(amb_test.sats.prns[0] == 3);
-  fail_unless(amb_test.sats.prns[1] == 1);
-  fail_unless(amb_test.sats.prns[2] == 2);
-  fail_unless(amb_test.sats.prns[3] == 5);
+  fail_unless(amb_test.sats.sids[0].sat == 3);
+  fail_unless(amb_test.sats.sids[1].sat == 1);
+  fail_unless(amb_test.sats.sids[2].sat == 2);
+  fail_unless(amb_test.sats.sids[3].sat == 5);
   /* And it should have dropped PRN's value from the hypothesis,
    * which should still be there and still be the only one. */
   hyp = (hypothesis_t *) amb_test.pool->allocated_nodes_head->elem;
@@ -97,15 +97,14 @@ START_TEST(test_update_sats_rebase)
   create_empty_ambiguity_test(&amb_test);
 
   amb_test.sats.num_sats = 4;
-  amb_test.sats.prns[0] = 3;
-  amb_test.sats.prns[1] = 1;
-  amb_test.sats.prns[2] = 2;
-  amb_test.sats.prns[3] = 4;
+  amb_test.sats.sids[0].sat = 3;
+  amb_test.sats.sids[1].sat = 1;
+  amb_test.sats.sids[2].sat = 2;
+  amb_test.sats.sids[3].sat = 4;
 
-  sdiff_t sdiffs[3] = {{.prn = 1, .snr = 0},
-                       {.prn = 2, .snr = 0},
-                      // {.prn = 3, .snr = 0},
-                       {.prn = 4, .snr = 1}};
+  sdiff_t sdiffs[3] = {{.sid = {.sat = 1}, .snr = 0},
+                       {.sid = {.sat = 2}, .snr = 0},
+                       {.sid = {.sat = 4}, .snr = 1}};
   u8 num_sdiffs = 3;
 
   hypothesis_t *hyp = (hypothesis_t *)memory_pool_add(amb_test.pool);
@@ -117,9 +116,9 @@ START_TEST(test_update_sats_rebase)
 
   ambiguity_update_sats(&amb_test, num_sdiffs, sdiffs, &float_sats, NULL, NULL, NULL, false);
   fail_unless(amb_test.sats.num_sats == 3);
-  fail_unless(amb_test.sats.prns[0] == 4);
-  fail_unless(amb_test.sats.prns[1] == 1);
-  fail_unless(amb_test.sats.prns[2] == 2);
+  fail_unless(amb_test.sats.sids[0].sat == 4);
+  fail_unless(amb_test.sats.sids[1].sat == 1);
+  fail_unless(amb_test.sats.sids[2].sat == 2);
   fail_unless(hyp->N[0] == -2);
   fail_unless(hyp->N[1] == -1);
 }
@@ -130,14 +129,14 @@ START_TEST(test_ambiguity_update_reference)
   srandom(1);
 
   ambiguity_test_t amb_test = {.sats = {.num_sats = 4,
-                                        .prns = {3,1,2,4}}};
+                                        .sids = {{.sat = 3},{.sat = 1},{.sat = 2},{.sat = 4}}}};
   create_empty_ambiguity_test(&amb_test);
 
   amb_test.sats.num_sats = 4;
 
-  sdiff_t sdiffs[4] = {{.prn = 1, .snr = 0},
-                       {.prn = 2, .snr = 0},
-                       {.prn = 4, .snr = 1}};
+  sdiff_t sdiffs[4] = {{.sid = {.sat = 1}, .snr = 0},
+                       {.sid = {.sat = 2}, .snr = 0},
+                       {.sid = {.sat = 4}, .snr = 1}};
   u8 num_sdiffs = 3;
 
   for (u32 i=0; i<3; i++) {
@@ -159,18 +158,18 @@ END_TEST
 START_TEST(test_sats_match)
 {
   ambiguity_test_t amb_test = {.sats = {.num_sats = 3,
-                                        .prns = {3,1,2}}};
-  sdiff_t sdiffs[4] = {{.prn = 1},
-                       {.prn = 2},
-                       {.prn = 3},
-                       {.prn = 4}};
+                                        .sids = {{.sat = 3},{.sat = 1},{.sat = 2}}}};
+  sdiff_t sdiffs[4] = {{.sid = {.sat = 1}},
+                       {.sid = {.sat = 2}},
+                       {.sid = {.sat = 3}},
+                       {.sid = {.sat = 4}}};
   u8 num_sdiffs = 4;
   fail_unless(!sats_match(&amb_test, num_sdiffs, sdiffs));
 
   num_sdiffs = 3;
   fail_unless(sats_match(&amb_test, num_sdiffs, sdiffs));
 
-  sdiffs[0].prn = 22;
+  sdiffs[0].sid.sat = 22;
   fail_unless(!sats_match(&amb_test, num_sdiffs, sdiffs));
 
 }
@@ -234,9 +233,10 @@ START_TEST(test_amb_sat_inclusion)
   matrix_copy(state_dim, state_dim, b, cov_mat);
 
   /* Take some block, factor */
-  u8 prns[dim];
+  gnss_signal_t prns[dim];
+  memset(prns, 0, sizeof(prns));
   for (u8 i = 0; i < dim+1; i++) {
-    prns[i] = i;
+    prns[i].sat = i;
   }
   double block[dim * dim];
   resize_matrix(state_dim, state_dim, dim, dim, cov_mat, block);
@@ -255,7 +255,7 @@ START_TEST(test_amb_sat_inclusion)
   sats_management_t float_sats = {
     .num_sats = dim+1,
   };
-  memcpy(float_sats.prns, prns, (dim+1) * sizeof(u8));
+  memcpy(float_sats.sids, prns, (dim+1) * sizeof(gnss_signal_t));
 
   u16 pool_size;
   u8 flag;

--- a/tests/check_baseline.c
+++ b/tests/check_baseline.c
@@ -256,35 +256,35 @@ static void check_baseline_setup()
 {
   memset(ref_ecef, 0, sizeof(ref_ecef));
 
-  sdiffs[0].prn = 1;
+  sdiffs[0].sid.sat = 1;
   sdiffs[0].sat_pos[0] = 1;
   sdiffs[0].sat_pos[1] = 1;
   sdiffs[0].sat_pos[2] = 0;
   sdiffs[0].carrier_phase = 1;
   sdiffs[0].snr = 0.0;
 
-  sdiffs[1].prn = 2;
+  sdiffs[1].sid.sat = 2;
   sdiffs[1].sat_pos[0] = 1;
   sdiffs[1].sat_pos[1] = 0;
   sdiffs[1].sat_pos[2] = 0;
   sdiffs[1].carrier_phase = 2;
   sdiffs[1].snr = 0.0;
 
-  sdiffs[2].prn = 3;
+  sdiffs[2].sid.sat = 3;
   sdiffs[2].sat_pos[0] = 0;
   sdiffs[2].sat_pos[1] = 1;
   sdiffs[2].sat_pos[2] = 0;
   sdiffs[2].carrier_phase = 3;
   sdiffs[2].snr = 0.0;
 
-  sdiffs[3].prn = 4;
+  sdiffs[3].sid.sat = 4;
   sdiffs[3].sat_pos[0] = 0;
   sdiffs[3].sat_pos[1] = 1;
   sdiffs[3].sat_pos[2] = 1;
   sdiffs[3].carrier_phase = 4;
   sdiffs[3].snr = 0.0;
 
-  sdiffs[4].prn = 5;
+  sdiffs[4].sid.sat = 5;
   sdiffs[4].sat_pos[0] = 0;
   sdiffs[4].sat_pos[1] = 0;
   sdiffs[4].sat_pos[2] = 1;
@@ -301,7 +301,7 @@ START_TEST(test_baseline_ref_first)
    * This should verify that the loop can start correctly. */
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {1, 2, 3, 4, 5},
+    .sids = {{.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
     .ambs = {0, 0, 0, 0}
   };
 
@@ -325,7 +325,7 @@ START_TEST(test_baseline_ref_middle)
    * This should verify that the induction works. */
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {1, 2, 3, 4, 5},
+    .sids = {{.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
     .ambs = {0, 0, 0, 0}
   };
 
@@ -354,7 +354,7 @@ START_TEST(test_baseline_ref_end)
    * This should verify that the loop can terminate correctly.*/
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {1, 2, 3, 4, 5},
+    .sids = {{.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
     .ambs = {0, 0, 0, 0}
   };
 
@@ -384,7 +384,7 @@ START_TEST(test_baseline_fixed_point)
    * matching the baseline. */
   ambiguities_t ambs = {
     .n = 4,
-    .prns = {5, 1, 2, 3, 4},
+    .sids = {{.sat = 5}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}},
     .ambs = {0, 0, 0, 0}
   };
 
@@ -418,7 +418,7 @@ START_TEST(test_baseline_few_sats)
 {
   ambiguities_t ambs = {
     .n = 0,
-    .prns = {5, 1, 2, 3, 4},
+    .sids = {{.sat = 5}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}},
     .ambs = {0, 0, 0, 0}
   };
 

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -15,11 +15,11 @@ extern ambiguity_test_t ambiguity_test;
 START_TEST(test_dgnss_update_ambiguity_state_1)
 {
   sats_management.num_sats = 5;
-  sats_management.prns[0] = 1;
-  sats_management.prns[1] = 2;
-  sats_management.prns[2] = 3;
-  sats_management.prns[3] = 4;
-  sats_management.prns[4] = 5;
+  sats_management.sids[0].sat = 1;
+  sats_management.sids[1].sat = 2;
+  sats_management.sids[2].sat = 3;
+  sats_management.sids[3].sat = 4;
+  sats_management.sids[4].sat = 5;
   nkf.state_dim = 4;
   nkf.state_mean[0] = 1;
   nkf.state_mean[1] = 2;
@@ -34,13 +34,13 @@ START_TEST(test_dgnss_update_ambiguity_state_1)
   ambiguity_test.amb_check.matching_ndxs[2] = 3;
   ambiguity_test.amb_check.matching_ndxs[3] = 5;
   ambiguity_test.sats.num_sats = 7;
-  ambiguity_test.sats.prns[0] = 1;
-  ambiguity_test.sats.prns[1] = 2;
-  ambiguity_test.sats.prns[2] = 3;
-  ambiguity_test.sats.prns[3] = 4;
-  ambiguity_test.sats.prns[4] = 5;
-  ambiguity_test.sats.prns[5] = 6;
-  ambiguity_test.sats.prns[6] = 7;
+  ambiguity_test.sats.sids[0].sat = 1;
+  ambiguity_test.sats.sids[1].sat = 2;
+  ambiguity_test.sats.sids[2].sat = 3;
+  ambiguity_test.sats.sids[3].sat = 4;
+  ambiguity_test.sats.sids[4].sat = 5;
+  ambiguity_test.sats.sids[5].sat = 6;
+  ambiguity_test.sats.sids[6].sat = 7;
   ambiguity_test.amb_check.ambs[0] = 20;
   ambiguity_test.amb_check.ambs[1] = 21;
   ambiguity_test.amb_check.ambs[2] = 22;
@@ -49,12 +49,12 @@ START_TEST(test_dgnss_update_ambiguity_state_1)
   ambiguity_state_t s = {
     .float_ambs = {
       .n = 4,
-      .prns = {1, 2, 3, 4, 5},
+      .sids = {{.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
       .ambs = {1, 2, 3, 4}
     },
     .fixed_ambs = {
       .n = 4,
-      .prns = {1, 2, 4, 5, 7},
+      .sids = {{.sat = 1}, {.sat = 2}, {.sat = 4}, {.sat = 5}, {.sat = 7}},
       .ambs = {20, 21, 22, 23}
     }
   };
@@ -71,11 +71,11 @@ END_TEST
 START_TEST(test_dgnss_update_ambiguity_state_2)
 {
   sats_management.num_sats = 5;
-  sats_management.prns[0] = 1;
-  sats_management.prns[1] = 2;
-  sats_management.prns[2] = 3;
-  sats_management.prns[3] = 4;
-  sats_management.prns[4] = 5;
+  sats_management.sids[0].sat = 1;
+  sats_management.sids[1].sat = 2;
+  sats_management.sids[2].sat = 3;
+  sats_management.sids[3].sat = 4;
+  sats_management.sids[4].sat = 5;
   nkf.state_dim = 4;
   nkf.state_mean[0] = 1;
   nkf.state_mean[1] = 2;
@@ -90,13 +90,13 @@ START_TEST(test_dgnss_update_ambiguity_state_2)
   ambiguity_test.amb_check.matching_ndxs[2] = 3;
   ambiguity_test.amb_check.matching_ndxs[3] = 5;
   ambiguity_test.sats.num_sats = 7;
-  ambiguity_test.sats.prns[0] = 1;
-  ambiguity_test.sats.prns[1] = 2;
-  ambiguity_test.sats.prns[2] = 3;
-  ambiguity_test.sats.prns[3] = 4;
-  ambiguity_test.sats.prns[4] = 5;
-  ambiguity_test.sats.prns[5] = 6;
-  ambiguity_test.sats.prns[6] = 7;
+  ambiguity_test.sats.sids[0].sat = 1;
+  ambiguity_test.sats.sids[1].sat = 2;
+  ambiguity_test.sats.sids[2].sat = 3;
+  ambiguity_test.sats.sids[3].sat = 4;
+  ambiguity_test.sats.sids[4].sat = 5;
+  ambiguity_test.sats.sids[5].sat = 6;
+  ambiguity_test.sats.sids[6].sat = 7;
   ambiguity_test.amb_check.ambs[0] = 20;
   ambiguity_test.amb_check.ambs[1] = 21;
   ambiguity_test.amb_check.ambs[2] = 22;
@@ -151,35 +151,35 @@ static void check_dgnss_baseline_setup()
 {
   memset(ref_ecef, 0, sizeof(ref_ecef));
 
-  sdiffs[0].prn = 1;
+  sdiffs[0].sid.sat = 1;
   sdiffs[0].sat_pos[0] = 1;
   sdiffs[0].sat_pos[1] = 1;
   sdiffs[0].sat_pos[2] = 0;
   sdiffs[0].carrier_phase = 1;
   sdiffs[0].snr = 1.0;
 
-  sdiffs[1].prn = 2;
+  sdiffs[1].sid.sat = 2;
   sdiffs[1].sat_pos[0] = 1;
   sdiffs[1].sat_pos[1] = 0;
   sdiffs[1].sat_pos[2] = 0;
   sdiffs[1].carrier_phase = 2;
   sdiffs[1].snr = 0.0;
 
-  sdiffs[2].prn = 3;
+  sdiffs[2].sid.sat = 3;
   sdiffs[2].sat_pos[0] = 0;
   sdiffs[2].sat_pos[1] = 1;
   sdiffs[2].sat_pos[2] = 0;
   sdiffs[2].carrier_phase = 3;
   sdiffs[2].snr = 0.0;
 
-  sdiffs[3].prn = 4;
+  sdiffs[3].sid.sat = 4;
   sdiffs[3].sat_pos[0] = 0;
   sdiffs[3].sat_pos[1] = 1;
   sdiffs[3].sat_pos[2] = 1;
   sdiffs[3].carrier_phase = 4;
   sdiffs[3].snr = 0.0;
 
-  sdiffs[4].prn = 5;
+  sdiffs[4].sid.sat = 5;
   sdiffs[4].sat_pos[0] = 0;
   sdiffs[4].sat_pos[1] = 0;
   sdiffs[4].sat_pos[2] = 1;
@@ -195,12 +195,12 @@ START_TEST(test_dgnss_baseline_1)
   ambiguity_state_t s = {
     .float_ambs = {
       .n = 4,
-      .prns = {1, 2, 3, 4, 5},
+      .sids = {{.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
       .ambs = {0, 0, 0, 0}
     },
     .fixed_ambs = {
       .n = 4,
-      .prns = {2, 1, 3, 4, 5},
+      .sids = {{.sat = 2}, {.sat = 1}, {.sat = 3}, {.sat = 4}, {.sat = 5}},
       .ambs = {0, 1, 0, 0}
     }
   };

--- a/tests/check_ephemeris.c
+++ b/tests/check_ephemeris.c
@@ -123,7 +123,7 @@ START_TEST(test_ephemeris_equal)
       "Ephemerides should not be equal (healthy)");
   memset(&a, 0, sizeof(a));
 
-  a.prn = 1;
+  a.sid.sat = 1;
   fail_unless(!ephemeris_equal(&a, &b),
       "Ephemerides should not be equal (prn)");
   memset(&a, 0, sizeof(a));

--- a/tests/check_observation.c
+++ b/tests/check_observation.c
@@ -4,7 +4,7 @@
 #include "observation.h"
 
 navigation_measurement_t nm1 = {
-  .prn = 1,
+  .sid = {.sat = 1},
   .raw_pseudorange = 11,
   .carrier_phase = 12,
   .raw_doppler = 13,
@@ -13,7 +13,7 @@ navigation_measurement_t nm1 = {
   .sat_vel = {4, 5, 6},
 };
 navigation_measurement_t nm1_2 = {
-  .prn = 1,
+  .sid = {.sat = 1},
   .raw_pseudorange = 111,
   .carrier_phase = 112,
   .raw_doppler = 113,
@@ -22,7 +22,7 @@ navigation_measurement_t nm1_2 = {
   .sat_vel = {10, 11, 12},
 };
 navigation_measurement_t nm2 = {
-  .prn = 2,
+  .sid = {.sat = 2},
   .raw_pseudorange = 21,
   .carrier_phase = 22,
   .raw_doppler = 23,
@@ -31,7 +31,7 @@ navigation_measurement_t nm2 = {
   .sat_vel = {4, 5, 6},
 };
 navigation_measurement_t nm2_2 = {
-  .prn = 2,
+  .sid = {.sat = 2},
   .raw_pseudorange = 221,
   .carrier_phase = 222,
   .raw_doppler = 223,
@@ -40,7 +40,7 @@ navigation_measurement_t nm2_2 = {
   .sat_vel = {16, 17, 18},
 };
 navigation_measurement_t nm3 = {
-  .prn = 3,
+  .sid = {.sat = 3},
   .raw_pseudorange = 31,
   .carrier_phase = 32,
   .raw_doppler = 33,
@@ -49,7 +49,7 @@ navigation_measurement_t nm3 = {
   .sat_vel = {4, 5, 6},
 };
 navigation_measurement_t nm4 = {
-  .prn = 4,
+  .sid = {.sat = 4},
   .raw_pseudorange = 41,
   .carrier_phase = 42,
   .raw_doppler = 43,
@@ -99,7 +99,7 @@ START_TEST(test_single_diff_2)
     u8 num_match = single_diff(2, nms1, 2, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 1);
+    fail_unless(sds_out[0].sid.sat == 1);
     fail_unless(sds_out[0].pseudorange == 0);
     fail_unless(sds_out[0].carrier_phase == 0);
     fail_unless(sds_out[0].doppler == 0);
@@ -114,7 +114,7 @@ START_TEST(test_single_diff_2)
     num_match = single_diff(2, nms1, 2, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 1);
+    fail_unless(sds_out[0].sid.sat == 1);
     fail_unless(sds_out[0].pseudorange == -100);
     fail_unless(sds_out[0].carrier_phase == -100);
     fail_unless(sds_out[0].doppler == -100);
@@ -129,7 +129,7 @@ START_TEST(test_single_diff_2)
     num_match = single_diff(1, nms1, 2, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 1);
+    fail_unless(sds_out[0].sid.sat == 1);
     fail_unless(sds_out[0].pseudorange == 100);
     fail_unless(sds_out[0].carrier_phase == 100);
     fail_unless(sds_out[0].doppler == 100);
@@ -144,7 +144,7 @@ START_TEST(test_single_diff_2)
     num_match = single_diff(2, nms1, 1, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 1);
+    fail_unless(sds_out[0].sid.sat == 1);
     fail_unless(sds_out[0].pseudorange == 0);
     fail_unless(sds_out[0].carrier_phase == 0);
     fail_unless(sds_out[0].doppler == 0);
@@ -160,7 +160,7 @@ START_TEST(test_single_diff_2)
 
     fail_unless(num_match == 2);
 
-    fail_unless(sds_out[0].prn == 1);
+    fail_unless(sds_out[0].sid.sat == 1);
     fail_unless(sds_out[0].pseudorange == 100);
     fail_unless(sds_out[0].carrier_phase == 100);
     fail_unless(sds_out[0].doppler == 100);
@@ -168,7 +168,7 @@ START_TEST(test_single_diff_2)
     fail_unless(memcmp(sds_out[0].sat_pos, nm1.sat_pos, sizeof(nm1.sat_pos)) == 0);
     fail_unless(memcmp(sds_out[0].sat_vel, nm1.sat_vel, sizeof(nm1.sat_vel)) == 0);
 
-    fail_unless(sds_out[1].prn == 2);
+    fail_unless(sds_out[1].sid.sat == 2);
     fail_unless(sds_out[1].pseudorange == -200);
     fail_unless(sds_out[1].carrier_phase == -200);
     fail_unless(sds_out[1].doppler == -200);
@@ -188,7 +188,7 @@ START_TEST(test_single_diff_3)
 
     u8 num_match = single_diff(2, nms1, 2, nms2, sds_out);
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 3);
+    fail_unless(sds_out[0].sid.sat == 3);
 
     /* Test for both with two the other way */
     nms1[0] = nm2; nms1[1] = nm3;
@@ -197,7 +197,7 @@ START_TEST(test_single_diff_3)
     num_match = single_diff(2, nms1, 2, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 3);
+    fail_unless(sds_out[0].sid.sat == 3);
 
     /* Test when one has only one */
     nms1[0] = nm2;
@@ -206,7 +206,7 @@ START_TEST(test_single_diff_3)
     num_match = single_diff(1, nms1, 2, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 2);
+    fail_unless(sds_out[0].sid.sat == 2);
 
     /* Test when the other has only one */
     nms1[0] = nm1; nms1[1] = nm2;
@@ -215,7 +215,7 @@ START_TEST(test_single_diff_3)
     num_match = single_diff(2, nms1, 1, nms2, sds_out);
 
     fail_unless(num_match == 1);
-    fail_unless(sds_out[0].prn == 2);
+    fail_unless(sds_out[0].sid.sat == 2);
 }
 END_TEST
 

--- a/tests/check_pvt.c
+++ b/tests/check_pvt.c
@@ -6,55 +6,55 @@
 #include "pvt.h"
 
 static navigation_measurement_t nm1 = {
-  .prn = 9,
+  .sid = {.sat = 9},
   .pseudorange = 23946993.888943646,
   .sat_pos = {-19477278.087422125, -7649508.9457812719, 16674633.163554827}
 };
 
 static navigation_measurement_t nm2 = {
-  .prn = 1,
+  .sid = {.sat = 1},
   .pseudorange = 22932174.156858064,
   .sat_pos = {-9680013.5408340245, -15286326.354385279, 19429449.383770257},
 };
 
 static navigation_measurement_t nm3 = {
-  .prn = 2,
+  .sid = {.sat = 2},
   .pseudorange = 24373231.648055989,
   .sat_pos = {-19858593.085281931, -3109845.8288993631, 17180320.439503901},
 };
 
 static navigation_measurement_t nm4 = {
-  .prn = 3,
+  .sid = {.sat = 3},
   .pseudorange = 24779663.252316438,
   .sat_pos = {6682497.8716542246, -14006962.389166718, 21410456.275678463},
 };
 
 static navigation_measurement_t nm5 = {
-  .prn = 4,
+  .sid = {.sat = 4},
   .pseudorange = 26948717.022331879,
   .sat_pos = {7415370.9916331079, -24974079.044485383, -3836019.0262199985},
 };
 
 static navigation_measurement_t nm6 = {
-  .prn = 5,
+  .sid = {.sat = 5},
   .pseudorange = 23327405.435463827,
   .sat_pos = {-2833466.1648670658, -22755197.793894723, 13160322.082875408},
 };
 
 static navigation_measurement_t nm7 = {
-  .prn = 6,
+  .sid = {.sat = 6},
   .pseudorange = 27371419.016328193,
   .sat_pos = {14881660.383624561, -5825253.4316490609, 21204679.68313824},
 };
 
 static navigation_measurement_t nm8 = {
-  .prn = 7,
+  .sid = {.sat = 7},
   .pseudorange = 26294221.697782904,
   .sat_pos = {12246530.477279386, -22184711.955107089, 7739084.2855069181},
 };
 
 static navigation_measurement_t nm9 = {
-  .prn = 8,
+  .sid = {.sat = 8},
   .pseudorange = 25781999.479948733,
   .sat_pos = {-25360766.249484103, -1659033.490658124, 7821492.0398916304},
 };

--- a/tests/check_rtcm3.c
+++ b/tests/check_rtcm3.c
@@ -132,7 +132,7 @@ START_TEST(test_rtcm3_encode_decode)
   seed_rng();
 
   for (u8 i=0; i<22; i++) {
-    nm[i].prn = i;
+    nm[i].sid.sat = i;
     nm[i].raw_pseudorange = frand(19e6, 21e6);
     nm[i].carrier_phase = frand(-5e5, 5e5);
     nm[i].lock_time = frand(0, 1000);
@@ -166,8 +166,8 @@ START_TEST(test_rtcm3_encode_decode)
   ret = rtcm3_decode_1002(buff, &id, &tow_out, &n_sat, nm_out, &sync);
 
   for (u8 i=0; i<22; i++) {
-    fail_unless(nm[i].prn == nm_out[i].prn, "[%d] PRNs not equal - "
-        "decoded %d, expected %d", i, nm_out[i].prn, nm[i].prn);
+    fail_unless(nm[i].sid.sat == nm_out[i].sid.sat, "[%d] PRNs not equal - "
+        "decoded %d, expected %d", i, nm_out[i].sid.sat, nm[i].sid.sat);
 
     double pr_err = nm[i].raw_pseudorange - nm_out[i].raw_pseudorange;
     fail_unless(fabs(pr_err) < 0.02, "[%d] pseudorange error > 0.04m - "

--- a/tests/check_sats_management.c
+++ b/tests/check_sats_management.c
@@ -8,18 +8,18 @@
 
 START_TEST(test_rebase_1)
 {
-  u8 prns[4] = {2,1,3,4};
-  u8 num_sats = sizeof(prns);
-  u8 new_ref = 3;
+  gnss_signal_t prns[] = {{.sat = 2},{.sat = 1},{.sat = 3},{.sat = 4}};
+  u8 num_sats = sizeof(prns)/sizeof(gnss_signal_t);
+  gnss_signal_t new_ref = {.sat = 3};
 
   sats_management_t sats_management;
   sats_management.num_sats = 4;
-  sats_management.prns[0] = 2;
-  sats_management.prns[1] = 1;
-  sats_management.prns[2] = 3;
-  sats_management.prns[3] = 4;
+  sats_management.sids[0].sat = 2;
+  sats_management.sids[1].sat = 1;
+  sats_management.sids[2].sat = 3;
+  sats_management.sids[3].sat = 4;
 
-  set_reference_sat_of_prns(new_ref, num_sats, prns);
+  set_reference_sat_of_sids(new_ref, num_sats, prns);
   /* Just check the sats_management prns update */
   set_reference_sat(new_ref, &sats_management, 0, 0, 0);
   /* TODO make a better test */

--- a/tests/check_set.c
+++ b/tests/check_set.c
@@ -163,40 +163,40 @@ START_TEST(test_is_prn_set)
 {
 
 #define TEST_IS_SET(set, result) \
-  fail_unless(is_prn_set(sizeof(set)/sizeof(set[0]), set) == result, \
-              "is_prn_set(" #set ") != " #result);
+  fail_unless(is_sid_set(sizeof(set)/sizeof(set[0]), set) == result, \
+              "is_sid_set(" #set ") != " #result);
 
   /* Normal set. */
-  u8 prns1[] = {0, 1, 2, 33, 44, 200};
+  gnss_signal_t prns1[] = {{.sat = 0}, {.sat = 1}, {.sat = 2}, {.sat = 33}, {.sat = 44}, {.sat = 200}};
   TEST_IS_SET(prns1, true);
 
   /* Empty set. */
-  fail_unless(is_prn_set(0, prns1) == true);
+  fail_unless(is_sid_set(0, prns1) == true);
 
   /* Single element set. */
-  u8 prns2[] = {22};
+  gnss_signal_t prns2[] = {{.sat = 22}};
   TEST_IS_SET(prns2, true);
 
   /* Repeated elements. */
 
-  u8 prns3[] = {22, 22};
+  gnss_signal_t prns3[] = {{.sat = 22}, {.sat = 22}};
   TEST_IS_SET(prns3, false);
 
-  u8 prns4[] = {0, 1, 2, 3, 3};
+  gnss_signal_t prns4[] = {{.sat = 0}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 3}};
   TEST_IS_SET(prns4, false);
 
-  u8 prns5[] = {1, 1, 2, 3, 4};
+  gnss_signal_t prns5[] = {{.sat = 1}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}};
   TEST_IS_SET(prns5, false);
 
   /* Incorrectly sorted. */
 
-  u8 prns6[] = {22, 1, 2, 3, 4};
+  gnss_signal_t prns6[] = {{.sat = 22}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 4}};
   TEST_IS_SET(prns6, false);
 
-  u8 prns7[] = {0, 1, 2, 3, 1};
+  gnss_signal_t prns7[] = {{.sat = 0}, {.sat = 1}, {.sat = 2}, {.sat = 3}, {.sat = 1}};
   TEST_IS_SET(prns7, false);
 
-  u8 prns8[] = {0, 1, 22, 3, 4};
+  gnss_signal_t prns8[] = {{.sat = 0}, {.sat = 1}, {.sat = 22}, {.sat = 3}, {.sat = 4}};
   TEST_IS_SET(prns8, false);
 }
 END_TEST


### PR DESCRIPTION
Replaces #208.

This defines a general signal structure `signal_t` with fields to represent constellation, band and satellite PRN.  The use of u8s everywhere to represent GPS PRNs is replaced with the new structure.  Comparison functions for `qsort` and `bsearch` are updated to use the new structure.  A function is added to test equality of signals.

/cc @jacobmcnamee 
