### PR TITLE
Add Klobuchar ionoshperic delay model

### DIFF
--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -7,6 +7,8 @@ Tools needed:
  - doxygen
  - convert from ImageMagick
  - pip install gcovr diff-cover
+ - pdflatex from TeX Live
+ - libcheck (otherwise `make` will not run unit tests)
 
 To get started, run::
 

--- a/include/libswiftnav/constants.h
+++ b/include/libswiftnav/constants.h
@@ -34,7 +34,7 @@
 /** The official GPS value of Pi.
  * This is the value used by the CS to curve fit ephemeris parameters and
  * should be used in all ephemeris calculations. */
-#define GPS_PI 3.14159265358979323846
+#define GPS_PI 3.1415926535898
 
 /** The GPS L1 center frequency in Hz. */
 #define GPS_L1_HZ 1.57542e9
@@ -101,5 +101,3 @@
 /* \} */
 
 #endif /* LIBSWIFTNAV_CONSTANTS_H */
-
-

--- a/include/libswiftnav/ionosphere.h
+++ b/include/libswiftnav/ionosphere.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Leith Bade <leith@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef LIBSWIFTNAV_IONOSHPERE_H
+#define LIBSWIFTNAV_IONOSHPERE_H
+
+#include "common.h"
+#include "gpstime.h"
+
+typedef struct {
+  double a0, a1, a2, a3;
+  double b0, b1, b2, b3;
+} ionosphere_t;
+
+double calc_ionosphere(gps_time_t t_gps,
+                       double lat_u, double lon_u,
+                       double a, double e,
+                       const ionosphere_t *i);
+
+#endif /* LIBSWIFTNAV_IONOSHPERE_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(libswiftnav_SRCS
   printing_utils.c
   filter_utils.c
   signal.c
+  ionosphere.c
   ${plover_SRCS}
 
   CACHE INTERNAL ""

--- a/src/almanac.c
+++ b/src/almanac.c
@@ -241,4 +241,3 @@ double calc_sat_doppler_almanac(const almanac_t* alm, double t, s16 week,
 }
 
 /** \} */
-

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -21,6 +21,10 @@
 #include "constants.h"
 #include "ephemeris.h"
 
+/** \defgroup ephemeris Ephemeris
+ * Functions and calculations related to the GPS ephemeris.
+ * \{ */
+
 /** Calculate satellite position, velocity from xyz ephemeris.
  *
  * References:
@@ -565,3 +569,5 @@ bool ephemeris_equal(const ephemeris_t *a, const ephemeris_t *b)
     return false;
   }
 }
+
+/** \} */

--- a/src/ionosphere.c
+++ b/src/ionosphere.c
@@ -10,12 +10,13 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <float.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "constants.h"
 #include "ionosphere.h"
 
-// TODO add unit tests for a bunch of inputs
 /** \defgroup ionosphere Ionospheric models
  * Implemenations of ionoshperic delay correction models.
  * \{ */
@@ -32,7 +33,7 @@
  * \param e Elevation of the satellite [rad]
  * \param i Ionosphere parameters struct from GPS NAV data
  *
- * \return  Ionospheric delay for GPS L1 frequency [s]
+ * \return  Ionospheric delay distance for GPS L1 frequency [m]
  */
 double calc_ionosphere(gps_time_t t_gps,
                        double lat_u, double lon_u,
@@ -70,7 +71,7 @@ double calc_ionosphere(gps_time_t t_gps,
   if (t > 86400.0) {
     t -= 86400.0;
   }
-  if (t < 86400) {
+  if (t < 0.0) {
     t += 86400.0;
   }
 
@@ -102,7 +103,7 @@ double calc_ionosphere(gps_time_t t_gps,
     d_l1 = sf * (5e-9 + amp * (1.0 - x_2 / 2.0 + x_2 * x_2 / 24.0));
   }
 
-  // TODO dont use during extended ops
+  d_l1 *= GPS_C;
 
   return d_l1;
 }

--- a/src/ionosphere.c
+++ b/src/ionosphere.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Leith Bade <leith@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <math.h>
+
+#include "constants.h"
+#include "ionosphere.h"
+
+// TODO add unit tests for a bunch of inputs
+/** \defgroup ionosphere Ionospheric models
+ * Implemenations of ionoshperic delay correction models.
+ * \{ */
+
+/** Calculate ionospheric delay using Klobuchar model.
+ *
+ * References:
+ *   -# IS-GPS-200H, Section 20.3.3.5.2.5 and Figure 20-4
+ *
+ * \param t_gps GPS time at which to calculate the ionospheric delay
+ * \param lat_u Latitude of the receiver [rad]
+ * \param lon_u Longitude of the receiver [rad]
+ * \param a Azimuth of the satellite, clockwise positive from North [rad]
+ * \param e Elevation of the satellite [rad]
+ * \param i Ionosphere parameters struct from GPS NAV data
+ *
+ * \return  Ionospheric delay for GPS L1 frequency [s]
+ */
+double calc_ionosphere(gps_time_t t_gps,
+                       double lat_u, double lon_u,
+                       double a, double e,
+                       const ionosphere_t *i)
+{
+  /* Convert inputs from radians to semicircles */
+  /* All calculations are in semicircles */
+  lat_u = lat_u / M_PI;
+  lon_u = lon_u / M_PI;
+  /* a can remain in radians */
+  e = e / M_PI;
+
+  /* Calculate the earth-centered angle */
+  double psi = 0.0137 / (e + 0.11) - 0.022;
+
+  /* Compute the latitude of the Ionospheric Pierce Point */
+  double lat_i = lat_u + psi * cos(a);
+  if (lat_i > 0.416) {
+    lat_i = 0.416;
+  }
+  if (lat_i < -0.416) {
+    lat_i = -0.416;
+  }
+
+  /* Compute the longitude of the IPP */
+  double lon_i = lon_u + (psi * sin(a)) / cos(lat_i * M_PI);
+
+  /* Find the geomagnetic latitude of the IPP */
+  double lat_m = lat_i + 0.064 * cos((lon_i - 1.617) * M_PI);
+
+  /* Find the local time at the IPP */
+  double t = 43200.0 * lon_i + t_gps.tow;
+  t = fmod(t, 86400.0);
+  if (t > 86400.0) {
+    t -= 86400.0;
+  }
+  if (t < 86400) {
+    t += 86400.0;
+  }
+
+  /* Compute the amplitude of ionospheric delay */
+  double amp = i->a0 + lat_m * (i->a1 + lat_m * (i->a2 + i->a3 * lat_m));
+  if (amp < 0.0) {
+    amp = 0.0;
+  }
+
+  /* Compute the period of ionospheric delay */
+  double per = i->b0 + lat_m * (i->b1 + lat_m * (i->b2 + i->b3 * lat_m));
+  if (per < 72000.0) {
+    per = 72000.0;
+  }
+
+  /* Compute the phase of ionospheric delay */
+  double x = 2.0 * M_PI * (t - 50400.0) / per;
+
+  /* Compute the slant factor */
+  double temp = 0.53 - e;
+  double sf = 1.0 + 16.0 * temp * temp * temp;
+
+  /* Compute the ionospheric time delay */
+  double d_l1;
+  if (x >= 1.57) {
+    d_l1 = sf * 5e-9;
+  } else {
+    double x_2 = x * x;
+    d_l1 = sf * (5e-9 + amp * (1.0 - x_2 / 2.0 + x_2 * x_2 / 24.0));
+  }
+
+  // TODO dont use during extended ops
+
+  return d_l1;
+}
+
+/** \} */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ else (CMAKE_CROSSCOMPILING)
       check_set.c
       check_viterbi.c
       check_gpstime.c
+      check_ionosphere.c
     )
 
     target_link_libraries(test_libswiftnav ${TEST_LIBS})

--- a/tests/check_ionosphere.c
+++ b/tests/check_ionosphere.c
@@ -1,0 +1,57 @@
+
+#include <check.h>
+
+#include <constants.h>
+#include <ionosphere.h>
+
+START_TEST(test_calc_ionosphere)
+{
+  gps_time_t t = {.wn = 1875, .tow = 479820};
+  ionosphere_t i = {.a0 = 0.1583e-7, .a1 = -0.7451e-8, .a2 = -0.5960e-7, .a3 = 0.1192e-6,
+                    .b0 = 0.1290e6, .b1 = -0.2130e6, .b2 = 0.6554e5, .b3 = 0.3277e6};
+  double lat_u = -35.3 * D2R, lon_u = 149.1 * D2R;
+  double a = 0.0 * D2R, e = 15.0 * D2R;
+  double d_true = 7.202;
+
+  const double d_tol = 1e-3;
+
+  double d_l1 = calc_ionosphere(t, lat_u, lon_u, a, e, &i);
+  double d_err = fabs(d_l1 - d_true);
+
+  fail_unless(d_err < d_tol,
+      "Distance didn't match hardcoded correct values. Saw: %.5f\n", d_l1);
+
+  t.wn = 1042;
+  t.tow = 593100;
+  i.a0 = 0.3820e-7;
+  i.a1 = 0.1490e-7;
+  i.a2 = -0.1790e-6;
+  i.a3 = 0.0;
+  i.b0 = 0.1430e6;
+  i.b1 = 0.0;
+  i.b2 = -0.3280e6;
+  i.b3 = 0.1130e6;
+  lat_u = 40.0 * D2R;
+  lon_u = 260.0 * D2R;
+  a = 210.0 * D2R;
+  e = 20.0 * D2R;
+  d_true = 23.784;
+
+  d_l1 = calc_ionosphere(t, lat_u, lon_u, a, e, &i);
+  d_err = fabs(d_l1 - d_true);
+
+  fail_unless(d_err < d_tol,
+      "Distance didn't match hardcoded correct values. Saw: %.5f\n", d_l1);
+}
+END_TEST
+
+Suite* ionosphere_suite(void)
+{
+  Suite *s = suite_create("Ionosphere");
+
+  TCase *tc_core = tcase_create("Core");
+  tcase_add_test(tc_core, test_calc_ionosphere);
+  suite_add_tcase(s, tc_core);
+
+  return s;
+}

--- a/tests/check_ionosphere.c
+++ b/tests/check_ionosphere.c
@@ -7,8 +7,10 @@
 START_TEST(test_calc_ionosphere)
 {
   gps_time_t t = {.wn = 1875, .tow = 479820};
-  ionosphere_t i = {.a0 = 0.1583e-7, .a1 = -0.7451e-8, .a2 = -0.5960e-7, .a3 = 0.1192e-6,
-                    .b0 = 0.1290e6, .b1 = -0.2130e6, .b2 = 0.6554e5, .b3 = 0.3277e6};
+  ionosphere_t i = {.a0 = 0.1583e-7, .a1 = -0.7451e-8,
+                    .a2 = -0.5960e-7, .a3 = 0.1192e-6,
+                    .b0 = 0.1290e6, .b1 = -0.2130e6,
+                    .b2 = 0.6554e5, .b3 = 0.3277e6};
   double lat_u = -35.3 * D2R, lon_u = 149.1 * D2R;
   double a = 0.0 * D2R, e = 15.0 * D2R;
   double d_true = 7.202;

--- a/tests/check_main.c
+++ b/tests/check_main.c
@@ -28,6 +28,7 @@ int main(void)
   srunner_add_suite(sr, set_suite());
   srunner_add_suite(sr, viterbi_suite());
   srunner_add_suite(sr, gpstime_test_suite());
+  srunner_add_suite(sr, ionosphere_suite());
 
   srunner_set_fork_status(sr, CK_NOFORK);
   srunner_run_all(sr, CK_NORMAL);

--- a/tests/check_suites.h
+++ b/tests/check_suites.h
@@ -19,5 +19,6 @@ Suite* ephemeris_suite(void);
 Suite* set_suite(void);
 Suite* viterbi_suite(void);
 Suite* gpstime_test_suite(void);
+Suite* ionosphere_suite(void);
 
 #endif /* CHECK_SUITES_H */


### PR DESCRIPTION
Implements the ionospheric delay model from GPS ICD.

Next job will be to extract the parameters from the NAV data and apply the corrections for SPP.

Ready for review.