### PR TITLE
Improve UTC handling (WIP)

### DIFF
--- a/include/libswiftnav/constants.h
+++ b/include/libswiftnav/constants.h
@@ -24,9 +24,6 @@
 #define R2D (180.0 / M_PI) /**< Conversion factor from radians to degrees. */
 #define D2R (M_PI / 180.0) /**< Conversion factor from degrees to radians. */
 
-#define DAY_SECS (24*60*60) /** < Seconds in a day */
-#define WEEK_SECS (7*DAY_SECS) /** < Seconds in a week */
-
 /** \defgroup gps_constants GPS
  * Constants related to the Global Positioning System.
  * See ICD-GPS-200C.

--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -51,11 +51,11 @@ typedef struct {
   };
 } ephemeris_t;
 
-s8 calc_sat_state(const ephemeris_t *e, gps_time_t t,
+s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                   double pos[3], double vel[3],
                   double *clock_err, double *clock_rate_err);
 
-u8 ephemeris_good(const ephemeris_t *eph, gps_time_t t);
+u8 ephemeris_good(const ephemeris_t *eph, const gps_time_t *t);
 
 float decode_ura_index(const u8 index);
 u8 decode_fit_interval(u8 fit_interval_flag, u16 iodc);

--- a/include/libswiftnav/ionosphere.h
+++ b/include/libswiftnav/ionosphere.h
@@ -16,12 +16,13 @@
 #include <libswiftnav/common.h>
 #include <libswiftnav/time.h>
 
+/** Structure holding Klobuchar ionospheric model parameters. */
 typedef struct {
   double a0, a1, a2, a3;
   double b0, b1, b2, b3;
 } ionosphere_t;
 
-double calc_ionosphere(gps_time_t t_gps,
+double calc_ionosphere(const gps_time_t *t_gps,
                        double lat_u, double lon_u,
                        double a, double e,
                        const ionosphere_t *i);

--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -48,7 +48,7 @@ u8 make_propagated_sdiffs_wip(u8 n_local, navigation_measurement_t *m_local,
 u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           u8 n_remote, navigation_measurement_t *m_remote,
                           double *remote_dists, double remote_pos_ecef[3],
-                          const ephemeris_t *e[], gps_time_t t,
+                          const ephemeris_t *e[], const gps_time_t *t,
                           sdiff_t *sds);
 
 s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids, u8 num_dds,

--- a/include/libswiftnav/time.h
+++ b/include/libswiftnav/time.h
@@ -17,11 +17,32 @@
 
 #include <libswiftnav/common.h>
 
-/** Number of seconds in a week. */
-#define WEEK_SECS (7*24*60*60)
+/** Number of days in a common (non-leap) year. */
+#define COMMON_YEAR_DAYS (365)
+
+/** Number of days in a leap year. */
+#define LEAP_YEAR_DAYS (366)
+
+/** Number of days in four years. */
+#define FOUR_YEARS_DAYS (3 * COMMON_YEAR_DAYS + LEAP_YEAR_DAYS)
+
+/** Number of days in 100 years. */
+#define HUNDRED_YEARS_DAYS (24 * FOUR_YEARS_DAYS + 4 * COMMON_YEAR_DAYS)
+
+/** Number of days in 400 years. */
+#define  FOUR_HUNDRED_YEARS_DAYS (3 * HUNDRED_YEARS_DAYS + 25 * FOUR_YEARS_DAYS)
+
+/** Number of seconds in a minute. */
+#define MINUTE_SECS (60)
+
+/** Number of seconds in a hour. */
+#define HOUR_SECS (60 * MINUTE_SECS)
 
 /** Number of seconds in a day. */
-#define DAYS_SECS (24*60*60)
+#define DAY_SECS (24 * HOUR_SECS)
+
+/** Number of seconds in a week. */
+#define WEEK_SECS (7 * DAY_SECS)
 
 /** Number of rollovers in the 10-bit broadcast GPS week number.
  * Update on next rollover on April 7, 2019.
@@ -38,6 +59,13 @@
 /** Unix timestamp of the GPS epoch 1980-01-06 00:00:00 UTC */
 #define GPS_EPOCH 315964800
 
+/** Modified Julian days of the GPS epoch 1980-01-06 00:00:00 UTC */
+#define MJD_JAN_6_1980 44244
+
+/** Modified Julian days of 1601-01-01 */
+#define MJD_JAN_1_1601 -94187
+//#define MJD_JAN_1_1601 15385
+
 #define WN_UNKNOWN -1
 
 /** Structure representing a GPS time. */
@@ -46,9 +74,33 @@ typedef struct __attribute__((packed)) {
   s16 wn;     /**< GPS week number. */
 } gps_time_t;
 
+/** Structure containing GPS UTC correction parameters. */
+typedef struct {
+  double a0;
+  double a1;
+  gps_time_t tot;
+  gps_time_t t_lse;
+  u8 dt_ls;
+  u8 dt_lsf;
+} utc_params_t;
+
+/** Structure representing UTC time. */
+typedef struct {
+  u16 year;           /**< Number of years AD. In four digit format. */
+  u8 year_day;        /**< Day of the year (1 - 366). */
+  u8 month;           /**< Month of the year (1 - 12). 0 = January, 12 = December. */
+  u8 month_day;       /**< Day of the month (1 - 31). */
+  u8 week_day;        /**< Day of the week (1 - 7). 1 = Monday, 7 = Sunday. */
+  u8 hour;            /**< Minutes of the hour (0 - 59). */
+  u8 minute;          /**< Minutes of the hour (0 - 59). */
+  u8 second_int;      /**< Integer part of seconds of the minute (0 - 60). */
+  double second_frac; /**< Fractional part of seconds (0 - .99...). */
+} utc_time_t;
+
 void normalize_gps_time(gps_time_t *t_gps);
 
-time_t gps2time(const gps_time_t *t);
+void gps2utc(const utc_params_t *p, const gps_time_t *t, utc_time_t *u);
+time_t gps2time(const utc_params_t *p, const gps_time_t *t_gps);
 
 double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning);
 void gps_time_match_weeks(gps_time_t *t, const gps_time_t *ref);

--- a/include/libswiftnav/time.h
+++ b/include/libswiftnav/time.h
@@ -87,7 +87,7 @@ typedef struct {
 /** Structure representing UTC time. */
 typedef struct {
   u16 year;           /**< Number of years AD. In four digit format. */
-  u8 year_day;        /**< Day of the year (1 - 366). */
+  u16 year_day;       /**< Day of the year (1 - 366). */
   u8 month;           /**< Month of the year (1 - 12). 0 = January, 12 = December. */
   u8 month_day;       /**< Day of the month (1 - 31). */
   u8 week_day;        /**< Day of the week (1 - 7). 1 = Monday, 7 = Sunday. */

--- a/include/libswiftnav/time.h
+++ b/include/libswiftnav/time.h
@@ -30,7 +30,7 @@
 #define HUNDRED_YEARS_DAYS (24 * FOUR_YEARS_DAYS + 4 * COMMON_YEAR_DAYS)
 
 /** Number of days in 400 years. */
-#define  FOUR_HUNDRED_YEARS_DAYS (3 * HUNDRED_YEARS_DAYS + 25 * FOUR_YEARS_DAYS)
+#define FOUR_HUNDRED_YEARS_DAYS (3 * HUNDRED_YEARS_DAYS + 25 * FOUR_YEARS_DAYS)
 
 /** Number of seconds in a minute. */
 #define MINUTE_SECS (60)
@@ -52,7 +52,6 @@
 /** Offset between GPS and UTC times in seconds.
  * Update when a new leap second is inserted and be careful about times in the
  * past when this offset was different.
- * TODO handle leap seconds properly!
  */
 #define GPS_MINUS_UTC_SECS 17
 
@@ -80,8 +79,8 @@ typedef struct {
   double a1;
   gps_time_t tot;
   gps_time_t t_lse;
-  u8 dt_ls;
-  u8 dt_lsf;
+  s8 dt_ls;
+  s8 dt_lsf;
 } utc_params_t;
 
 /** Structure representing UTC time. */

--- a/include/libswiftnav/time.h
+++ b/include/libswiftnav/time.h
@@ -17,6 +17,12 @@
 
 #include <libswiftnav/common.h>
 
+/** Number of seconds in a week. */
+#define WEEK_SECS (7*24*60*60)
+
+/** Number of seconds in a day. */
+#define DAYS_SECS (24*60*60)
+
 /** Number of rollovers in the 10-bit broadcast GPS week number.
  * Update on next rollover on April 7, 2019.
  * \todo Detect and handle rollover more gracefully. */
@@ -40,11 +46,11 @@ typedef struct __attribute__((packed)) {
   s16 wn;     /**< GPS week number. */
 } gps_time_t;
 
-gps_time_t normalize_gps_time(gps_time_t);
+void normalize_gps_time(gps_time_t *t_gps);
 
-time_t gps2time(gps_time_t t);
+time_t gps2time(const gps_time_t *t);
 
-double gpsdifftime(gps_time_t end, gps_time_t beginning);
+double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning);
 void gps_time_match_weeks(gps_time_t *t, const gps_time_t *ref);
 
 #endif /* LIBSWIFTNAV_TIME_H */

--- a/python/swiftnav/ephemeris.pxd
+++ b/python/swiftnav/ephemeris.pxd
@@ -42,10 +42,10 @@ cdef extern from "libswiftnav/ephemeris.h":
     ephemeris_kepler_t kepler
     ephemeris_xyz_t xyz
 
-  s8 calc_sat_state(const ephemeris_t *e, gps_time_t t,
+  s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                     double pos[3], double vel[3],
                     double *clock_err, double *clock_rate_err)
-  u8 ephemeris_good(const ephemeris_t *eph, gps_time_t t)
+  u8 ephemeris_good(const ephemeris_t *eph, const gps_time_t *t)
   void decode_ephemeris(u32 frame_words[3][8], ephemeris_t *e)
   u8 ephemeris_equal(const ephemeris_t *a, const ephemeris_t *b)
 

--- a/python/swiftnav/observation.pxd
+++ b/python/swiftnav/observation.pxd
@@ -40,7 +40,7 @@ cdef extern from "libswiftnav/observation.h":
   u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                             u8 n_remote, navigation_measurement_t *m_remote,
                             double *remote_dists, double remote_pos_ecef[3],
-                            const ephemeris_t *e[], gps_time_t t,
+                            const ephemeris_t *e[], const gps_time_t *t,
                             sdiff_t *sds)
 
   s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids,

--- a/python/swiftnav/time.pxd
+++ b/python/swiftnav/time.pxd
@@ -17,14 +17,16 @@ cdef extern from "libswiftnav/time.h":
   u8 GPS_MINUS_UTC_SECS
   u16 GPS_EPOCH
   double WN_UNKNOWN
+  u16 WEEK_SECS
+  u16 DAYS_SECS
 
   ctypedef struct gps_time_t:
     double tow
     s16 wn
 
-  gps_time_t normalize_gps_time(gps_time_t)
-  time_t gps2time(gps_time_t t)
-  double gpsdifftime(gps_time_t end, gps_time_t beginning)
+  void normalize_gps_time(const gps_time_t *t)
+  time_t gps2time(const gps_time_t *t_gps)
+  double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning)
   void gps_time_match_weeks(gps_time_t *t, const gps_time_t *ref)
 
 cdef class GpsTime:

--- a/python/swiftnav/time.pxd
+++ b/python/swiftnav/time.pxd
@@ -15,10 +15,19 @@ from posix.types cimport time_t
 cdef extern from "libswiftnav/time.h":
   u8 GPS_WEEK_CYCLE
   u8 GPS_MINUS_UTC_SECS
-  u16 GPS_EPOCH
+  u32 GPS_EPOCH
+  u32 MJD_JAN_6_1980
+  u32 MJD_JAN_1_1601
   double WN_UNKNOWN
-  u16 WEEK_SECS
-  u16 DAYS_SECS
+  u32 WEEK_SECS
+  u32 DAY_SECS
+  u32 HOUR_SECS
+  u32 MINUTE_SECS
+  u32 COMMON_YEAR_DAYS
+  u32 LEAP_YEAR_DAYS
+  u32 FOUR_YEARS_DAYS
+  u32 HUNDRED_YEARS_DAYS
+  u32 FOUR_HUNDRED_YEARS_DAYS
 
   ctypedef struct gps_time_t:
     double tow

--- a/src/almanac.c
+++ b/src/almanac.c
@@ -16,6 +16,7 @@
 #include <libswiftnav/constants.h>
 #include <libswiftnav/linear_algebra.h>
 #include <libswiftnav/coord_system.h>
+#include <libswiftnav/time.h>
 #include <libswiftnav/almanac.h>
 
 /** \defgroup almanac Almanac

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -37,7 +37,7 @@
  * \return  0 on success,
  *         -1 if ephemeris is older (or newer) than 4 hours
  */
-static s8 calc_sat_state_xyz(const ephemeris_t *e, gps_time_t t,
+static s8 calc_sat_state_xyz(const ephemeris_t *e, const gps_time_t *t,
                              double pos[3], double vel[3],
                              double *clock_err, double *clock_rate_err)
 {
@@ -51,8 +51,8 @@ static s8 calc_sat_state_xyz(const ephemeris_t *e, gps_time_t t,
     return -1;
 
   const ephemeris_xyz_t *ex = &e->xyz;
-  u8 ndays = t.tow / DAY_SECS;
-  double tod = t.tow - DAY_SECS * ndays;
+  u8 ndays = t->tow / DAY_SECS;
+  double tod = t->tow - DAY_SECS * ndays;
   double dt = tod - ex->toa;
 
   if (dt > DAY_SECS/2)
@@ -95,7 +95,7 @@ static s8 calc_sat_state_xyz(const ephemeris_t *e, gps_time_t t,
  *         -1 if ephemeris is older (or newer) than 4 hours
  */
 static s8 calc_sat_state_kepler(const ephemeris_t *e,
-                                gps_time_t t,
+                                const gps_time_t *t,
                                 double pos[3], double vel[3],
                                 double *clock_err, double *clock_rate_err)
 {
@@ -104,12 +104,12 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
   /* Calculate satellite clock terms */
 
   /* Seconds from clock data reference time (toc) */
-  double dt = gpsdifftime(t, k->toc);
+  double dt = gpsdifftime(t, &k->toc);
   *clock_err = k->af0 + dt * (k->af1 + dt * k->af2) - k->tgd;
   *clock_rate_err = k->af1 + 2.0 * dt * k->af2;
 
   /* Seconds from the time from ephemeris reference epoch (toe) */
-  dt = gpsdifftime(t, e->toe);
+  dt = gpsdifftime(t, &e->toe);
 
   /* If dt is greater than fit_interval hours our ephemeris isn't valid. */
   if (fabs(dt) > ((u32)e->fit_interval)*60*60) {
@@ -219,7 +219,7 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
  * \return  0 on success,
  *         -1 if ephemeris is older (or newer) than 4 hours
  */
-s8 calc_sat_state(const ephemeris_t *e, gps_time_t t,
+s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                   double pos[3], double vel[3],
                   double *clock_err, double *clock_rate_err)
 {
@@ -251,10 +251,10 @@ s8 calc_sat_state(const ephemeris_t *e, gps_time_t t,
  * \return 1 if the ephemeris is valid and not too old.
  *         0 otherwise.
  */
-u8 ephemeris_good(const ephemeris_t *eph, gps_time_t t)
+u8 ephemeris_good(const ephemeris_t *eph, const gps_time_t *t)
 {
   /* Seconds from the time from ephemeris reference epoch (toe) */
-  double dt = gpsdifftime(t, eph->toe);
+  double dt = gpsdifftime(t, &eph->toe);
 
   /* TODO: this doesn't exclude ephemerides older than a week so could be made
    * better. */

--- a/src/ionosphere.c
+++ b/src/ionosphere.c
@@ -35,7 +35,7 @@
  *
  * \return  Ionospheric delay distance for GPS L1 frequency [m]
  */
-double calc_ionosphere(gps_time_t t_gps,
+double calc_ionosphere(const gps_time_t *t_gps,
                        double lat_u, double lon_u,
                        double a, double e,
                        const ionosphere_t *i)
@@ -66,13 +66,13 @@ double calc_ionosphere(gps_time_t t_gps,
   double lat_m = lat_i + 0.064 * cos((lon_i - 1.617) * M_PI);
 
   /* Find the local time at the IPP */
-  double t = 43200.0 * lon_i + t_gps.tow;
-  t = fmod(t, 86400.0);
-  if (t > 86400.0) {
-    t -= 86400.0;
+  double t = 43200.0 * lon_i + t_gps->tow;
+  t = fmod(t, DAY_SECS);
+  if (t > DAY_SECS) {
+    t -= DAY_SECS;
   }
   if (t < 0.0) {
-    t += 86400.0;
+    t += DAY_SECS;
   }
 
   /* Compute the amplitude of ionospheric delay */

--- a/src/observation.c
+++ b/src/observation.c
@@ -177,7 +177,7 @@ int cmp_sid_sdiff(const void *a, const void *b)
 u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           u8 n_remote, navigation_measurement_t *m_remote,
                           double *remote_dists, double remote_pos_ecef[3],
-                          const ephemeris_t *e[], gps_time_t t,
+                          const ephemeris_t *e[], const gps_time_t *t,
                           sdiff_t *sds)
 {
   u8 i, j, n = 0;

--- a/src/pvt.c
+++ b/src/pvt.c
@@ -582,7 +582,7 @@ s8 calc_PVT(const u8 n_used,
   soln->time.tow += nav_meas[0].pseudorange / GPS_C;
   /* Subtract clock offset. */
   soln->time.tow -= rx_state[3] / GPS_C;
-  soln->time = normalize_gps_time(soln->time);
+  normalize_gps_time(&soln->time);
 
   u8 ret;
   if ((ret = filter_solution(soln, dops))) {

--- a/src/time.c
+++ b/src/time.c
@@ -15,10 +15,9 @@
 #include <libswiftnav/time.h>
 #include <libswiftnav/constants.h>
 
-// TODO add a doc group
-
-/* TODO: does it make sense to be passing structs by value in all
-   these functions? */
+/** \defgroup time Time functions
+ * Functions to handle GPS and UTC time values.
+ * \{ */
 
 /** Normalize a `gps_time_t` GPS time struct.
  * Ensures that the time of week is greater than zero and less than one week by
@@ -27,34 +26,31 @@
  * \param t GPS time struct.
  * \return Normalized GPS time struct.
  */
-/* TODO: Either normalise in place or rename to normalised. */
-gps_time_t normalize_gps_time(gps_time_t t)
+void normalize_gps_time(gps_time_t *t)
 {
-  while(t.tow < 0) {
-    t.tow += WEEK_SECS;
-    t.wn -= 1;
+  while(t->tow < 0) {
+    t->tow += WEEK_SECS;
+    t->wn += 1;
   }
 
-  while(t.tow > WEEK_SECS) {
-    t.tow -= WEEK_SECS;
-    t.wn += 1;
+  while(t->tow > WEEK_SECS) {
+    t->tow -= WEEK_SECS;
+    t->wn -= 1;
   }
-
-  return t;
 }
 
 /** Convert a `gps_time_t` GPS time to a Unix `time_t`.
  * \note Adjusts for leap seconds using the current constant offset.
  *
- * \param gps_t GPS time struct.
+ * \param t_gps GPS time struct.
  * \return Unix time.
  */
-time_t gps2time(gps_time_t gps_t)
+time_t gps2time(const gps_time_t *t_gps)
 {
   time_t t = GPS_EPOCH - GPS_MINUS_UTC_SECS;
 
-  t += WEEK_SECS*gps_t.wn;
-  t += (s32)gps_t.tow;
+  t += WEEK_SECS * t_gps->wn;
+  t += (s32)t_gps->tow;
 
   return t;
 }
@@ -69,10 +65,10 @@ time_t gps2time(gps_time_t gps_t)
  *                  the result is negative.
  * \return The time difference in seconds between `beginning` and `end`.
  */
-double gpsdifftime(gps_time_t end, gps_time_t beginning)
+double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning)
 {
-  double dt = end.tow - beginning.tow;
-  if (end.wn == WN_UNKNOWN || beginning.wn == WN_UNKNOWN) {
+  double dt = end->tow - beginning->tow;
+  if (end->wn == WN_UNKNOWN || beginning->wn == WN_UNKNOWN) {
     /* One or both of the week numbers is unspecified.  Assume times
        are within +/- 0.5 weeks of each other. */
     if (dt > WEEK_SECS / 2)
@@ -81,7 +77,7 @@ double gpsdifftime(gps_time_t end, gps_time_t beginning)
       dt += WEEK_SECS;
   } else {
     /* Week numbers were provided - use them. */
-    dt += (end.wn - beginning.wn) * WEEK_SECS;
+    dt += (end->wn - beginning->wn) * WEEK_SECS;
   }
   return dt;
 }
@@ -101,3 +97,5 @@ void gps_time_match_weeks(gps_time_t *t, const gps_time_t *ref)
   else if (dt < -WEEK_SECS / 2)
     t->wn++;
 }
+
+/** \} */

--- a/src/time.c
+++ b/src/time.c
@@ -19,12 +19,11 @@
  * Functions to handle GPS and UTC time values.
  * \{ */
 
-/** Normalize a `gps_time_t` GPS time struct.
+/** Normalize a `gps_time_t` GPS time struct in place.
  * Ensures that the time of week is greater than zero and less than one week by
  * wrapping and adjusting the week number accordingly.
  *
  * \param t GPS time struct.
- * \return Normalized GPS time struct.
  */
 void normalize_gps_time(gps_time_t *t)
 {
@@ -39,15 +38,138 @@ void normalize_gps_time(gps_time_t *t)
   }
 }
 
+// http://www.ngs.noaa.gov/gps-toolbox/bwr-c.txt
+// TODO note Beidou uses a different DN definition than GPS/Galileo
+// TODO add day of week field to utc_time
+void gps2utc(const utc_params_t *p, const gps_time_t *t, utc_time_t *u)
+{
+  /* Seconds from current time to leap second effctivity time */
+  double dt_lse = gpsdifftime(t, &p->t_lse);
+
+  /* Seconds from UTC data reference time (tot) */
+  double dt = gpsdifftime(t, &p->tot); // TODO when making tot need to set WN correct
+
+  // TODO move to header and python - split into hours?
+
+  /* Check if we are near the LS effectivity time and pick correct LS offset */
+  bool within_6hrs = false;
+  u8 dt_ls;
+  if ((dt_lse >= -6 * HOUR_SECS) && (dt_lse <= 6 * HOUR_SECS)) {
+    /* We are within 6 hours before or after LS effectivity time */
+    dt_ls = p->dt_ls;
+    within_6hrs = true;
+
+  } else if (dt_lse < 0.0) {
+    /* We are before the LS effectivity time */
+    dt_ls = p->dt_ls;
+
+  } else {
+    /* We are after the LS effectivity time */
+    dt_ls = p->dt_lsf;
+  }
+
+  /* Calculate the UTC to GPS difference */
+  double dt_utc = dt_ls + p->a0 + p->a1 * dt;
+
+  /* Check if we need to correct for LS event */
+  double t_utc;
+  if (within_6hrs) {
+    double w =
+      fmod(t->tow - dt_utc - 12 * HOUR_SECS, DAY_SECS) + 12 * HOUR_SECS;
+    t_utc = fmod(w, DAY_SECS + p->dt_lsf - p->dt_ls);
+  } else {
+    t_utc = fmod(t->tow - dt_utc, DAY_SECS);
+  }
+
+  /* t_utc now contains the seconds from the start of the day */
+  /* It may be 1 second longer than a normal day due to LS */
+
+  /* Convert this into hours, minutes and seconds */
+  u32 second_int = t_utc;                /* The integer part of the seconds */
+  u->second_frac = fmod(t_utc, 1.0);     /* The fractional part of the seconds */
+  u->hour = second_int / HOUR_SECS;      /* The hours (1 - 23) */
+  if (u->hour > 23) {
+    u->hour = 23;                        /* Correct for a LS making it 24 */
+  }
+  second_int -= u->hour * HOUR_SECS;     /* Remove the hours from seconds */
+  u->minute = second_int / MINUTE_SECS;  /* The minutes (1 - 59) */
+  if (u->minute > 59) {
+    u->minute = 59;                      /* Correct for a LS making it 60 */
+  }
+  second_int -= u->minute * MINUTE_SECS; /* Remove the minutes from seconds */
+  u->second_int = second_int;            /* The seconds (1 - 60) */
+
+  /* Calculate the years */
+
+  /* Days from 1 Jan 1980. GPS epoch is 6 Jan 1980 */
+  u8 day_of_week = t->tow / DAY_SECS;
+  day_of_week += ((fmod(t->tow, DAY_SECS) > 23 * HOUR_SECS) &&
+                 (t_utc < 1 * HOUR_SECS));
+  u32 modified_julian_days = MJD_JAN_6_1980 + t->wn * 7 + day_of_week;
+  u32 days_since_1601 = modified_julian_days - MJD_JAN_1_1601;
+
+  /* Calculate the number of leap years */
+  u16 num_400_years = days_since_1601 / FOUR_HUNDRED_YEARS_DAYS;
+  u32 days_left = days_since_1601 -
+                       num_400_years * FOUR_HUNDRED_YEARS_DAYS;
+  u16 num_100_years = days_left / HUNDRED_YEARS_DAYS -
+                                days_left / (FOUR_HUNDRED_YEARS_DAYS - 1);
+  days_left -= num_100_years * HUNDRED_YEARS_DAYS;
+  u16 num_4_years = days_left / FOUR_YEARS_DAYS;
+  days_left -= num_4_years * FOUR_YEARS_DAYS;
+  u16 num_non_leap_years = days_left / COMMON_YEAR_DAYS -
+                                days_left / (FOUR_YEARS_DAYS - 1);
+
+  /* Calculate the total number of years from 1980 */
+  u->year = 1601 + num_400_years * 400 +
+            num_100_years * 100 + num_4_years * 4 + num_non_leap_years;
+
+  /* Calculate the month of the year */
+
+  /* Calculate the day of the current year */
+  u->year_day = days_left - num_non_leap_years * COMMON_YEAR_DAYS + 1;
+
+  /* Work out if it is currently a leap year, 0 = no, 1 = yes` */
+  u8 leap_year = ((u->year % 4) == 0) &&
+                 (((u->year % 100) != 0) || ((u->year % 400) == 0));
+
+  /* Roughly work out the month number */
+  u8 month_guess = u->year_day * 0.032;
+
+  /* Lookup table of the total number of days in the year after each month */
+  /* First row is for a non-leap year, second row is for a leap year */
+  static u16 days_after_month[2][13] = {
+    {0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365},
+    {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366}
+  };
+
+  /* Check if our guess was out, and what the correction is, */
+  /* 0 = correct, 1 = wrong */
+  u8 month_correction = (u->year_day - days_after_month[leap_year][month_guess + 1]) > 0;
+
+  /* Calculate the corrected number of months */
+  u->month = month_guess + month_correction + 1;
+
+  /* Calculate the day of the month */
+  u->month_day = u->year_day - days_after_month[leap_year][month_guess + month_correction];
+
+  /* Calculate the day of the week. 1 Jan 1601 was a Monday */
+  u->week_day = days_since_1601 % 7 + 1;
+
+  // TODO how use within_6hrs to handle roll over of leap second day past 60 seconds?
+}
+
 /** Convert a `gps_time_t` GPS time to a Unix `time_t`.
  * \note Adjusts for leap seconds using the current constant offset.
  *
+ * \param p UTC correction parameters.
  * \param t_gps GPS time struct.
  * \return Unix time.
  */
-time_t gps2time(const gps_time_t *t_gps)
+time_t gps2time(const utc_params_t *p, const gps_time_t *t_gps)
 {
-  time_t t = GPS_EPOCH - GPS_MINUS_UTC_SECS;
+  // TODO should go via gps2utc
+  time_t t = GPS_EPOCH - p->dt_ls;
 
   t += WEEK_SECS * t_gps->wn;
   t += (s32)t_gps->tow;

--- a/src/track.c
+++ b/src/track.c
@@ -773,7 +773,7 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
     nav_meas[i]->lock_counter = meas[i]->lock_counter;
 
     /* calc sat clock error */
-    calc_sat_state(e[i], nav_meas[i]->tot,
+    calc_sat_state(e[i], &nav_meas[i]->tot,
                    nav_meas[i]->sat_pos, nav_meas[i]->sat_vel,
                    &clock_err[i], &clock_rate_err[i]);
 
@@ -794,7 +794,7 @@ void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *mea
     nav_meas[i]->doppler = nav_meas[i]->raw_doppler + clock_rate_err[i]*GPS_L1_HZ;
 
     nav_meas[i]->tot.tow -= clock_err[i];
-    nav_meas[i]->tot = normalize_gps_time(nav_meas[i]->tot);
+    normalize_gps_time(&nav_meas[i]->tot);
   }
 }
 
@@ -843,7 +843,7 @@ u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
       /* TODO: check that using difference of TOTs here is a valid
        * approximation. */
       m_corrected[n].raw_doppler = (m_new[i].carrier_phase - m_old[j].carrier_phase)
-                                    / gpsdifftime(m_new[i].tot, m_old[j].tot);
+                                    / gpsdifftime(&m_new[i].tot, &m_old[j].tot);
       /* Re-apply the same correction to the raw Doppler to get the corrected Doppler. */
       m_corrected[n].doppler = m_corrected[n].raw_doppler + dopp_corr;
       n++;

--- a/tests/check_ionosphere.c
+++ b/tests/check_ionosphere.c
@@ -17,7 +17,7 @@ START_TEST(test_calc_ionosphere)
 
   const double d_tol = 1e-3;
 
-  double d_l1 = calc_ionosphere(t, lat_u, lon_u, a, e, &i);
+  double d_l1 = calc_ionosphere(&t, lat_u, lon_u, a, e, &i);
   double d_err = fabs(d_l1 - d_true);
 
   fail_unless(d_err < d_tol,
@@ -39,7 +39,7 @@ START_TEST(test_calc_ionosphere)
   e = 20.0 * D2R;
   d_true = 23.784;
 
-  d_l1 = calc_ionosphere(t, lat_u, lon_u, a, e, &i);
+  d_l1 = calc_ionosphere(&t, lat_u, lon_u, a, e, &i);
   d_err = fabs(d_l1 - d_true);
 
   fail_unless(d_err < d_tol,

--- a/tests/check_time.c
+++ b/tests/check_time.c
@@ -24,7 +24,7 @@ START_TEST(test_gpsdifftime)
   const double tow_tol = 1e-10;
   for (size_t i = 0;
        i < sizeof(testcases) / sizeof(struct gpsdifftime_testcase); i++) {
-    double dt = gpsdifftime(testcases[i].a, testcases[i].b);
+    double dt = gpsdifftime(&testcases[i].a, &testcases[i].b);
     fail_unless(fabs(dt - testcases[i].dt) < tow_tol,
                 "gpsdifftime test case %d failed, dt = %.12f", i, dt);
   }


### PR DESCRIPTION
Main improvements:
- replace using system Unix time functions (which introduces many problems) with our own
- convert GPS network time into UTC

So far the conversion of seconds into a calendar data and clock display works perfectly for the next 32,000 years with an extensive unit test.

However the leap second event handling is broken. It has something to do with the GPS ICD's algorithim returns seconds modulo a day, which make it hard to roll over the date when the leap second happens at midnight.

I have not found any public or open source implementation of GPS leap seconds to study.
