### PR TITLE
Fixes to lesq_solve_raim bindings and tests

### DIFF
--- a/python/swiftnav/baseline.pyx
+++ b/python/swiftnav/baseline.pyx
@@ -171,4 +171,7 @@ def lesq_solve_raim_(dd_obs, N, DE, disable_raim, raim_threshold):
                                  &N_[0], &DE_[0,0], &b[0],
                                  disable_raim, raim_threshold,
                                  &num_used, &residuals[0], &removed_obs)
-  return (code, num_used, residuals, removed_obs, b)
+  # If we drop satellites from the solution, then the residuals array will only
+  # contain `num_used` valid residuals. Truncate before returning.
+  residuals_ = residuals[:num_used]
+  return (code, num_used, residuals_, removed_obs, b)

--- a/python/tests/test_baseline.py
+++ b/python/tests/test_baseline.py
@@ -304,7 +304,7 @@ def test_lesq_repair8():
   code, num_used, residuals, removed_obs, b \
     = bl.lesq_solve_raim_(dd_obs, N, DE, False, bl.DEFAULT_RAIM_THRESHOLD_)
   assert num_used == 7
-  assert np.allclose(residuals, np.array([0, 0, 0, 0, 0, 0, 0, 0]))
+  assert np.allclose(residuals, np.zeros(num_used))
   assert removed_obs == 7
   assert np.allclose(b, np.array([ 0.19023801,  0.19023801,  0.19023801]))
   assert code == 1, "Expecting 1 for repaired solution, got: %i." % code
@@ -323,7 +323,7 @@ def test_lesq_repair1():
   code, num_used, residuals, removed_obs, b \
     = bl.lesq_solve_raim_(dd_obs, N, DE, False, bl.DEFAULT_RAIM_THRESHOLD_)
   assert num_used == 4
-  assert np.allclose(residuals, np.array([0, 0, 0, 0, 0]))
+  assert np.allclose(residuals, np.zeros(num_used))
   assert removed_obs == 4
   assert np.allclose(b, np.array([ 0.19023801,  0.19023801,  0.19023801]))
   assert code == 1, "Expecting 1 for repaired solution, got: %i." % code
@@ -361,6 +361,6 @@ def test_lesq_repair2():
     = bl.lesq_solve_raim_(dd_obs, N, DE, False, bl.DEFAULT_RAIM_THRESHOLD_)
   assert np.allclose(b, np.array([ 0.1705906,  -0.00802221, -0.00802221]))
   assert num_used == 0
-  assert np.allclose(residuals, np.array([[0, 0, 0, 0]]))
+  assert np.allclose(residuals, np.zeros(num_used))
   assert removed_obs == 0
   assert code == -4, "Expecting -4 for not enough dds to repair, got: %i." % code


### PR DESCRIPTION
When RAIM repair is performed we were returning a residuals array that was too long with junk elements at the end.

cc: @mookerji @ljbade 