### PR TITLE
Fix almanac python binding init

### DIFF
--- a/python/swiftnav/almanac.pyx
+++ b/python/swiftnav/almanac.pyx
@@ -26,8 +26,13 @@ cdef class Almanac:
 
   def __init__(self, **kwargs):
     memset(&self._thisptr, 0, sizeof(almanac_t))
-    if kwargs:
-      self._thisptr = kwargs
+    self._thisptr.sid = kwargs.pop('sid')
+    self._thisptr.healthy = kwargs.pop('healthy')
+    self._thisptr.valid = kwargs.pop('valid')
+    if 'gps' in kwargs:
+      self._thisptr.gps = kwargs.pop('gps')
+    elif 'sbas' in kwargs:
+      self._thisptr.sbas = kwargs.pop('sbas')
 
   def __getattr__(self, k):
     return self._thisptr.get(k)

--- a/python/swiftnav/almanac.pyx
+++ b/python/swiftnav/almanac.pyx
@@ -85,7 +85,7 @@ cdef class Almanac:
       The tuple (azimuth, elevation) in radians.
 
     """
-    assert len(ref) != 3, "ECEF coordinates must have dimension 3."
+    assert len(ref) == 3, "ECEF coordinates must have dimension 3."
     cdef np.ndarray[np.double_t, ndim=1, mode="c"] ref_ = np.array(ref, dtype=np.double)
     cdef double az, el
     calc_sat_az_el_almanac(&self._thisptr, t, week, &ref_[0], &az, &el)
@@ -111,6 +111,6 @@ cdef class Almanac:
       The Doppler shift in Hz.
 
     """
-    assert len(ref) != 3, "ECEF coordinates must have dimension 3."
+    assert len(ref) == 3, "ECEF coordinates must have dimension 3."
     cdef np.ndarray[np.double_t, ndim=1, mode="c"] ref_ = np.array(ref, dtype=np.double)
     return calc_sat_doppler_almanac(&self._thisptr, t, week, &ref_[0])

--- a/python/tests/test_almanac.py
+++ b/python/tests/test_almanac.py
@@ -39,16 +39,6 @@ def test_init():
         'constellation': 0,
         'sat': 1
     },
-    'sbas': {
-      'data_id': 1,
-      'x': 1,
-      'y': 2,
-      'z': 3,
-      'x_rate': 4,
-      'y_rate': 5,
-      'z_rate': 6,
-      't0': 7
-    },
     'valid': 1,
   }
 

--- a/python/tests/test_almanac.py
+++ b/python/tests/test_almanac.py
@@ -12,12 +12,6 @@
 import numpy as np
 import swiftnav.almanac
 
-def test_imports():
-  """Verify that distributed packages survive setuptools installation.
-
-  """
-  assert True
-
 def test_init():
   alm = {
     'gps': {
@@ -46,3 +40,41 @@ def test_init():
   assert np.isclose(alm['gps']['a'], satAlmanac.gps['a'])
   assert np.isclose(alm['gps']['ecc'], satAlmanac.gps['ecc'])
 
+def test_almanac_functions():
+  alm = {
+    'healthy': 1,
+    'gps': {
+        'a': 26559810.38052176,
+        'week': 814,
+        'ecc': 0.004033565521,
+        'argp': 0.380143734,
+        'af0': -7.629394531e-06,
+        'rora': -7.874613724e-09,
+        'ma': 2.030394348,
+        'toa': 233472.0,
+        'inc': 0.9619461694,
+        'af1': 0.0,
+        'raaw': -0.9244574916
+    },
+    'valid': 1,
+    'sid': {
+        'band': 0,
+        'constellation': 0,
+        'sat': 1
+    }
+  }
+  tow = 168214.6
+  wn = 814
+  pos = np.array([-2704369.61784456, -4263211.09418205,  3884641.21270987])
+
+  satAlmanac = swiftnav.almanac.Almanac(**alm)
+  position, velocity = satAlmanac.calc_state(tow, week=wn)
+  assert np.allclose(position, np.array([7938925.33852649, -19535003.95771277, -16086183.49111858]))
+  assert np.allclose(velocity, np.array([1771.68410121, -1031.78569083,  2151.49172217]))
+
+  doppler = satAlmanac.calc_doppler(tow, pos, week=wn)
+  assert np.isclose(doppler, -1607.88747151)
+
+  azimuth, elevation = satAlmanac.calc_az_el(tow, pos, week=wn)
+  assert np.isclose(azimuth, 2.43752431894)
+  assert np.isclose(elevation, -0.239507449606)

--- a/python/tests/test_almanac.py
+++ b/python/tests/test_almanac.py
@@ -9,6 +9,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+import numpy as np
 import swiftnav.almanac
 
 def test_imports():
@@ -16,3 +17,42 @@ def test_imports():
 
   """
   assert True
+
+def test_init():
+  alm = {
+    'gps': {
+        'a': 8,
+        'af0': 9,
+        'af1': 10,
+        'argp': 7,
+        'ecc': 8,
+        'inc': 3,
+        'ma': 8,
+        'raaw': 6,
+        'rora': 4,
+        'toa': 2,
+        'week': 11
+    },
+    'healthy': 1,
+    'sid': {
+        'band': 0,
+        'constellation': 0,
+        'sat': 1
+    },
+    'sbas': {
+      'data_id': 1,
+      'x': 1,
+      'y': 2,
+      'z': 3,
+      'x_rate': 4,
+      'y_rate': 5,
+      'z_rate': 6,
+      't0': 7
+    },
+    'valid': 1,
+  }
+
+  satAlmanac = swiftnav.almanac.Almanac(**alm)
+  assert np.isclose(alm['gps']['a'], satAlmanac.gps['a'])
+  assert np.isclose(alm['gps']['ecc'], satAlmanac.gps['ecc'])
+


### PR DESCRIPTION
This changes the almanac initializer to be similar to the ephemeris python binding. The second commit has a failing test with the old initializer and the third commit has a passing test with the new initializer. 

@mookerji @fnoble 