### PR TITLE
Update README.md to show build status for master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libswiftnav
 ===========
 
-[![Build status][1]][2]
+[![Build Status](https://travis-ci.org/swift-nav/libswiftnav.svg?branch=master)](https://travis-ci.org/swift-nav/libswiftnav)
 
 Libswiftnav is a platform independent library that implements GNSS functions
 and algorithms for use by software-defined GNSS receivers or software requiring

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libswiftnav
 ===========
 
-libswfitnav/master: [![Build status][1]][2]
+master: [![Build status][1]][2]
 
 Libswiftnav is a platform independent library that implements GNSS functions
 and algorithms for use by software-defined GNSS receivers or software requiring

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libswiftnav
 ===========
 
-[![Build status][1]][2]
+libswfitnav/master: [![Build status][1]][2]
 
 Libswiftnav is a platform independent library that implements GNSS functions
 and algorithms for use by software-defined GNSS receivers or software requiring

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libswiftnav
 ===========
 
-[![Build Status](https://travis-ci.org/swift-nav/libswiftnav.svg?branch=master)](https://travis-ci.org/swift-nav/libswiftnav)
+[![Build status][1]][2]
 
 Libswiftnav is a platform independent library that implements GNSS functions
 and algorithms for use by software-defined GNSS receivers or software requiring
@@ -19,5 +19,5 @@ For installation, see [docs/install.dox.](http://docs.swift-nav.com/libswiftnav/
 
 For development help, see [DEVELOPMENT.rst](https://github.com/swift-nav/libswiftnav/blob/master/DEVELOPMENT.rst)
 
-[1]: https://travis-ci.org/swift-nav/libswiftnav.png
+[1]: https://travis-ci.org/swift-nav/libswiftnav.svg?branch=master
 [2]: https://travis-ci.org/swift-nav/libswiftnav


### PR DESCRIPTION
The build status was showing the most recent libswiftnav build (including PRs), so that while looking at the master branch you may see a red "build failed" which actually corresponded to a development branch.

https://github.com/letsencrypt/letsencrypt/issues/927

This change makes it so the build status (on all branches) shows an indicator of the master build.