### PR TITLE
Print navigation measurements, bug fix, and test.

### DIFF
--- a/python/swiftnav/ambiguity_test.pyx
+++ b/python/swiftnav/ambiguity_test.pyx
@@ -137,9 +137,7 @@ cdef class AmbiguityTest:
                             is_bad_measurement):
     num_sdiffs = len(sdiffs)
     cdef sdiff_t sdiffs_[32]
-    print "here"
     mk_sdiff_array(sdiffs, 32, &sdiffs_[0])
-    print sdiffs_
     return ambiguity_update_sats(&self._thisptr,
                                  num_sdiffs,
                                  &sdiffs_[0],

--- a/python/swiftnav/ephemeris.pyx
+++ b/python/swiftnav/ephemeris.pyx
@@ -82,4 +82,4 @@ cdef mk_ephemeris_array(py_ephemerides, u8 n_c_ephemerides,
 
   """
   for (i, ephemeris) in enumerate(py_ephemerides):
-    c_ephemerides[i] = &((<Ephemeris ?>ephemeris[i])._thisptr)
+    c_ephemerides[i] = &((<Ephemeris ?>ephemeris)._thisptr)

--- a/python/swiftnav/observation.pyx
+++ b/python/swiftnav/observation.pyx
@@ -43,6 +43,9 @@ cdef class SingleDiff:
   def from_dict(self, d):
     self._thisptr = d
 
+  def __rich_cmp__(self, SingleDiff sd, op):
+    return cmp_sdiff(<void *>&self._thisptr, <void *>&sd._thisptr)
+
 def single_diff_(m_a, m_b):
   """Calculate single differences from two sets of observations.
   Undifferenced input observations are assumed to be both taken at the
@@ -214,10 +217,10 @@ cdef mk_sdiff_array(py_sdiffs, u8 n_c_sdiffs, sdiff_t *c_sdiffs):
 cdef read_sdiff_array(u8 n_c_sdiffs, sdiff_t *c_sdiffs):
   """Given an array of c sdiff_t's, returns an array of SingleDiffs.
 
+  Not efficient, but works for now.
+
   """
-  cdef sdiff_t sd_
-  py_sdiffs = [SingleDiff()]*n_c_sdiffs
-  for (i, sdiff) in enumerate(py_sdiffs):
-    sd_ = (<SingleDiff> sdiff)._thisptr
-    memcpy(&sd_, &c_sdiffs[i], sizeof(sdiff_t))
+  py_sdiffs = []
+  for n in range(n_c_sdiffs):
+    py_sdiffs.append(SingleDiff(**c_sdiffs[n]))
   return py_sdiffs

--- a/python/swiftnav/track.pyx
+++ b/python/swiftnav/track.pyx
@@ -18,6 +18,7 @@ from common cimport *
 from ephemeris cimport ephemeris_t
 from ephemeris cimport Ephemeris
 from ephemeris import Ephemeris
+from fmt_utils import fmt_repr
 from time cimport *
 from time import GpsTime
 from libc.stdlib cimport malloc, free
@@ -452,6 +453,12 @@ cdef class NavigationMeasurement:
 
   def __getattr__(self, k):
     return self._thisptr.get(k)
+
+  def to_dict(self):
+    return self._thisptr
+
+  def __repr__(self):
+    return fmt_repr(self)
 
   def __rich_cmp__(self, nav_msg, op):
     cdef navigation_measurement_t nav_msg_ = nav_msg._thisptr

--- a/python/tests/test_observation.py
+++ b/python/tests/test_observation.py
@@ -9,6 +9,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+from swiftnav.ephemeris import Ephemeris
 from swiftnav.pvt import calc_PVT_
 import numpy as np
 import pytest
@@ -133,3 +134,59 @@ def test_single_diff():
   assert len(sdiffs) == 2
   sdiffs = o.single_diff_([nms[1], nms[0]], [nms[2], nms[0]])
   assert len(sdiffs) == 1
+
+def test_prop_single_diff():
+  rover_nm = [t.NavigationMeasurement(sat_pos=[-19277207.52067729, -8215764.2479763795, 16367744.770246204],
+                                      pseudorange=21123480.27105955, doppler=0, raw_doppler=0, carrier_phase=-110993309.26669005,
+                                      sat_vel=[-1025.0370403901404, -1821.9217799467374, -2091.6303199092254],
+                                      lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.92954684512),
+                                      raw_pseudorange=21121324.476403236,
+                                      snr=30.0, sid=s.GNSSSignal(band=0, constellation=0, sat=0), lock_counter=0),
+              t.NavigationMeasurement(sat_pos=[-16580310.849158794, 918714.1939749047, 20731444.258332774],
+                                      pseudorange=22432049.84763688, doppler=0, raw_doppler=0, carrier_phase=-117882743.21601027,
+                                      sat_vel=[1060.9864205977192, -2411.43509917502, 953.6270954519971],
+                                      lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.9251737675),
+                                      raw_pseudorange=22432340.166121125,
+                                      snr=30.0, sid=s.GNSSSignal(band=0, constellation=0, sat=2), lock_counter=0)]
+  remote_dists = np.array([ 21121393.87562408,  22432814.46819838])
+  base_pos = np.array( [-2704375, -4263211,  3884637])
+  es = [Ephemeris(**{'ura': 0.0, 'healthy': 1,
+                     'xyz': {'acc': [-6.51925802230835e-08, 4.718410826464475e-09, 2.6226835183928943],
+                             'iod': 0, 'a_gf0': 5153.648313522339, 'a_gf1': 0.5977821557062277,
+                             'pos': [5.122274160385132e-09, 19.0625, 259.9375],
+                             'rate': [1.0151416063308716e-06, 6.260350346565247e-06, -6.332993507385254e-08],
+                             'toa': 4096},
+                     'valid': 1,
+                     'sid': {'band': 0, 'constellation': 0, 'sat': 0},
+                     'toe': {'wn': 1876, 'tow': 172800.0},
+                     'kepler': {'inc_dot': 4.4966158735287064e-10, 'tgd': 5.122274160385132e-09, 'omegadot': -8.099980253833005e-09,
+                                'sqrta': 5153.648313522339, 'inc': 0.9634151551139846, 'cus': 6.260350346565247e-06,
+                                'omega0': 0.5977821557062277, 'cuc': 1.0151416063308716e-06, 'm0': 2.6226835183928943,
+                                'toc': {'wn': 1876, 'tow': 172800.0}, 'dn': 4.718410826464475e-09, 'ecc': 0.0049016030970960855,
+                                'cic': -6.332993507385254e-08, 'crs': 19.0625, 'iode': 74, 'iodc': 21845, 'cis': -6.51925802230835e-08,
+                                'crc': 259.9375, 'w': 0.4885959643259506, 'af0': 7.212162017822266e-06, 'af1': 9.094947017729282e-13, 'af2': 0.0},
+                     'fit_interval': 4}),
+        Ephemeris(**{'ura': 0.0, 'healthy': 1,
+                     'xyz': {'acc': [-6.146728992462158e-08, 4.742340394655613e-09, -0.8114190126645531], 'iod': 0,
+                             'a_gf0': 5153.798839569092, 'a_gf1': 1.6390180338742641,
+                             'pos': [1.862645149230957e-09, -40.5625, 221.625],
+                             'rate': [-2.2239983081817627e-06, 8.001923561096191e-06, 3.725290298461914e-09], 'toa': 0},
+                     'valid': 1,
+                     'sid': {'band': 0, 'constellation': 0, 'sat': 2},
+                     'toe': {'wn': 1876, 'tow': 172800.0},
+                     'kepler': {'inc_dot': -4.475186409476941e-10, 'tgd': 1.862645149230957e-09, 'omegadot': -8.103551831174965e-09,
+                                'sqrta': 5153.798839569092, 'inc': 0.9587534715647247, 'cus': 8.001923561096191e-06,
+                                'omega0': 1.6390180338742641, 'cuc': -2.2239983081817627e-06, 'm0': -0.8114190126645531,
+                                'toc': {'wn': 1876, 'tow': 172800.0}, 'dn': 4.742340394655613e-09, 'ecc': 0.00035172002390027046,
+                                'cic': 3.725290298461914e-09, 'crs': -40.5625, 'iode': 59, 'iodc': 21845, 'cis': -6.146728992462158e-08,
+                                'crc': 221.625, 'w': 2.9037284161724037, 'af0': -9.969808161258698e-07, 'af1': -5.229594535194337e-12, 'af2': 0.0},
+                     'fit_interval': 4})]
+  gpst = ti.GpsTime(wn=1876, tow=167132)
+  sdiffs = o.make_propagated_sdiffs_(rover_nm, rover_nm, remote_dists, base_pos, es, gpst)
+  assert len(sdiffs) == 2
+  assert sdiffs[0].pseudorange > 0
+  assert sdiffs[1].pseudorange > 0
+  assert sdiffs[0].carrier_phase < 0
+  assert sdiffs[0].doppler > 0
+  assert sdiffs[0].sid['sat'] == 0
+  assert sdiffs[1].sid['sat'] == 2


### PR DESCRIPTION
Notably, adds a test case for the make_propagated_sdiffs function with
some synthetic data taken from Kleeman's SITL runner. The case is
somewhat huge, so I think we'd ultimately want to replace something
like this something that could be generated more cleanly within the
library.

/cc @akleeman @benjamin0 @fnoble