### PR TITLE
Add ephemeris_params_valid

### DIFF
--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -56,6 +56,8 @@ s8 calc_sat_state(const ephemeris_t *e, const gps_time_t *t,
                   double *clock_err, double *clock_rate_err);
 
 u8 ephemeris_valid(const ephemeris_t *eph, const gps_time_t *t);
+u8 ephemeris_params_valid(const u8 v, const u8 fit_interval,
+                      const gps_time_t* toe, const gps_time_t *t);
 u8 satellite_healthy(const ephemeris_t *eph);
 
 float decode_ura_index(const u8 index);

--- a/python/swiftnav/ephemeris.pxd
+++ b/python/swiftnav/ephemeris.pxd
@@ -49,6 +49,9 @@ cdef extern from "libswiftnav/ephemeris.h":
   u8 satellite_healthy(const ephemeris_t *eph)
   void decode_ephemeris(u32 frame_words[3][8], ephemeris_t *e)
   u8 ephemeris_equal(const ephemeris_t *a, const ephemeris_t *b)
+  u8 ephemeris_params_valid(const u8 v, const u8 fit_interval,
+                      const gps_time_t* toe, const gps_time_t *t)
+
 
 cdef class Ephemeris:
   cdef ephemeris_t _thisptr

--- a/python/swiftnav/ephemeris.pyx
+++ b/python/swiftnav/ephemeris.pyx
@@ -19,6 +19,7 @@ from time import GpsTime
 from libc.string cimport memcpy, memset
 import numpy as np
 
+
 cdef class Ephemeris:
 
   def __init__(self, **kwargs):
@@ -55,6 +56,10 @@ cdef class Ephemeris:
 
   def is_valid(self, GpsTime time):
     return ephemeris_valid(&self._thisptr, &time._thisptr)
+
+  @staticmethod
+  def is_params_valid(u8 v, u8 fit_interval, GpsTime toe, GpsTime t):
+    return ephemeris_params_valid(v, fit_interval, &toe._thisptr, &t._thisptr)
 
   def is_healthy(self):
     return satellite_healthy(&self._thisptr)

--- a/python/tests/test_ephemeris.py
+++ b/python/tests/test_ephemeris.py
@@ -155,3 +155,34 @@ def test_sat_state():
   assert eph.is_valid(t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0 + 3600.*2}))
   assert not eph.is_valid(t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0 + 3600.*3 + 1}))
   assert eph.is_healthy()
+
+def test_parameters():
+  toe = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  time = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  valid = 1
+  fit_interval = 4
+  assert e.Ephemeris.is_params_valid(valid, fit_interval, toe, time)
+
+  toe = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  time = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  valid = 0
+  fit_interval = 4
+  assert not e.Ephemeris.is_params_valid(valid, fit_interval, toe, time)
+
+  toe = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  time = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  valid = 1
+  fit_interval = 0
+  assert not e.Ephemeris.is_params_valid(valid, fit_interval, toe, time)
+
+  toe = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  time = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0 + 3600.0 * 2,})
+  valid = 1
+  fit_interval = 4
+  assert e.Ephemeris.is_params_valid(valid, fit_interval, toe, time)
+
+  toe = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0,})
+  time = t.GpsTime(**{ 'wn': 1867, 'tow': 518400.0 + 3600.0 * 3 ,})
+  valid = 1
+  fit_interval = 4
+  assert not e.Ephemeris.is_params_valid(valid, fit_interval, toe, time)


### PR DESCRIPTION
The function allows to avoid passing whole ephemeris as parameter.
The change has been done for Nav DB.