### PR TITLE
Change the formulation of raw_pseudorange to allow inference of TOT.

### DIFF
--- a/src/track.c
+++ b/src/track.c
@@ -750,7 +750,6 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
                                  double nav_time, const ephemeris_t* e[])
 {
   double TOTs[n_channels];
-  double min_TOF = -DBL_MAX;
   double clock_err[n_channels], clock_rate_err[n_channels];
 
   for (u8 i=0; i<n_channels; i++) {

--- a/src/track.c
+++ b/src/track.c
@@ -776,14 +776,13 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
     calc_sat_state(e[i], nav_meas[i]->tot,
                    nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
                    &clock_err[i], &clock_rate_err[i]);
-
-    /* remove clock error to put all tots within the same time window */
-    if ((TOTs[i] + clock_err[i]) > min_TOF)
-      min_TOF = TOTs[i];
   }
 
   for (u8 i=0; i<n_channels; i++) {
-    nav_meas[i]->raw_pseudorange = (min_TOF - TOTs[i])*GPS_C + GPS_NOMINAL_RANGE;
+  /* Using nav_time as the reference here lets us back out the
+  * time of transmission later.
+  */
+    nav_meas[i]->raw_pseudorange = (nav_time - TOTs[i])*GPS_C;
 
     nav_meas[i]->pseudorange = nav_meas[i]->raw_pseudorange \
                                + clock_err[i]*GPS_C;

--- a/src/track.c
+++ b/src/track.c
@@ -775,14 +775,12 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
     calc_sat_state(e[i], nav_meas[i]->tot,
                    nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
                    &clock_err[i], &clock_rate_err[i]);
-  }
-
-  for (u8 i=0; i<n_channels; i++) {
-  /* Using nav_time as the reference here lets us back out the
-  * time of transmission later.
-  */
+    /* Using nav_time as the reference here lets us back out the
+     * time of transmission later.
+    */
     nav_meas[i]->raw_pseudorange = (nav_time - TOTs[i])*GPS_C;
-
+    printf("nav_time: %7.3f \t TOT: %7.3f \t raw_pseudorange: %10.3f",
+           nav_time, TOTs[i], nav_meas[i]->raw_pseudorange);
     nav_meas[i]->pseudorange = nav_meas[i]->raw_pseudorange \
                                + clock_err[i]*GPS_C;
     nav_meas[i]->doppler = nav_meas[i]->raw_doppler + clock_rate_err[i]*GPS_L1_HZ;


### PR DESCRIPTION
Use `(nav_time - tot) * c` as the raw_pseudorange instead of using a fixed pseudorange from a reference satellite.  This allows us to back out time of transmission if needed.

@henryhallam @fnoble @mookerji