### PR TITLE
[TESTS] Add test for costas discriminator.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ else (CMAKE_CROSSCOMPILING)
       check_time.c
       check_ionosphere.c
       check_signal.c
+      check_track.c
     )
 
     target_link_libraries(test_libswiftnav ${TEST_LIBS})

--- a/tests/check_main.c
+++ b/tests/check_main.c
@@ -30,6 +30,7 @@ int main(void)
   srunner_add_suite(sr, time_test_suite());
   srunner_add_suite(sr, ionosphere_suite());
   srunner_add_suite(sr, signal_test_suite());
+  srunner_add_suite(sr, track_test_suite());
 
   srunner_set_fork_status(sr, CK_NOFORK);
   srunner_run_all(sr, CK_NORMAL);

--- a/tests/check_suites.h
+++ b/tests/check_suites.h
@@ -21,5 +21,6 @@ Suite* viterbi_suite(void);
 Suite* time_test_suite(void);
 Suite* ionosphere_suite(void);
 Suite* signal_test_suite(void);
+Suite* track_test_suite(void);
 
 #endif /* CHECK_SUITES_H */

--- a/tests/check_track.c
+++ b/tests/check_track.c
@@ -1,0 +1,73 @@
+#include <math.h>
+#include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include "check_utils.h"
+
+#include <libswiftnav/track.h>
+
+START_TEST(test_costas_discriminator)
+{
+  const struct
+  {
+    float i, q;
+    float res;
+    bool valid;
+  } test_cases[] = {
+      {
+        .i = 0,
+        .res = 0,
+        .valid = true
+      },
+      {
+        .i = 0.1,
+        .q = 0,
+        .res = 0,
+        .valid = true
+      },
+      {
+        .i = 1.0,
+        .q = M_PI,
+        .res = 0.20095336902385319,
+        .valid = true
+      },
+      {
+        .i = 2.0,
+        .q = -M_PI,
+        .res = -0.20095336902385319,
+        .valid = false
+      },
+      {
+        .i = 1.0,
+        .q = -M_PI,
+        .res = -0.20095336902385319,
+        .valid = true
+      },
+  };
+
+  for (u32 i=0; i<sizeof(test_cases) / sizeof(test_cases[0]); i++) {
+    float res  = costas_discriminator(test_cases[i].i, test_cases[i].q);
+    /*
+    Result is expected to be close to the predicted value only when
+    the test is expected to pass.
+    */
+
+    fail_unless(((fabs(test_cases[i].res - res) < 1e-6) && test_cases[i].valid) ||
+                ((fabs(test_cases[i].res - res) > 1e-6) && !test_cases[i].valid),
+                "result is incorrect (%f vs %f)", test_cases[i].res, res);
+  }
+}
+END_TEST
+
+Suite* track_test_suite(void)
+{
+  Suite *s = suite_create("Track");
+
+  TCase *tc_core = tcase_create("Core");
+  tcase_add_test(tc_core, test_costas_discriminator);
+  suite_add_tcase(s, tc_core);
+
+  return s;
+}
+


### PR DESCRIPTION
This was the introduction for Exafore team into unit tests and github work flow.
@swift-nav/firmware @swift-nav/estimation to take a look.