### PR TITLE
Check for valid ephemeris in satellite_healthy()

### DIFF
--- a/python/tests/test_ephemeris.py
+++ b/python/tests/test_ephemeris.py
@@ -122,7 +122,7 @@ def test_sat_state():
                                 'af1': 3.637978807091713e-12,
                                 'af2': 0.0}})
   assert not eph.is_valid(t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,}))
-  assert not eph.is_healthy()
+  assert eph.is_healthy()
   eph = e.Ephemeris(**{'sid': {'sat': 17, 'code': 0},
                          'toe': { 'wn': 1867, 'tow': 518400.0,},
                          'ura': 2.0,

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -286,7 +286,13 @@ u8 ephemeris_valid(const ephemeris_t *eph, const gps_time_t *t)
  */
 u8 satellite_healthy(const ephemeris_t *eph)
 {
-  return eph->healthy;
+  if (eph->valid) {
+    return eph->healthy;
+  } else {
+    /* If we don't yet have an ephemeris, assume satellite is healthy */
+    /* Otherwise we will stop tracking the sat and never find out */
+    return 1;
+  }
 }
 
 /** Convert a GPS URA index into a value.


### PR DESCRIPTION
Removed need to check `eph->valid` before using `satellite_healthy`