### PR TITLE
Loosen cmake version requirement to 2.8.7 for Travis builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.7)
 project(libswiftnav)
 
 set(CMAKE_C_FLAGS_RELEASE "-O3")


### PR DESCRIPTION
Travis runs ubuntu 12.04 which only has cmake 2.8.7 available.

@mookerji 