### PR TITLE
Check for high RTK DOPs

### DIFF
--- a/include/libswiftnav/baseline.h
+++ b/include/libswiftnav/baseline.h
@@ -55,11 +55,11 @@ void diff_ambs(gnss_signal_t ref_sid, u8 num_ambs, const ambiguity_t *amb_set,
                double *dd_ambs);
 s8 baseline_(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
              u8 num_ambs, const ambiguity_t *single_ambs,
-             u8 *num_used, double b[3],
+             u8 *num_used, gnss_signal_t *used_sids, double b[3],
              bool disable_raim, double raim_threshold);
 s8 baseline(u8 num_sdiffs, const sdiff_t *sdiffs, const double ref_ecef[3],
-            const ambiguities_t *ambs, u8 *num_used, double b[3],
-            bool disable_raim, double raim_threshold);
+            const ambiguities_t *ambs, u8 *num_used, gnss_signal_t *used_sids,
+            double b[3], bool disable_raim, double raim_threshold);
 
 void ambiguities_init(ambiguities_t *ambs);
 s8 lesq_solve_raim(u8 num_dds_u8, const double *dd_obs,

--- a/include/libswiftnav/dgnss_management.h
+++ b/include/libswiftnav/dgnss_management.h
@@ -64,7 +64,7 @@ void dgnss_init_known_baseline(u8 num_sats, sdiff_t *sdiffs, double receiver_ece
 void dgnss_update_ambiguity_state(ambiguity_state_t *s);
 s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                   const double ref_ecef[3], const ambiguity_state_t *s,
-                  u8 *num_used, double b[3],
+                  u8 *num_used, gnss_signal_t *used_sids, double b[3],
                   bool disable_raim, double raim_threshold);
 void measure_amb_kf_b(u8 num_sdiffs, sdiff_t *sdiffs,
                       const double receiver_ecef[3], double *b);

--- a/include/libswiftnav/observation.h
+++ b/include/libswiftnav/observation.h
@@ -48,7 +48,6 @@ u8 make_propagated_sdiffs_wip(u8 n_local, navigation_measurement_t *m_local,
 u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           u8 n_remote, navigation_measurement_t *m_remote,
                           double *remote_dists, double remote_pos_ecef[3],
-                          const ephemeris_t *e[], const gps_time_t *t,
                           sdiff_t *sds);
 
 s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids, u8 num_dds,

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -161,6 +161,7 @@ typedef struct {
 typedef struct {
   double raw_pseudorange;
   double pseudorange;
+  double raw_carrier_phase;
   double carrier_phase;
   double raw_doppler;
   double doppler;
@@ -234,12 +235,12 @@ void cn0_est_init(cn0_est_state_t *s, float bw, float cn0_0,
 float cn0_est(cn0_est_state_t *s, float I, float Q);
 
 s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
-                               navigation_measurement_t *nav_meas[], gps_time_t *nav_time,
+                               navigation_measurement_t *nav_meas[], gps_time_t *rec_time,
                                const ephemeris_t* e[]);
 
 int nav_meas_cmp(const void *a, const void *b);
 u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                 u8 n_old, navigation_measurement_t *m_old,
-                navigation_measurement_t *m_corrected);
+                navigation_measurement_t *m_corrected, double dt);
 
 #endif /* LIBSWIFTNAV_TRACK_H */

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -234,7 +234,7 @@ void cn0_est_init(cn0_est_state_t *s, float bw, float cn0_0,
 float cn0_est(cn0_est_state_t *s, float I, float Q);
 
 s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
-                               navigation_measurement_t *nav_meas[],
+                               navigation_measurement_t *nav_meas[], gps_time_t *nav_time,
                                const ephemeris_t* e[]);
 
 int nav_meas_cmp(const void *a, const void *b);

--- a/python/swiftnav/observation.pxd
+++ b/python/swiftnav/observation.pxd
@@ -40,7 +40,6 @@ cdef extern from "libswiftnav/observation.h":
   u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                             u8 n_remote, navigation_measurement_t *m_remote,
                             double *remote_dists, double remote_pos_ecef[3],
-                            const ephemeris_t *e[], const gps_time_t *t,
                             sdiff_t *sds)
 
   s8 make_dd_measurements_and_sdiffs(gnss_signal_t ref_sid, const gnss_signal_t *non_ref_sids,

--- a/python/swiftnav/observation.pyx
+++ b/python/swiftnav/observation.pyx
@@ -71,8 +71,7 @@ def single_diff_(m_a, m_b):
 # TODO (Buro): special note that there are a bunch of statically
 # declared things in the .c file for observation.c
 
-def make_propagated_sdiffs_(m_local, m_remote, remote_dists, remote_pos_ecef,
-                            es, GpsTime t):
+def make_propagated_sdiffs_(m_local, m_remote, remote_dists, remote_pos_ecef):
   """Propagates remote measurements to a local time and makes
   sdiffs. When we get two sets of observations that aren't time
   matched to each other (but are internally time matched within each
@@ -93,8 +92,6 @@ def make_propagated_sdiffs_(m_local, m_remote, remote_dists, remote_pos_ecef,
   cdef navigation_measurement_t m_local_[32], m_remote_[32]
   mk_nav_meas_array(m_local, n_local, &m_local_[0])
   mk_nav_meas_array(m_remote, n_remote, &m_remote_[0])
-  cdef ephemeris_t** es_ = <ephemeris_t **>malloc(len(es)*sizeof(ephemeris_t *))
-  mk_ephemeris_array(es, len(es), es_)
   # TODO (Buro): These can be moved up into type hints.
   cdef np.ndarray[np.double_t, ndim=1, mode="c"] remote_dists_ \
     = np.array(remote_dists, dtype=np.double)
@@ -106,10 +103,7 @@ def make_propagated_sdiffs_(m_local, m_remote, remote_dists, remote_pos_ecef,
                                            n_remote, &m_remote_[0],
                                            &remote_dists_[0],
                                            &remote_pos_ecef_[0],
-                                           es_,
-                                           &t._thisptr,
                                            &sdiffs_[0])
-  free(es_)
   return read_sdiff_array(n_sats, &sdiffs_[0])
 
 def make_dd_measurements_and_sdiffs_(GNSSSignal ref_sid, non_ref_sids, sdiffs_in):

--- a/python/swiftnav/track.pxd
+++ b/python/swiftnav/track.pxd
@@ -170,6 +170,7 @@ cdef extern from "libswiftnav/track.h":
   ctypedef struct navigation_measurement_t:
     double raw_pseudorange
     double pseudorange
+    double raw_carrier_phase
     double carrier_phase
     double raw_doppler
     double doppler
@@ -183,12 +184,13 @@ cdef extern from "libswiftnav/track.h":
 
   s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
                                  navigation_measurement_t *nav_meas[],
-                                 const ephemeris_t* e[])
+                                 gps_time_t *rec_time, const ephemeris_t* e[])
+
 
   int nav_meas_cmp(const void *a, const void *b)
   u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                   u8 n_old, navigation_measurement_t *m_old,
-                  navigation_measurement_t *m_corrected)
+                  navigation_measurement_t *m_corrected, double dt)
 
 cdef class Correlation:
   cdef correlation_t _thisptr

--- a/python/swiftnav/track.pyx
+++ b/python/swiftnav/track.pyx
@@ -442,11 +442,12 @@ cdef class ChannelMeasurement:
 cdef class NavigationMeasurement:
 
   def __init__(self,
-               raw_pseudorange, pseudorange, carrier_phase, raw_doppler,
-               doppler, sat_pos, sat_vel, snr, lock_time,
+               raw_pseudorange, pseudorange, raw_carrier_phase, carrier_phase,
+               raw_doppler, doppler, sat_pos, sat_vel, snr, lock_time,
                GpsTime tot, GNSSSignal sid, lock_counter):
     self._thisptr.raw_pseudorange = raw_pseudorange
     self._thisptr.pseudorange = pseudorange
+    self._thisptr.raw_carrier_phase = raw_carrier_phase
     self._thisptr.carrier_phase = carrier_phase
     self._thisptr.raw_doppler = raw_doppler
     self._thisptr.doppler = doppler
@@ -492,7 +493,8 @@ cdef mk_nav_meas_array(py_nav_meas, u8 n_c_nav_meas, navigation_measurement_t *c
     memcpy(&c_nav_meas[i], &sd_, sizeof(navigation_measurement_t))
 
 # TODO (Buro): Remove mallocs, etc. here. Do all this in-place
-def _calc_navigation_measurement(chan_meas, nav_meas, ephemerides):
+def _calc_navigation_measurement(chan_meas, nav_meas, GpsTime rec_time,
+                                 ephemerides):
   """
   """
   n_channels = len(chan_meas)
@@ -504,14 +506,15 @@ def _calc_navigation_measurement(chan_meas, nav_meas, ephemerides):
     chan_meas_[n] = &((<ChannelMeasurement ?>chan_meas[n])._thisptr)
     nav_meas_[n] = &((<NavigationMeasurement ?>nav_meas[n])._thisptr)
     ephs[n] = &((<Ephemeris ?>ephemerides[n])._thisptr)
-  calc_navigation_measurement(n_channels, chan_meas_, nav_meas_, ephs)
+  calc_navigation_measurement(n_channels, chan_meas_, nav_meas_,
+                              &rec_time._thisptr, ephs)
   free(chan_meas_)
   free(nav_meas_)
   free(ephs)
   return nav_meas
 
 # TODO (Buro): Remove mallocs, etc. here. Also, wow, this is awful
-def _tdcp_doppler(m_new, m_old):
+def _tdcp_doppler(m_new, m_old, dt):
   n_new = len(m_new)
   n_old = len(m_old)
   n_corrected = min(n_new, n_old)
@@ -525,7 +528,7 @@ def _tdcp_doppler(m_new, m_old):
     m_old_[n] = &((<NavigationMeasurement?>m_old[n])._thisptr)
   for n in range(n_corrected):
     m_corrected_[n] = (<NavigationMeasurement?>m_corrected[n])._thisptr
-  n_written = tdcp_doppler(n_new, m_new_[0], n_old, m_old_[0], m_corrected_)
+  n_written = tdcp_doppler(n_new, m_new_[0], n_old, m_old_[0], m_corrected_, dt)
   free(m_new_)
   free(m_old_)
   free(m_corrected_)

--- a/python/tests/test_observation.py
+++ b/python/tests/test_observation.py
@@ -11,6 +11,7 @@
 
 from swiftnav.ephemeris import Ephemeris
 from swiftnav.pvt import calc_PVT_
+import copy
 import numpy as np
 import pytest
 import swiftnav.time as ti
@@ -23,7 +24,7 @@ nms = \
                            pseudorange=23946993.888943646,
                            raw_pseudorange=23946993.888943646,
                            sat_pos=(-19477278.087422125, -7649508.9457812719, 16674633.163554827),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -31,7 +32,7 @@ nms = \
                            pseudorange=22932174.156858064,
                            raw_pseudorange=22932174.156858064,
                            sat_pos=(-9680013.5408340245, -15286326.354385279, 19429449.383770257),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -39,7 +40,7 @@ nms = \
                            pseudorange=24373231.648055989,
                            raw_pseudorange=24373231.648055989,
                            sat_pos=(-19858593.085281931, -3109845.8288993631, 17180320.439503901),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -47,7 +48,7 @@ nms = \
                            pseudorange=24779663.252316438,
                            raw_pseudorange=24779663.252316438,
                            sat_pos=(6682497.8716542246, -14006962.389166718, 21410456.275678463),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -55,7 +56,7 @@ nms = \
                            pseudorange=26948717.022331879,
                            raw_pseudorange=26948717.022331879,
                            sat_pos=(7415370.9916331079, -24974079.044485383, -3836019.0262199985),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -63,7 +64,7 @@ nms = \
                            pseudorange=23327405.435463827,
                            raw_pseudorange=23327405.435463827,
                            sat_pos=(-2833466.1648670658, -22755197.793894723, 13160322.082875408),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -71,7 +72,7 @@ nms = \
                            pseudorange=27371419.016328193,
                            raw_pseudorange=27371419.016328193,
                            sat_pos=(14881660.383624561, -5825253.4316490609, 21204679.68313824),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -79,7 +80,7 @@ nms = \
                            pseudorange=26294221.697782904,
                            raw_pseudorange=26294221.697782904,
                            sat_pos=(12246530.477279386, -22184711.955107089, 7739084.2855069181),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0)),
@@ -87,7 +88,7 @@ nms = \
                            pseudorange=25781999.479948733,
                            raw_pseudorange=25781999.479948733,
                            sat_pos=(-25360766.249484103, -1659033.490658124, 7821492.0398916304),
-                           sat_vel=(0, 0, 0), carrier_phase=0,
+                           sat_vel=(0, 0, 0), raw_carrier_phase=0, carrier_phase=0,
                            raw_doppler=0, doppler=0, lock_counter=0,
                            snr=0, lock_time=0,
                            tot=ti.GpsTime(tow=0, wn=0))]
@@ -140,49 +141,29 @@ def test_prop_single_diff():
                                       pseudorange=21123480.27105955, doppler=0, raw_doppler=0, carrier_phase=-110993309.26669005,
                                       sat_vel=[-1025.0370403901404, -1821.9217799467374, -2091.6303199092254],
                                       lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.92954684512),
-                                      raw_pseudorange=21121324.476403236,
+                                      raw_pseudorange=21121324.476403236, raw_carrier_phase=-110993309.26669005,
                                       snr=30.0, sid=s.GNSSSignal(code=0, sat=0), lock_counter=0),
               t.NavigationMeasurement(sat_pos=[-16580310.849158794, 918714.1939749047, 20731444.258332774],
                                       pseudorange=22432049.84763688, doppler=0, raw_doppler=0, carrier_phase=-117882743.21601027,
                                       sat_vel=[1060.9864205977192, -2411.43509917502, 953.6270954519971],
                                       lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.9251737675),
-                                      raw_pseudorange=22432340.166121125,
+                                      raw_pseudorange=22432340.166121125, raw_carrier_phase=-117882743.21601027,
                                       snr=30.0, sid=s.GNSSSignal(code=0, sat=2), lock_counter=0)]
-  remote_dists = np.array([ 21121393.87562408,  22432814.46819838])
-  base_pos = np.array( [-2704375, -4263211,  3884637])
-  es = [Ephemeris(**{'ura': 0.0, 'healthy': 1,
-                     'xyz': {'acc': [-6.51925802230835e-08, 4.718410826464475e-09, 2.6226835183928943],
-                             'iod': 0, 'a_gf0': 5153.648313522339, 'a_gf1': 0.5977821557062277,
-                             'pos': [5.122274160385132e-09, 19.0625, 259.9375],
-                             'rate': [1.0151416063308716e-06, 6.260350346565247e-06, -6.332993507385254e-08],
-                             'toa': 4096},
-                     'valid': 1,
-                     'sid': {'code': 0, 'sat': 0},
-                     'toe': {'wn': 1876, 'tow': 172800.0},
-                     'kepler': {'inc_dot': 4.4966158735287064e-10, 'tgd': 5.122274160385132e-09, 'omegadot': -8.099980253833005e-09,
-                                'sqrta': 5153.648313522339, 'inc': 0.9634151551139846, 'cus': 6.260350346565247e-06,
-                                'omega0': 0.5977821557062277, 'cuc': 1.0151416063308716e-06, 'm0': 2.6226835183928943,
-                                'toc': {'wn': 1876, 'tow': 172800.0}, 'dn': 4.718410826464475e-09, 'ecc': 0.0049016030970960855,
-                                'cic': -6.332993507385254e-08, 'crs': 19.0625, 'iode': 74, 'iodc': 21845, 'cis': -6.51925802230835e-08,
-                                'crc': 259.9375, 'w': 0.4885959643259506, 'af0': 7.212162017822266e-06, 'af1': 9.094947017729282e-13, 'af2': 0.0},
-                     'fit_interval': 14400}),
-        Ephemeris(**{'ura': 0.0, 'healthy': 1,
-                     'xyz': {'acc': [-6.146728992462158e-08, 4.742340394655613e-09, -0.8114190126645531], 'iod': 0,
-                             'a_gf0': 5153.798839569092, 'a_gf1': 1.6390180338742641,
-                             'pos': [1.862645149230957e-09, -40.5625, 221.625],
-                             'rate': [-2.2239983081817627e-06, 8.001923561096191e-06, 3.725290298461914e-09], 'toa': 0},
-                     'valid': 1,
-                     'sid': {'code': 0, 'sat': 2},
-                     'toe': {'wn': 1876, 'tow': 172800.0},
-                     'kepler': {'inc_dot': -4.475186409476941e-10, 'tgd': 1.862645149230957e-09, 'omegadot': -8.103551831174965e-09,
-                                'sqrta': 5153.798839569092, 'inc': 0.9587534715647247, 'cus': 8.001923561096191e-06,
-                                'omega0': 1.6390180338742641, 'cuc': -2.2239983081817627e-06, 'm0': -0.8114190126645531,
-                                'toc': {'wn': 1876, 'tow': 172800.0}, 'dn': 4.742340394655613e-09, 'ecc': 0.00035172002390027046,
-                                'cic': 3.725290298461914e-09, 'crs': -40.5625, 'iode': 59, 'iodc': 21845, 'cis': -6.146728992462158e-08,
-                                'crc': 221.625, 'w': 2.9037284161724037, 'af0': -9.969808161258698e-07, 'af1': -5.229594535194337e-12, 'af2': 0.0},
-                     'fit_interval': 14400})]
-  gpst = ti.GpsTime(wn=1876, tow=167132)
-  sdiffs = o.make_propagated_sdiffs_(rover_nm, rover_nm, remote_dists, base_pos, es, gpst)
+  base_nm = [t.NavigationMeasurement(sat_pos=[-19277279.74504115, -8215892.62052003, 16367597.39238895],
+                                      pseudorange=21123480.27105955, doppler=0, raw_doppler=0, carrier_phase=-110993309.26669005,
+                                      sat_vel=[-1025.03418813, -1821.90205153, -2091.65477547],
+                                      lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.92954684512),
+                                      raw_pseudorange=21121324.476403236, raw_carrier_phase=-110993309.26669005,
+                                      snr=30.0, sid=s.GNSSSignal(code=0, sat=0), lock_counter=0),
+              t.NavigationMeasurement(sat_pos=[-16580231.46081397, 918533.75723257, 20731515.61249766],
+                                      pseudorange=22432049.84763688, doppler=0, raw_doppler=0, carrier_phase=-117882743.21601027,
+                                      sat_vel=[1060.97989026, -2411.44777346, 953.59410165],
+                                      lock_time=0, tot=ti.GpsTime(wn=1876, tow=167131.9251737675),
+                                      raw_pseudorange=22432340.166121125, raw_carrier_phase=-117882743.21601027,
+                                      snr=30.0, sid=s.GNSSSignal(code=0, sat=2), lock_counter=0)]
+  remote_dists = np.array([ 21121393.87562408, 22432814.46819838])
+  base_pos = np.array( [-2704375, -4263211, 3884637])
+  sdiffs = o.make_propagated_sdiffs_(rover_nm, base_nm, remote_dists, base_pos)
   assert len(sdiffs) == 2
   assert sdiffs[0].pseudorange > 0
   assert sdiffs[1].pseudorange > 0

--- a/src/baseline.c
+++ b/src/baseline.c
@@ -409,8 +409,9 @@ static bool chi_test(double threshold, u8 num_dds,
  *
  *   -`-1`: < 3 dds
  *   -`-2`: dgelsy  error (see lesq_solution_float)
- *   -`-3`: raim check failed, repair failed
+ *   -`-3`: raim check failed, repair failed, ref satellite was bad
  *   -`-4`: raim check failed, not enough sats for repair
+ *   -`-5`: raim check failed, repair failed, more than one acceptable solution
  */
 /* TODO(dsk) update all call sites to use n_used as calculated here.
  * TODO(dsk) add warn/info logging to call sites when repair occurs.

--- a/src/baseline.c
+++ b/src/baseline.c
@@ -501,7 +501,7 @@ s8 lesq_solve_raim(u8 num_dds_u8, const double *dd_obs,
     if (n_used) {
       *n_used = 0;
     }
-    return -3;
+    return -5;
   }
 }
 

--- a/src/dgnss_management.c
+++ b/src/dgnss_management.c
@@ -435,6 +435,8 @@ void dgnss_update_ambiguity_state(ambiguity_state_t *s)
  * \param s           Current ambiguity test state.
  * \param num_used    Output number of sdiffs actually used in the baseline
  *                    estimate.
+ * \param used_sids   Pointer to where to store the sids of satellites used in
+ *                    the baseline solution, length `num_used`
  * \param b           Output baseline.
  * \param disable_raim Flag to turn off raim checks/repair.
  * \param raim_threshold raim check threshold
@@ -444,7 +446,7 @@ void dgnss_update_ambiguity_state(ambiguity_state_t *s)
  */
 s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                   const double ref_ecef[3], const ambiguity_state_t *s,
-                  u8 *num_used, double b[3],
+                  u8 *num_used, gnss_signal_t *used_sids, double b[3],
                   bool disable_raim, double raim_threshold)
 {
 
@@ -474,8 +476,8 @@ s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
     log_debug("  %u: %f", s->float_ambs.sids[i].sat, s->float_ambs.ambs[i]);
   }
 
-  s8 ret = baseline(num_sdiffs, sdiffs, ref_ecef, &s->fixed_ambs, num_used, b,
-                    disable_raim, raim_threshold);
+  s8 ret = baseline(num_sdiffs, sdiffs, ref_ecef, &s->fixed_ambs, num_used,
+                    used_sids, b, disable_raim, raim_threshold);
   if (ret >= 0) {
     if (ret == 1) /* TODO: Export this rather than just printing */
     {
@@ -489,8 +491,8 @@ s8 dgnss_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
   }
   /* We weren't able to get an IAR resolved baseline, check if we can get a
    * float baseline. */
-  if ((ret = baseline(num_sdiffs, sdiffs, ref_ecef, &s->float_ambs, num_used, b,
-                      disable_raim, raim_threshold))
+  if ((ret = baseline(num_sdiffs, sdiffs, ref_ecef, &s->float_ambs, num_used,
+                      used_sids, b, disable_raim, raim_threshold))
         >= 0) {
     if (ret == 1) /* TODO: Export this rather than just printing */
     {

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -261,7 +261,6 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
 
   /* TODO: Implement convergence test using integer difference of doubles,
    * http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm */
-  /* TODO: Bound number of iterations. */
   do {
     ea_old = ea;
     temp = 1.0 - ecc * cos(ea_old);

--- a/src/observation.c
+++ b/src/observation.c
@@ -60,7 +60,7 @@ static void single_diff_(void *context, u32 n, const void *a, const void *b)
 
   sds[n].sid = m_a->sid;
   sds[n].pseudorange = m_a->raw_pseudorange - m_b->raw_pseudorange;
-  sds[n].carrier_phase = m_a->carrier_phase - m_b->carrier_phase;
+  sds[n].carrier_phase = m_a->raw_carrier_phase - m_b->raw_carrier_phase;
   sds[n].doppler = m_a->raw_doppler - m_b->raw_doppler;
   sds[n].snr = MIN(m_a->snr, m_b->snr);
   sds[n].lock_counter = m_a->lock_counter + m_b->lock_counter;
@@ -168,16 +168,12 @@ int cmp_sid_sdiff(const void *a, const void *b)
  *                           correspond to the i-th element of m_remote).
  * \param remote_pos_ecef   The position of the remote receiver (presumed
  *                           constant in ecef).
- * \param e                 Array of pointers to ephemerides corresponding
- *                          to the signals in m_local
- * \param t
  * \param sds               The single differenced propagated measurements.
  * \return The number of sats common in both local and remote sdiffs.
  */
 u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
                           u8 n_remote, navigation_measurement_t *m_remote,
                           double *remote_dists, double remote_pos_ecef[3],
-                          const ephemeris_t *e[], const gps_time_t *t,
                           sdiff_t *sds)
 {
   u8 i, j, n = 0;
@@ -189,19 +185,8 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
     else if (sid_compare(m_local[i].sid, m_remote[j].sid) > 0)
       i--;
     else {
-      double clock_err;
-      double clock_rate_err;
-      double local_sat_pos[3];
-      double local_sat_vel[3];
-      if (calc_sat_state(e[i], t, local_sat_pos, local_sat_vel,
-                     &clock_err, &clock_rate_err) != 0) {
-        continue;
-      }
       sds[n].sid = m_local[i].sid;
-      double dx = local_sat_pos[0] - remote_pos_ecef[0];
-      double dy = local_sat_pos[1] - remote_pos_ecef[1];
-      double dz = local_sat_pos[2] - remote_pos_ecef[2];
-      double new_dist = sqrt( dx * dx + dy * dy + dz * dz);
+      double new_dist = vector_distance(3, m_local[i].sat_pos, remote_pos_ecef);
       double dist_diff = new_dist - remote_dists[j];
       /* Explanation:
        * pseudorange = dist + c
@@ -218,15 +203,15 @@ u8 make_propagated_sdiffs(u8 n_local, navigation_measurement_t *m_local,
       sds[n].pseudorange = m_local[i].raw_pseudorange
                          - (m_remote[j].raw_pseudorange
                             + dist_diff);
-      sds[n].carrier_phase = m_local[i].carrier_phase
-                           - (m_remote[j].carrier_phase
+      sds[n].carrier_phase = m_local[i].raw_carrier_phase
+                           - (m_remote[j].raw_carrier_phase
                               - dist_diff / GPS_L1_LAMBDA);
 
       /* Doppler is not propagated.
        * sds[n].doppler = m_local[i].raw_doppler - m_remote[j].raw_doppler; */
       sds[n].snr = MIN(m_local[i].snr, m_remote[j].snr);
-      memcpy(&(sds[n].sat_pos), &(local_sat_pos[0]), 3*sizeof(double));
-      memcpy(&(sds[n].sat_vel), &(local_sat_vel[0]), 3*sizeof(double));
+      memcpy(sds[n].sat_pos, m_local[i].sat_pos, sizeof(m_local[i].sat_pos));
+      memcpy(sds[n].sat_vel, m_local[i].sat_vel, sizeof(m_local[i].sat_vel));
 
       n++;
     }

--- a/src/pvt.c
+++ b/src/pvt.c
@@ -256,8 +256,8 @@ static double pvt_solve(double rx_state[],
 
 static u8 filter_solution(gnss_solution* soln, dops_t* dops)
 {
-  if (dops->pdop > 50.0)
-    /* PDOP is too high to yield a good solution. */
+  if (dops->gdop > 50.0)
+    /* GDOP is too high to yield a good solution. */
     return 1;
 
   if (soln->pos_llh[2] < -1e3 || soln->pos_llh[2] > 1e6)
@@ -482,7 +482,7 @@ static s8 pvt_solve_raim(double rx_state[],
  *  e.g. `pvt_err_msg[-ret - 1]`
  *    where `ret` is the return value of calc_PVT(). */
 const char *pvt_err_msg[] = {
-  "PDOP too high",
+  "GDOP too high (>50)",
   "Altitude unreasonable",
   "Velocity >= 1000 kts",
   "RAIM repair attempted, failed",
@@ -502,7 +502,7 @@ const char *pvt_err_msg[] = {
  *   -  `2`: Solution converged but RAIM unavailable or disabled
  *   -  `1`: Solution converged, failed RAIM but was successfully repaired
  *   -  `0`: Solution converged and verified by RAIM
- *   - `-1`: PDOP is too high to yield a good solution.
+ *   - `-1`: GDOP is too high to yield a good solution.
  *   - `-2`: Altitude is unreasonable.
  *   - `-3`: Velocity is greater than or equal to 1000 kts.
  *   - `-4`: RAIM check failed and repair was unsuccessful

--- a/src/pvt.c
+++ b/src/pvt.c
@@ -497,7 +497,7 @@ const char *pvt_err_msg[] = {
  * \param nav_meas array of measurements
  * \param disable_raim passing True will omit raim check/repair functionality
  * \param soln output solution struct
- * \param dops output doppler information
+ * \param dops output dilution of precision information
  * \return Non-negative values indicate a valid solution.
  *   -  `2`: Solution converged but RAIM unavailable or disabled
  *   -  `1`: Solution converged, failed RAIM but was successfully repaired
@@ -576,8 +576,8 @@ s8 calc_PVT(const u8 n_used,
   soln->clock_offset = rx_state[3] / GPS_C;
   soln->clock_bias = rx_state[7] / GPS_C;
 
-  /* Time at receiver is TOT plus time of flight. Time of flight is eqaul to
-   * the pseudorange minus the clock bias. */
+  /* Time at receiver is TOT plus time of flight. Time of flight is equal to
+   * the pseudorange minus the clock offset. */
   soln->time = nav_meas[0].tot;
   soln->time.tow += nav_meas[0].pseudorange / GPS_C;
   /* Subtract clock offset. */

--- a/src/rtcm3.c
+++ b/src/rtcm3.c
@@ -255,7 +255,7 @@ static void gen_obs_gps(navigation_measurement_t *nm,
   double prc = *pr * 0.02 + *amb * PRUNIT_GPS;
 
   /* L1 phaserange - L1 pseudorange */
-  double cp_pr = nm->carrier_phase - prc / (CLIGHT / FREQ1);
+  double cp_pr = nm->raw_carrier_phase - prc / (CLIGHT / FREQ1);
 
   /* If the phaserange and pseudorange have diverged close to the limits of the
    * data field (20 bits) then we modify the carrier phase by an integer amount
@@ -265,7 +265,7 @@ static void gen_obs_gps(navigation_measurement_t *nm,
    * +/- 1379 cycles. Limit to just 1000 as that should still be plenty. */
   if (fabs(cp_pr) > 1000) {
     nm->lock_time = 0;
-    nm->carrier_phase -= (s32)cp_pr;
+    nm->raw_carrier_phase -= (s32)cp_pr;
     cp_pr -= (s32)cp_pr;
   }
 
@@ -372,7 +372,7 @@ s8 rtcm3_decode_1002(u8 *buff, u16 *id, double *tow, u8 *n_sat,
     u8 cnr = getbitu(buff, bit, 8); bit += 8;
 
     nm[i].raw_pseudorange = 0.02*pr + PRUNIT_GPS*amb;
-    nm[i].carrier_phase = (nm[i].raw_pseudorange + 0.0005*ppr) / (CLIGHT / FREQ1);
+    nm[i].raw_carrier_phase = (nm[i].raw_pseudorange + 0.0005*ppr) / (CLIGHT / FREQ1);
     nm[i].lock_time = from_lock_ind(lock);
     nm[i].snr = pow(10.0, ((cnr / 4.0) - 40.0) / 10.0);
   }

--- a/src/track.c
+++ b/src/track.c
@@ -784,13 +784,13 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
     /* Compute the time of transmit of the signal on the satellite from the
      * tracking loop parameters. This will be used to compute the pseudorange. */
     nav_meas[i]->tot.tow = 1e-3 * meas[i]->time_of_week_ms;
-    nav_meas[i]->tot.tow += meas[i]->code_phase_chips / 1.023e6;
-    nav_meas[i]->tot.tow -= meas[i]->rec_time_delta * meas[i]->code_phase_rate / 1.023e6;
+    nav_meas[i]->tot.tow += meas[i]->code_phase_chips / GPS_CA_CHIPPING_RATE;
+    nav_meas[i]->tot.tow -= meas[i]->rec_time_delta * meas[i]->code_phase_rate / GPS_CA_CHIPPING_RATE;
     /* For now use the week number from the ephemeris. */
     /* TODO: Should we use a more reliable source for the week number? */
     /* TODO (Leith): There might be a bug where ephmeris ToW is set to 0 */
     /* near end of the week, without ToW being rolled over? */
-    /* It woukd this functions' assumptions to break. */
+    /* It would cause this functions' assumptions to break. */
     gps_time_match_weeks(&nav_meas[i]->tot, &e[i]->toe);
 
     /* Compute the carrier phase measurement. */
@@ -820,7 +820,7 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
     /* If we were given a time, use that. */
     tor = *rec_time;
   } else {
-    /* If we were not given a recieve time then we can just set one of the
+    /* If we were not given a time of reception then we can just set one of the
      * pseudoranges aribtrarily to a nominal value and reference all the other
      * pseudoranges to that. This doesn't affect the PVT solution but does
      * potentially correspond to a large receiver clock error. */
@@ -870,7 +870,7 @@ int nav_meas_cmp(const void *a, const void *b)
  * \param n_old Number of measurements in `m_old`
  * \param m_old Array of old navigation measurements, sorted by PRN
  * \param m_corrected Array in which to store the output measurements
- * \param dt The difference in receiver time betweeb the two measurements
+ * \param dt The difference in receiver time between the two measurements
  * \return The number of measurements written to `m_tdcp`
  */
 u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,

--- a/src/track.c
+++ b/src/track.c
@@ -761,26 +761,19 @@ float cn0_est(cn0_est_state_t *s, float I, float Q)
 
 /** Calculate observations from tracking channel measurements.
  *
- * This function takes an array of pointers, for a version taking a flat array
- * see calc_navigation_measurement().
- *
  * \param n_channels Number of tracking channel measurements
  * \param meas Array of pointers to tracking channel measurements, length
  *             `n_channels`
  * \param nav_meas Array of pointers of where to store the output observations,
  *                 length `n_channels`
- * \param nav_time_tc Receiver time at which to calculate the position solution
- *                    in seconds
- * \param nav_time Pointer to GPS time at which to calculate the position
- *                 solution. Can be `NULL` in which case one of the
- *                 pseudoranges is chosen as a reference and set to a nominal
- *                 range, implying a certain receiver clock error
- * \param ephemerides Array of pointers to ephemerides
- * \return  0 on success,
- *         -1 if ephemeris is invalid
+ * \param rec_time Pointer to an estimate of the current GPS time. Can be `NULL`
+                   in which case one of the pseudoranges is chosen as a
+                   reference and set to a nominal range, implying a certain
+                   receiver clock error.
+ * \param e Array of pointers to ephemerides
  */
 s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[],
-                               navigation_measurement_t *nav_meas[], gps_time_t *nav_time,
+                               navigation_measurement_t *nav_meas[], gps_time_t *rec_time,
                                const ephemeris_t* e[])
 {
   double clock_err[n_channels], clock_rate_err[n_channels];
@@ -795,11 +788,14 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
     nav_meas[i]->tot.tow -= meas[i]->rec_time_delta * meas[i]->code_phase_rate / 1.023e6;
     /* For now use the week number from the ephemeris. */
     /* TODO: Should we use a more reliable source for the week number? */
+    // TODO there might be a bug where ephmeris tow is set to 0 near end of week? without tow being rolled over?
+    // causes this functions assimption to break
     gps_time_match_weeks(&nav_meas[i]->tot, &e[i]->toe);
+    //gps_time_match_weeks(&nav_meas[i]->tot, rec_time); // TODO seems to cause a crash?
 
     /* Compute the carrier phase measurement. */
-    nav_meas[i]->carrier_phase = meas[i]->carrier_phase;
-    nav_meas[i]->carrier_phase -= meas[i]->rec_time_delta * meas[i]->carrier_freq;
+    nav_meas[i]->raw_carrier_phase = meas[i]->carrier_phase;
+    nav_meas[i]->raw_carrier_phase -= meas[i]->rec_time_delta * meas[i]->carrier_freq;
 
     /* For raw Doppler we use the instantaneous carrier frequency from the
      * tracking loop. */
@@ -820,9 +816,9 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
   /* To calculate the pseudorange from the time of transmit we need the local
    * time of reception. */
   gps_time_t tor;
-  if (nav_time) {
+  if (rec_time) {
     /* If we were given a time, use that. */
-    tor = *nav_time;
+    tor = *rec_time;
   } else {
     /* If we were not given a recieve time then we can just set one of the
      * pseudoranges aribtrarily to a nominal value and reference all the other
@@ -838,10 +834,12 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
      * light. */
     nav_meas[i]->raw_pseudorange = GPS_C * gpsdifftime(&tor, &nav_meas[i]->tot);
 
-    /* The corrected pseudorange and Doppler applies the clock error and clock
-     * rate error correction from the ephemeris respectively. */
+    /* The corrected pseudorange, carrier_phase, Doppler applies the clock error
+     * and clock rate error correction from the ephemeris respectively. */
     nav_meas[i]->pseudorange = nav_meas[i]->raw_pseudorange
                                + clock_err[i] * GPS_C;
+    nav_meas[i]->carrier_phase = nav_meas[i]->raw_carrier_phase
+                                 - clock_err[i] * GPS_L1_HZ;
     nav_meas[i]->doppler = nav_meas[i]->raw_doppler
                            + clock_rate_err[i] * GPS_L1_HZ;
 
@@ -872,11 +870,12 @@ int nav_meas_cmp(const void *a, const void *b)
  * \param n_old Number of measurements in `m_old`
  * \param m_old Array of old navigation measurements, sorted by PRN
  * \param m_corrected Array in which to store the output measurements
+ * \param dt The difference in receiver time betweeb the two measurements
  * \return The number of measurements written to `m_tdcp`
  */
 u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
                 u8 n_old, navigation_measurement_t *m_old,
-                navigation_measurement_t *m_corrected)
+                navigation_measurement_t *m_corrected, double dt)
 {
   /* Sort m_new, m_old should already be sorted. */
   qsort(m_new, n_new, sizeof(navigation_measurement_t), nav_meas_cmp);
@@ -895,12 +894,11 @@ u8 tdcp_doppler(u8 n_new, navigation_measurement_t *m_new,
       /* Calculate the Doppler correction between raw and corrected. */
       double dopp_corr = m_corrected[n].doppler - m_corrected[n].raw_doppler;
       /* Calculate raw Doppler from time difference of carrier phase. */
-      /* TODO: check that using difference of TOTs here is a valid
-       * approximation. */
-      m_corrected[n].raw_doppler = (m_new[i].carrier_phase - m_old[j].carrier_phase)
-                                    / gpsdifftime(&m_new[i].tot, &m_old[j].tot);
+      m_corrected[n].raw_doppler = (m_new[i].raw_carrier_phase - m_old[j].raw_carrier_phase)
+                                    / dt;
       /* Re-apply the same correction to the raw Doppler to get the corrected Doppler. */
-      m_corrected[n].doppler = m_corrected[n].raw_doppler + dopp_corr;
+      m_corrected[n].doppler = (m_new[i].carrier_phase - m_old[j].carrier_phase)
+                                    / dt + dopp_corr;
       n++;
     }
   }

--- a/src/track.c
+++ b/src/track.c
@@ -788,10 +788,10 @@ s8 calc_navigation_measurement(u8 n_channels, const channel_measurement_t *meas[
     nav_meas[i]->tot.tow -= meas[i]->rec_time_delta * meas[i]->code_phase_rate / 1.023e6;
     /* For now use the week number from the ephemeris. */
     /* TODO: Should we use a more reliable source for the week number? */
-    // TODO there might be a bug where ephmeris tow is set to 0 near end of week? without tow being rolled over?
-    // causes this functions assimption to break
+    /* TODO (Leith): There might be a bug where ephmeris ToW is set to 0 */
+    /* near end of the week, without ToW being rolled over? */
+    /* It woukd this functions' assumptions to break. */
     gps_time_match_weeks(&nav_meas[i]->tot, &e[i]->toe);
-    //gps_time_match_weeks(&nav_meas[i]->tot, rec_time); // TODO seems to cause a crash?
 
     /* Compute the carrier phase measurement. */
     nav_meas[i]->raw_carrier_phase = meas[i]->carrier_phase;

--- a/tests/check_baseline.c
+++ b/tests/check_baseline.c
@@ -307,12 +307,18 @@ START_TEST(test_baseline_ref_first)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
-  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
 
   fail_unless(valid == 0);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.742242));
   fail_unless(within_epsilon(b[1], -0.492905));
   fail_unless(within_epsilon(b[2], -0.0533294));
@@ -334,12 +340,18 @@ START_TEST(test_baseline_ref_middle)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
-  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
 
   fail_unless(valid == 0);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.622609));
   fail_unless(within_epsilon(b[1], -0.432371));
   fail_unless(within_epsilon(b[2], -0.00461595));
@@ -364,12 +376,18 @@ START_TEST(test_baseline_ref_end)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
-  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
 
   fail_unless(valid == 0);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.589178));
   fail_unless(within_epsilon(b[1], -0.35166));
   fail_unless(within_epsilon(b[2], 0.0288157));
@@ -402,12 +420,18 @@ START_TEST(test_baseline_fixed_point)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
-  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
 
   fail_unless(valid == 0);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], b_orig[0]));
   fail_unless(within_epsilon(b[1], b_orig[1]));
   fail_unless(within_epsilon(b[2], b_orig[2]));
@@ -424,9 +448,10 @@ START_TEST(test_baseline_few_sats)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
-  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = baseline(num_sdiffs, sdiffs, ref_ecef, &ambs, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
 
   fail_unless(valid == -1);
 }

--- a/tests/check_dgnss_management.c
+++ b/tests/check_dgnss_management.c
@@ -208,23 +208,34 @@ START_TEST(test_dgnss_baseline_1)
 
   double b[3];
   u8 num_used;
+  gnss_signal_t used_sids[5];
 
   /* Float only */
   s.fixed_ambs.n = 0;
-  s8 valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  s8 valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == 2);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.742242));
   fail_unless(within_epsilon(b[1], -0.492905));
   fail_unless(within_epsilon(b[2], -0.0533294));
 
   /* Fixed and float */
   s.fixed_ambs.n = 4;
-  valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == 1);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.417486));
   fail_unless(within_epsilon(b[1], -0.358386));
   fail_unless(within_epsilon(b[2],  0.271427));
@@ -232,10 +243,15 @@ START_TEST(test_dgnss_baseline_1)
   /* No solution possible */
   s.fixed_ambs.n = 0;
   s.float_ambs.n = 0;
-  valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, b,
-    false, DEFAULT_RAIM_THRESHOLD);
+  valid = dgnss_baseline(num_sdiffs, sdiffs, ref_ecef, &s, &num_used, used_sids,
+    b, false, DEFAULT_RAIM_THRESHOLD);
   fail_unless(valid == -1);
   fail_unless(num_used == 5);
+  fail_unless(used_sids[0].sat == 1);
+  fail_unless(used_sids[1].sat == 2);
+  fail_unless(used_sids[2].sat == 3);
+  fail_unless(used_sids[3].sat == 4);
+  fail_unless(used_sids[4].sat == 5);
   fail_unless(within_epsilon(b[0], -0.417486));
   fail_unless(within_epsilon(b[1], -0.358386));
   fail_unless(within_epsilon(b[2],  0.271427));

--- a/tests/check_observation.c
+++ b/tests/check_observation.c
@@ -6,7 +6,7 @@
 navigation_measurement_t nm1 = {
   .sid = {.sat = 1},
   .raw_pseudorange = 11,
-  .carrier_phase = 12,
+  .raw_carrier_phase = 12,
   .raw_doppler = 13,
   .snr = 14,
   .sat_pos = {1, 2, 3},
@@ -15,7 +15,7 @@ navigation_measurement_t nm1 = {
 navigation_measurement_t nm1_2 = {
   .sid = {.sat = 1},
   .raw_pseudorange = 111,
-  .carrier_phase = 112,
+  .raw_carrier_phase = 112,
   .raw_doppler = 113,
   .snr = 114,
   .sat_pos = {7, 8, 9},
@@ -24,7 +24,7 @@ navigation_measurement_t nm1_2 = {
 navigation_measurement_t nm2 = {
   .sid = {.sat = 2},
   .raw_pseudorange = 21,
-  .carrier_phase = 22,
+  .raw_carrier_phase = 22,
   .raw_doppler = 23,
   .snr = 224,
   .sat_pos = {1, 2, 3},
@@ -33,7 +33,7 @@ navigation_measurement_t nm2 = {
 navigation_measurement_t nm2_2 = {
   .sid = {.sat = 2},
   .raw_pseudorange = 221,
-  .carrier_phase = 222,
+  .raw_carrier_phase = 222,
   .raw_doppler = 223,
   .snr = 24,
   .sat_pos = {13, 14, 15},
@@ -42,7 +42,7 @@ navigation_measurement_t nm2_2 = {
 navigation_measurement_t nm3 = {
   .sid = {.sat = 3},
   .raw_pseudorange = 31,
-  .carrier_phase = 32,
+  .raw_carrier_phase = 32,
   .raw_doppler = 33,
   .snr = 34,
   .sat_pos = {1, 2, 3},
@@ -51,7 +51,7 @@ navigation_measurement_t nm3 = {
 navigation_measurement_t nm4 = {
   .sid = {.sat = 4},
   .raw_pseudorange = 41,
-  .carrier_phase = 42,
+  .raw_carrier_phase = 42,
   .raw_doppler = 43,
   .snr = 44,
   .sat_pos = {1, 2, 3},

--- a/tests/check_rtcm3.c
+++ b/tests/check_rtcm3.c
@@ -135,7 +135,7 @@ START_TEST(test_rtcm3_encode_decode)
   for (u8 i=0; i<22; i++) {
     nm[i].sid.sat = i;
     nm[i].raw_pseudorange = frand(19e6, 21e6);
-    nm[i].carrier_phase = frand(-5e5, 5e5);
+    nm[i].raw_carrier_phase = frand(-5e5, 5e5);
     nm[i].lock_time = frand(0, 1000);
     nm[i].snr = frand(0, 20);
   }
@@ -174,9 +174,9 @@ START_TEST(test_rtcm3_encode_decode)
     fail_unless(fabs(pr_err) < 0.02, "[%d] pseudorange error > 0.04m - "
         "decoded %f, expected %f, error %f", i, nm_out[i].raw_pseudorange, nm[i].raw_pseudorange, pr_err);
 
-    double carr_err = nm[i].carrier_phase - nm_out[i].carrier_phase;
+    double carr_err = nm[i].raw_carrier_phase - nm_out[i].raw_carrier_phase;
     fail_unless(fabs(carr_err) < 0.003, "carrier phase error (fractional part) > 0.003 cycles - "
-        "[%d] decoded %f, expected %f, error %f", i, nm_out[i].carrier_phase, nm[i].carrier_phase, carr_err);
+        "[%d] decoded %f, expected %f, error %f", i, nm_out[i].raw_carrier_phase, nm[i].raw_carrier_phase, carr_err);
 
     double snr_err = nm[i].snr - nm_out[i].snr;
     /* Calculate error bound on SNR given logarithmic error bound on CNR. */
@@ -188,10 +188,10 @@ START_TEST(test_rtcm3_encode_decode)
         "lock time should be zero when adjusting int. amb. - [%d] decoded %f",
         i, nm_out[i].lock_time, nm[i].lock_time);
 
-    double cp_adj = nm[i].carrier_phase - nm_orig[i].carrier_phase;
+    double cp_adj = nm[i].raw_carrier_phase - nm_orig[i].raw_carrier_phase;
     fail_unless(fmod(cp_adj, 1.0) == 0,
         "carrier phase adjusted by non integer amount %f -> %f (%f)",
-        nm_orig[i].carrier_phase, nm[i].carrier_phase, cp_adj);
+        nm_orig[i].raw_carrier_phase, nm[i].raw_carrier_phase, cp_adj);
   }
 
   /* Re-encode after adjustment, now there should be no further adjustment and
@@ -204,9 +204,9 @@ START_TEST(test_rtcm3_encode_decode)
   rtcm3_decode_1002(buff, &id, &tow_out, &n_sat, nm_out, &sync);
 
   for (u8 i=0; i<22; i++) {
-    double cp_adj = nm_out[i].carrier_phase - nm[i].carrier_phase;
+    double cp_adj = nm_out[i].raw_carrier_phase - nm[i].raw_carrier_phase;
     fail_unless(cp_adj < 0.003, "carrier phase re-adjusted %f -> %f (%f)",
-        nm[i].carrier_phase, nm_out[i].carrier_phase, cp_adj);
+        nm[i].raw_carrier_phase, nm_out[i].raw_carrier_phase, cp_adj);
 
     fail_unless(nm_out[i].lock_time <= nm[i].lock_time,
         "lock time error, should always be less than input lock time - [%d] decoded %f, expected %f",


### PR DESCRIPTION
This PR allows returning the list of satellites used in the RTK solution. This allows https://github.com/swift-nav/piksi_firmware/pull/685 to filter out solutions with a high PDOP.

The SPP DOP filter is also changed to check GDOP instead of PDOP, (since receiver time is also an important function of the SPP filter) and reduces the threshold from 50 to 20, per @anth-cole advice.

This PR is based on top of the CORS PR https://github.com/swift-nav/libswiftnav/pull/334 so that must be merged first.

/cc @swift-nav/firmware @swift-nav/estimation 
