### PR TITLE
Add alert and healthy flags to solution structs

### DIFF
--- a/include/libswiftnav/constants.h
+++ b/include/libswiftnav/constants.h
@@ -34,7 +34,7 @@
 /** The official GPS value of Pi.
  * This is the value used by the CS to curve fit ephemeris parameters and
  * should be used in all ephemeris calculations. */
-#define GPS_PI 3.14159265358979323846
+#define GPS_PI 3.1415926535898
 
 /** The GPS L1 center frequency in Hz. */
 #define GPS_L1_HZ 1.57542e9
@@ -101,5 +101,3 @@
 /* \} */
 
 #endif /* LIBSWIFTNAV_CONSTANTS_H */
-
-

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -171,6 +171,8 @@ typedef struct {
   gps_time_t tot;
   gnss_signal_t sid;
   u16 lock_counter;
+  u8 healthy;
+  u8 alert;
 } navigation_measurement_t;
 
 void calc_loop_gains(float bw, float zeta, float k, float loop_freq,

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -155,6 +155,7 @@ typedef struct {
                                 ambiguity is reset.  If this number changes it
                                 is an indication you should reset integer
                                 ambiguity resolution for this channel. */
+  u8 alert;                /**< The GPS alert flag from navigation data. */
 } channel_measurement_t;
 
 typedef struct {
@@ -241,4 +242,3 @@ u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                 navigation_measurement_t *m_corrected);
 
 #endif /* LIBSWIFTNAV_TRACK_H */
-

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -301,7 +301,7 @@ u8 decode_fit_interval(u8 fit_interval_flag, u16 iodc) {
       fit_interval = 8;
     } else if (((iodc >= 248) && (iodc <= 255)) || (iodc == 496)) {
       fit_interval = 14;
-    } else if ((iodc >= 497) && (iodc <= 503)) {
+    } else if (((iodc >= 497) && (iodc <= 503)) || ((iodc >= 1021) && (iodc <= 1023))) {
       fit_interval = 26;
     } else if ((iodc >= 504) && (iodc <= 510)) {
       fit_interval = 50;

--- a/src/track.c
+++ b/src/track.c
@@ -777,6 +777,10 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
                    nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
                    &clock_err[i], &clock_rate_err[i]);
 
+    /* copy the alert and health flags */
+    nav_meas[i]->healthy = e[i]->healthy;
+    nav_meas[i]->alert = meas[i]->alert;
+
     /* remove clock error to put all tots within the same time window */
     if ((TOTs[i] + clock_err[i]) > min_TOF)
       min_TOF = TOTs[i];
@@ -850,4 +854,3 @@ u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
 }
 
 /** \} */
-


### PR DESCRIPTION
Continuation of #255. Needed so in https://github.com/swift-nav/piksi_firmware/pull/588 I can exclude unhealthy sats from the solution.

@gsmcmullin Can you review?