### PR TITLE
Split ephemeris_valid into ephemeris_valid_at_time

### DIFF
--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -55,7 +55,8 @@ s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                   double pos[3], double vel[3],
                   double *clock_err, double *clock_rate_err);
 
-u8 ephemeris_valid(const ephemeris_t *eph, const gps_time_t *t);
+u8 ephemeris_valid(const ephemeris_t *eph);
+u8 ephemeris_not_stale(const ephemeris_t *eph, const gps_time_t *t);
 u8 satellite_healthy(const ephemeris_t *eph);
 
 float decode_ura_index(const u8 index);

--- a/python/swiftnav/ephemeris.pxd
+++ b/python/swiftnav/ephemeris.pxd
@@ -45,7 +45,8 @@ cdef extern from "libswiftnav/ephemeris.h":
   s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                     double pos[3], double vel[3],
                     double *clock_err, double *clock_rate_err)
-  u8 ephemeris_valid(const ephemeris_t *eph, const gps_time_t *t)
+  u8 ephemeris_valid(const ephemeris_t *eph)
+  u8 ephemeris_not_stale(const ephemeris_t *eph, const gps_time_t *t)
   u8 satellite_healthy(const ephemeris_t *eph)
   void decode_ephemeris(u32 frame_words[3][8], ephemeris_t *e)
   u8 ephemeris_equal(const ephemeris_t *a, const ephemeris_t *b)

--- a/python/swiftnav/ephemeris.pyx
+++ b/python/swiftnav/ephemeris.pyx
@@ -54,7 +54,7 @@ cdef class Ephemeris:
     return (pos, vel, clock_err, clock_rate_err)
 
   def is_valid(self, GpsTime time):
-    return ephemeris_valid(&self._thisptr, &time._thisptr)
+    return ephemeris_not_stale(&self._thisptr, &time._thisptr)
 
   def is_healthy(self):
     return satellite_healthy(&self._thisptr)

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -228,7 +228,7 @@ s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
   assert(clock_err != NULL);
   assert(clock_rate_err != NULL);
   assert(e != NULL);
-  assert(ephemeris_valid(e, t));
+  assert(ephemeris_not_stale(e, t));
 
   switch (e->sid.constellation) {
   case CONSTELLATION_GPS:
@@ -241,21 +241,33 @@ s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
   }
 }
 
-/** Is this ephemeris usable?
+
+/** Is this ephemeris usable at any time?
+ *
+ * \param eph Ephemeris struct
+ * \return 1 if the ephemeris is valid.
+ *         0 otherwise.
+ */
+u8 ephemeris_valid(const ephemeris_t *eph)
+{
+  return eph->valid;
+}
+
+/** Is this ephemeris usable at the given time?
  *
  * \param eph Ephemeris struct
  * \param t   The current GPS time. This is used to determine the ephemeris age.
  * \return 1 if the ephemeris is valid and not too old.
  *         0 otherwise.
  */
-u8 ephemeris_valid(const ephemeris_t *eph, const gps_time_t *t)
+u8 ephemeris_not_stale(const ephemeris_t *eph, const gps_time_t *t)
 {
   /* Seconds from the time from ephemeris reference epoch (toe) */
   double dt = gpsdifftime(t, &eph->toe);
 
   /* TODO: this doesn't exclude ephemerides older than a week so could be made
    * better. */
-  return (eph->valid && fabs(dt) < ((u32)eph->fit_interval)*60*60);
+  return (ephemeris_valid(eph) && fabs(dt) < ((u32)eph->fit_interval)*60*60);
 }
 
 /** Is this satellite healthy? Note this function only checks flags in the


### PR DESCRIPTION
This is so code that just wants to check if a valid ephemeris has been decoded (and not caring about it's age), can use a function rather than directly checking `ephemeris_t->valid` for consistency