### PR TITLE
Add DYLD_LIBRARY_PATH to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,7 @@ Then build the python bindings:
 
     cd ../python
     export LD_LIBRARY_PATH=../build/install/usr/local/lib
+    export DYLD_LIBRARY_PATH=../build/install/usr/local/lib
     tox
 
 Issues


### PR DESCRIPTION
Mac OS uses `DYLD_LIBRARY_PATH` in place of `LD_LIBRARY_PATH`.