### PR TITLE
Python time bug

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 from version import get_git_version
 
 setup_args = dict(

--- a/python/swiftnav/time.pyx
+++ b/python/swiftnav/time.pyx
@@ -16,8 +16,8 @@ cdef class GpsTime:
 
   def __init__(self, **kwargs):
     memset(&self._thisptr, 0, sizeof(gps_time_t))
-    self._thisptr.tow = kwargs.pop('tow')
-    self._thisptr.wn = kwargs.pop('wn')
+    if kwargs:
+      self._thisptr = kwargs
 
   def __getattr__(self, k):
     return self._thisptr.get(k)

--- a/python/swiftnav/time.pyx
+++ b/python/swiftnav/time.pyx
@@ -16,9 +16,12 @@ cdef class GpsTime:
 
   def __init__(self, **kwargs):
     memset(&self._thisptr, 0, sizeof(gps_time_t))
-    if kwargs:
-      self._thisptr = kwargs
+    self._thisptr.tow = kwargs.pop('tow')
+    self._thisptr.wn = kwargs.pop('wn')
 
+  def __getattr__(self, k):
+    return self._thisptr.get(k)
+  
   def __repr__(self):
     return "<GpsTime wn %d, tow %d>" % (self._thisptr.wn, self._thisptr.tow)
 
@@ -97,4 +100,4 @@ def datetime2gpst(timestamp):
   wn = dt.days / 7
   tow = (dt - datetime.timedelta(weeks=wn)).total_seconds()
   #wn % 1024 would be standard, but we want a bijective tranformation.
-  return GpsTime(wn, tow)
+  return GpsTime(wn=wn, tow=tow)

--- a/python/tests/test_time.py
+++ b/python/tests/test_time.py
@@ -10,6 +10,7 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 import swiftnav.time as t
+import datetime as dt
 
 # TODO (Buro): Add back case with WN_UNKNOWN?
 def test_gpsdifftime():
@@ -37,3 +38,18 @@ def test_gpsdifftime():
     normalized.normalize_gps_time()
     print normalized
     assert t.GpsTime(tow=a[0], wn=a[1]).gpsdifftime(t.GpsTime(tow=b[0], wn=b[1])) - dt < tow_tol
+
+def test_comp_2_datetime():
+  test_dt = t.gpst_components2datetime(1, 100)
+  time_dif = test_dt - dt.datetime.strptime('1980-01-13 00:01:41', '%Y-%m-%d %H:%M:%S')
+  assert abs(time_dif) == dt.timedelta(0, 1 , 0)
+
+def test_gpst2datetime():
+  gpst = t.GpsTime(wn=800, tow=30000)
+  test_dt = t.gpst2datetime(gpst)
+  assert test_dt == dt.datetime.strptime('1995-05-07 08:20:00', '%Y-%m-%d %H:%M:%S')
+
+def test_datetime2gpst():
+  test_dt = dt.datetime.strptime('1995-05-07 08:20:00', '%Y-%m-%d %H:%M:%S')
+  gpst = t.datetime2gpst(test_dt)
+  assert str(gpst) == str(t.GpsTime(wn=800, tow=30000))


### PR DESCRIPTION
I think this fixes some bugs in the python bindings around gpstime.  I also added a #! to the setup.py

I'm not 100% sure of the intended architecture in the python bindings, but this allowed me to use them.
/cc @mookerji @akleeman 

Next steps are to allow cython to work with a local libswiftnav library.