### PR TITLE
Pass receiver time delta into calc_navigation_measurement()

### DIFF
--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -146,8 +146,9 @@ typedef struct {
   double carrier_freq;     /**< Carrier frequency in Hz. */
   u32 time_of_week_ms;     /**< Number of milliseconds since the start of the
                                 GPS week corresponding to the last code rollover.  */
-  double receiver_time;    /**< Receiver clock time at which this measurement
-                                is valid in seconds. */
+  double rec_time_delta;   /**< Difference between receiver clock time at which
+                                this measurement is valid and reference time
+                                (seconds). */
   double snr;              /**< Signal to noise ratio. */
   u16 lock_counter;        /**< This number is changed each time the tracking
                                 channel is re-locked or a cycle slip is
@@ -234,7 +235,7 @@ float cn0_est(cn0_est_state_t *s, float I, float Q);
 
 s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
                                navigation_measurement_t *nav_meas[],
-                               double nav_time, const ephemeris_t* e[]);
+                               const ephemeris_t* e[]);
 
 int nav_meas_cmp(const void *a, const void *b);
 u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,

--- a/python/swiftnav/track.pxd
+++ b/python/swiftnav/track.pxd
@@ -163,7 +163,7 @@ cdef extern from "libswiftnav/track.h":
     double carrier_phase
     double carrier_freq
     u32 time_of_week_ms
-    double receiver_time
+    double rec_time_delta
     double snr
     u16 lock_counter
 
@@ -183,7 +183,7 @@ cdef extern from "libswiftnav/track.h":
 
   void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
                                    navigation_measurement_t *nav_meas[],
-                                   double nav_time, const ephemeris_t* e[])
+                                   const ephemeris_t* e[])
   int nav_meas_cmp(const void *a, const void *b)
   u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                   u8 n_old, navigation_measurement_t *m_old,

--- a/python/swiftnav/track.pxd
+++ b/python/swiftnav/track.pxd
@@ -181,9 +181,10 @@ cdef extern from "libswiftnav/track.h":
     gnss_signal_t sid
     u16 lock_counter
 
-  void calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
-                                   navigation_measurement_t *nav_meas[],
-                                   const ephemeris_t* e[])
+  s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
+                                 navigation_measurement_t *nav_meas[],
+                                 const ephemeris_t* e[])
+
   int nav_meas_cmp(const void *a, const void *b)
   u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                   u8 n_old, navigation_measurement_t *m_old,

--- a/python/swiftnav/track.pyx
+++ b/python/swiftnav/track.pyx
@@ -492,7 +492,7 @@ cdef mk_nav_meas_array(py_nav_meas, u8 n_c_nav_meas, navigation_measurement_t *c
     memcpy(&c_nav_meas[i], &sd_, sizeof(navigation_measurement_t))
 
 # TODO (Buro): Remove mallocs, etc. here. Do all this in-place
-def _calc_navigation_measurement(chan_meas, nav_meas, nav_time, ephemerides):
+def _calc_navigation_measurement(chan_meas, nav_meas, ephemerides):
   """
   """
   n_channels = len(chan_meas)
@@ -504,7 +504,7 @@ def _calc_navigation_measurement(chan_meas, nav_meas, nav_time, ephemerides):
     chan_meas_[n] = &((<ChannelMeasurement ?>chan_meas[n])._thisptr)
     nav_meas_[n] = &((<NavigationMeasurement ?>nav_meas[n])._thisptr)
     ephs[n] = &((<Ephemeris ?>ephemerides[n])._thisptr)
-  calc_navigation_measurement(n_channels, chan_meas_, nav_meas_, nav_time, ephs)
+  calc_navigation_measurement(n_channels, chan_meas_, nav_meas_, ephs)
   free(chan_meas_)
   free(nav_meas_)
   free(ephs)

--- a/src/track.c
+++ b/src/track.c
@@ -766,7 +766,7 @@ float cn0_est(cn0_est_state_t *s, float I, float Q)
  */
 s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
                                navigation_measurement_t *nav_meas[],
-                               double nav_time, const ephemeris_t* e[])
+                               const ephemeris_t* e[])
 {
   double TOTs[n_channels];
   double min_TOF = -DBL_MAX;
@@ -775,7 +775,7 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
   for (u8 i=0; i<n_channels; i++) {
     TOTs[i] = 1e-3 * meas[i]->time_of_week_ms;
     TOTs[i] += meas[i]->code_phase_chips / 1.023e6;
-    TOTs[i] += (nav_time - meas[i]->receiver_time) * meas[i]->code_phase_rate / 1.023e6;
+    TOTs[i] -= meas[i]->rec_time_delta * meas[i]->code_phase_rate / 1.023e6;
 
     /** \todo Maybe keep track of week number in tracking channel
         state or derive it from system time. */
@@ -787,7 +787,7 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
     nav_meas[i]->sid = meas[i]->sid;
 
     nav_meas[i]->carrier_phase = meas[i]->carrier_phase;
-    nav_meas[i]->carrier_phase += (nav_time - meas[i]->receiver_time) * meas[i]->carrier_freq;
+    nav_meas[i]->carrier_phase -= meas[i]->rec_time_delta * meas[i]->carrier_freq;
 
     nav_meas[i]->lock_counter = meas[i]->lock_counter;
 


### PR DESCRIPTION
Compute a receiver time delta for each measurement externally instead of passing in `nav_time` and computing it internally. Avoids subtracting two potentially large doubles to get a small number.