### PR TITLE
Use sid_to_string in logs

### DIFF
--- a/src/nav_msg.c
+++ b/src/nav_msg.c
@@ -323,6 +323,9 @@ bool subframe_ready(nav_msg_t *n) {
 }
 
 s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
+  char buf[SID_STR_LEN_MAX];
+  sid_to_string(buf, sizeof(buf), e->sid);
+
   // Check parity and parse out the ephemeris from the most recently received subframe
 
   if (!e) {
@@ -341,21 +344,21 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
     BIT_POLARITY_INVERTED;
   if ((prev_bit_polarity != BIT_POLARITY_UNKNOWN)
       && (prev_bit_polarity != n->bit_polarity)) {
-    log_error("PRN %02d Nav phase flip - half cycle slip detected, "
-              "but not corrected", e->sid.sat+1);
+    log_error("%s Nav phase flip - half cycle slip detected, "
+              "but not corrected", buf);
     /* TODO: declare phase ambiguity to IAR */
   }
 
   /* Complain if buffer overrun */
   if (n->overrun) {
-    log_error("PRN %02d nav_msg subframe buffer overrun!", e->sid.sat + 1);
+    log_error("%s nav_msg subframe buffer overrun!", buf);
     n->overrun = false;
   }
 
   /* Extract word 2, and the last two parity bits of word 1 */
   u32 sf_word2 = extract_word(n, 28, 32, 0);
   if (nav_parity(&sf_word2)) {
-    log_info("PRN %02d subframe parity mismatch (word 2)", e->sid.sat + 1);
+    log_info("%s subframe parity mismatch (word 2)", buf);
     n->subframe_start_index = 0;  // Mark the subframe as processed
     n->next_subframe_id = 1;      // Make sure we start again next time
     return -2;
@@ -369,7 +372,7 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
       n->frame_words[sf_id-1][w] = extract_word(n, 30*(w+2) - 2, 32, 0);    // Get the bits
       // MSBs are D29* and D30*.  LSBs are D1...D30
       if (nav_parity(&n->frame_words[sf_id-1][w])) {  // Check parity and invert bits if D30*
-        log_info("PRN %02d subframe parity mismatch (word %d)", e->sid.sat + 1, w+3);
+        log_info("%s subframe parity mismatch (word %d)", buf, w+3);
         n->next_subframe_id = 1;      // Make sure we start again next time
         n->subframe_start_index = 0;  // Mark the subframe as processed
         return -3;
@@ -396,4 +399,3 @@ s8 process_subframe(nav_msg_t *n, ephemeris_t *e) {
   return 0;
 
 }
-

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -307,7 +307,7 @@ u16 rtcm3_encode_1002(u8 *buff, u16 id, gps_time_t t, u8 n_sat,
   for (u8 i=0; i<n_sat; i++) {
     gen_obs_gps(&nm[i], &amb, &pr, &ppr, &lock, &cnr);
 
-    setbitu(buff, bit, 6, nm[i].sid.sat + 1); bit += 6;
+    setbitu(buff, bit, 6, nm[i].sid.sat); bit += 6;
     /* TODO: set GPS code indicator if we ever support P(Y) code measurements. */
     setbitu(buff, bit, 1,  0);    bit += 1;
     setbitu(buff, bit, 24, pr);   bit += 24;
@@ -356,7 +356,7 @@ s8 rtcm3_decode_1002(u8 *buff, u16 *id, double *tow, u8 *n_sat,
   u16 bit = 64;
   for (u8 i=0; i<*n_sat; i++) {
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    nm[i].sid.sat = getbitu(buff, bit, 6) - 1; bit += 6;
+    nm[i].sid.sat = getbitu(buff, bit, 6); bit += 6;
 
     u8 code = getbitu(buff, bit, 1); bit += 1;
     /* TODO: When we start storing the signal/system etc. properly we can
@@ -383,5 +383,3 @@ s8 rtcm3_decode_1002(u8 *buff, u16 *id, double *tow, u8 *n_sat,
 
 /** \} */
 /** \} */
-
-


### PR DESCRIPTION
Corrects the printing of SBAS PRNs by using `sid_to_string` in logs.

@jacobmcnamee Can you review?