### PR TITLE
remove indexing by PRN

### DIFF
--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -48,14 +48,14 @@ u8 make_propagated_sdiffs_wip(u8 n_local, navigation_measurement_t *m_local,
 u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           u8 n_remote, navigation_measurement_t *m_remote,
                           double *remote_dists, double remote_pos_ecef[3],
-                          ephemeris_t *es, gps_time_t t,
+                          const ephemeris_t *e[], gps_time_t t,
                           sdiff_t *sds);
 
 s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids, u8 num_dds,
                                    u8 num_sdiffs, const sdiff_t *sdiffs_in,
                                    double *dd_meas, sdiff_t *sdiffs_out);
 
-u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters,
+u8 check_lock_counters(u8 n_sds, const sdiff_t *sds, u16 *lock_counters[],
                        gnss_signal_t *sats_to_drop);
 
 s8 copy_sdiffs_put_ref_first(const gnss_signal_t ref_sid, const u8 num_sdiffs,

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -233,10 +233,7 @@ float cn0_est(cn0_est_state_t *s, float I, float Q);
 
 void calc_navigation_measurement(u8 n_channels, channel_measurement_t meas[],
                                  navigation_measurement_t nav_meas[],
-                                 double nav_time, ephemeris_t ephemerides[]);
-void calc_navigation_measurement_(u8 n_channels, channel_measurement_t* meas[],
-                                  navigation_measurement_t* nav_meas[],
-                                  double nav_time, ephemeris_t* ephemerides[]);
+                                 double nav_time, const ephemeris_t* e[]);
 
 int nav_meas_cmp(const void *a, const void *b);
 u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,

--- a/src/track.c
+++ b/src/track.c
@@ -746,50 +746,35 @@ float cn0_est(cn0_est_state_t *s, float I, float Q)
 }
 
 void calc_navigation_measurement(u8 n_channels, channel_measurement_t meas[],
-                                 navigation_measurement_t nav_meas[], double nav_time,
-                                 ephemeris_t ephemerides[])
-{
-  channel_measurement_t* meas_ptrs[n_channels];
-  navigation_measurement_t* nav_meas_ptrs[n_channels];
-  ephemeris_t* ephemerides_ptrs[n_channels];
-
-  for (u8 i=0; i<n_channels; i++) {
-    meas_ptrs[i] = &meas[i];
-    nav_meas_ptrs[i] = &nav_meas[i];
-    ephemerides_ptrs[i] = &ephemerides[meas[i].sid.sat];
-  }
-
-  calc_navigation_measurement_(n_channels, meas_ptrs, nav_meas_ptrs, nav_time, ephemerides_ptrs);
-}
-
-void calc_navigation_measurement_(u8 n_channels, channel_measurement_t* meas[], navigation_measurement_t* nav_meas[], double nav_time, ephemeris_t* ephemerides[])
+                                 navigation_measurement_t nav_meas[],
+                                 double nav_time, const ephemeris_t* e[])
 {
   double TOTs[n_channels];
   double min_TOF = -DBL_MAX;
   double clock_err[n_channels], clock_rate_err[n_channels];
 
   for (u8 i=0; i<n_channels; i++) {
-    TOTs[i] = 1e-3 * meas[i]->time_of_week_ms;
-    TOTs[i] += meas[i]->code_phase_chips / 1.023e6;
-    TOTs[i] += (nav_time - meas[i]->receiver_time) * meas[i]->code_phase_rate / 1.023e6;
+    TOTs[i] = 1e-3 * meas[i].time_of_week_ms;
+    TOTs[i] += meas[i].code_phase_chips / 1.023e6;
+    TOTs[i] += (nav_time - meas[i].receiver_time) * meas[i].code_phase_rate / 1.023e6;
 
     /** \todo Maybe keep track of week number in tracking channel
         state or derive it from system time. */
-    nav_meas[i]->tot.tow = TOTs[i];
-    gps_time_match_weeks(&nav_meas[i]->tot, &ephemerides[i]->toe);
+    nav_meas[i].tot.tow = TOTs[i];
+    gps_time_match_weeks(&nav_meas[i].tot, &e[i]->toe);
 
-    nav_meas[i]->raw_doppler = meas[i]->carrier_freq;
-    nav_meas[i]->snr = meas[i]->snr;
-    nav_meas[i]->sid.sat = meas[i]->sid.sat;
+    nav_meas[i].raw_doppler = meas[i].carrier_freq;
+    nav_meas[i].snr = meas[i].snr;
+    nav_meas[i].sid = meas[i].sid;
 
-    nav_meas[i]->carrier_phase = meas[i]->carrier_phase;
-    nav_meas[i]->carrier_phase += (nav_time - meas[i]->receiver_time) * meas[i]->carrier_freq;
+    nav_meas[i].carrier_phase = meas[i].carrier_phase;
+    nav_meas[i].carrier_phase += (nav_time - meas[i].receiver_time) * meas[i].carrier_freq;
 
-    nav_meas[i]->lock_counter = meas[i]->lock_counter;
+    nav_meas[i].lock_counter = meas[i].lock_counter;
 
     /* calc sat clock error */
-    calc_sat_state(ephemerides[i], nav_meas[i]->tot,
-                   nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
+    calc_sat_state(e[i], nav_meas[i].tot,
+                   nav_meas[i].sat_pos, nav_meas[i].sat_vel,
                    &clock_err[i], &clock_rate_err[i]);
 
     /* remove clock error to put all tots within the same time window */
@@ -798,14 +783,14 @@ void calc_navigation_measurement_(u8 n_channels, channel_measurement_t* meas[], 
   }
 
   for (u8 i=0; i<n_channels; i++) {
-    nav_meas[i]->raw_pseudorange = (min_TOF - TOTs[i])*GPS_C + GPS_NOMINAL_RANGE;
+    nav_meas[i].raw_pseudorange = (min_TOF - TOTs[i])*GPS_C + GPS_NOMINAL_RANGE;
 
-    nav_meas[i]->pseudorange = nav_meas[i]->raw_pseudorange \
+    nav_meas[i].pseudorange = nav_meas[i].raw_pseudorange \
                                + clock_err[i]*GPS_C;
-    nav_meas[i]->doppler = nav_meas[i]->raw_doppler + clock_rate_err[i]*GPS_L1_HZ;
+    nav_meas[i].doppler = nav_meas[i].raw_doppler + clock_rate_err[i]*GPS_L1_HZ;
 
-    nav_meas[i]->tot.tow -= clock_err[i];
-    nav_meas[i]->tot = normalize_gps_time(nav_meas[i]->tot);
+    nav_meas[i].tot.tow -= clock_err[i];
+    nav_meas[i].tot = normalize_gps_time(nav_meas[i].tot);
   }
 }
 


### PR DESCRIPTION
API changes to 
make_propagated_sdiffs()
calc_navigation_measurement()
check_lock_counters()

all of which now take in ephemeris pointers corresponding to the signals in other arrays instead of the entire global ephemeris array