### PR TITLE
update requirements.txt to require Cython>=0.22

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-cython>=0.17
+cython>=0.22
 numpy>=1.9
 flake8==2.3.0
 pep8==1.5.7


### PR DESCRIPTION
As told in the readme Cython needs to be >=0.22, otherwise the build fails.