### PR TITLE
Add Iono decoder

### DIFF
--- a/include/libswiftnav/ephemeris.h
+++ b/include/libswiftnav/ephemeris.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Swift Navigation Inc.
+ * Copyright (C) 2010, 2016 Swift Navigation Inc.
  * Contact: Henry Hallam <henry@swift-nav.com>
  *          Fergus Noble <fergus@swift-nav.com>
  *

--- a/include/libswiftnav/ionosphere.h
+++ b/include/libswiftnav/ionosphere.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Swift Navigation Inc.
+ * Copyright (C) 2015, 2016 Swift Navigation Inc.
  * Contact: Leith Bade <leith@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -26,5 +26,7 @@ double calc_ionosphere(const gps_time_t *t_gps,
                        double lat_u, double lon_u,
                        double a, double e,
                        const ionosphere_t *i);
+
+void decode_iono_parameters(const u32 *subframe4_words, ionosphere_t *iono);
 
 #endif /* LIBSWIFTNAV_IONOSHPERE_H */

--- a/include/libswiftnav/nav_msg.h
+++ b/include/libswiftnav/nav_msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Swift Navigation Inc.
+ * Copyright (C) 2010, 2016 Swift Navigation Inc.
  * Contact: Henry Hallam <henry@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -15,6 +15,7 @@
 
 #include <libswiftnav/common.h>
 #include <libswiftnav/ephemeris.h>
+#include <libswiftnav/ionosphere.h>
 
 #define NAV_MSG_SUBFRAME_BITS_LEN 14 /* Buffer 448 nav bits. */
 
@@ -45,6 +46,9 @@ typedef struct {
 typedef struct {
   ephemeris_t ephemeris;
   bool ephemeris_upd_flag;
+
+  ionosphere_t iono;
+  bool iono_corr_upd_flag;
 
   u32 gps_l2c_sv_capability;
   bool gps_l2c_sv_capability_upd_flag;

--- a/python/swiftnav/nav_msg.pxd
+++ b/python/swiftnav/nav_msg.pxd
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 Swift Navigation Inc.
+# Copyright (C) 2012, 2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -30,9 +30,21 @@ cdef extern from "libswiftnav/nav_msg.h":
     u8 next_subframe_id
     s8 bit_polarity
 
+  ctypedef struct ionosphere_t:
+    double a0
+    double a1
+    double a2
+    double a3
+    double b0
+    double b1
+    double b2
+    double b3
+            
   ctypedef struct gps_l1ca_decoded_data_t:
     ephemeris_t ephemeris
     bool ephemeris_upd_flag
+    ionosphere_t iono
+    bool iono_corr_upd_flag
     u32 gps_l2c_sv_capability
     bool gps_l2c_sv_capability_upd_flag
 

--- a/python/swiftnav/nav_msg.pyx
+++ b/python/swiftnav/nav_msg.pyx
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 Swift Navigation Inc.
+# Copyright (C) 2012, 2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Swift Navigation Inc.
+ * Copyright (C) 2010, 2016 Swift Navigation Inc.
  * Contact: Henry Hallam <henry@swift-nav.com>
  *          Fergus Noble <fergus@swift-nav.com>
  *

--- a/tests/check_ionosphere.c
+++ b/tests/check_ionosphere.c
@@ -1,5 +1,17 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Dmitry Tatarinov <dmitry.tatarinov@exafore.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 #include <check.h>
+#include <stdio.h>
 
 #include  <libswiftnav/constants.h>
 #include  <libswiftnav/ionosphere.h>
@@ -49,12 +61,65 @@ START_TEST(test_calc_ionosphere)
 }
 END_TEST
 
+START_TEST(test_decode_iono_parameters)
+{
+  #define tol 1e-12
+  struct {
+    u32 frame_words[8];
+    ionosphere_t result;
+  } t_case = {
+      .frame_words = {
+          /* 4th SF real data at 11-May-2016 */
+          0x1e0300c9,0x7fff8c24,0x23fbdc2,0,0,0,0,0
+      },
+      .result = { /* reference data provided by u-blox receiver */
+        .a0 = 0.0000000111758,
+        .a1 = 0.0000000223517,
+        .a2 = -0.0000000596046,
+        .a3 = -0.0000001192092,
+        .b0 = 98304.0,
+        .b1 = 131072.0,
+        .b2 = -131072.0,
+        .b3 = -589824.0,
+      }
+  };
+  ionosphere_t i;
+  decode_iono_parameters(t_case.frame_words, &i);
+  fail_unless(fabs(i.a0 - t_case.result.a0) < tol,
+              "alfa 0 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.a0, t_case.result.a0, tol);
+  fail_unless(fabs(i.a1 - t_case.result.a1) < tol,
+              "alfa 1 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.a1, t_case.result.a1, tol);
+  fail_unless(fabs(i.a2 - t_case.result.a2) < tol,
+              "alfa 2 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.a2, t_case.result.a2, tol);
+  fail_unless(fabs(i.a3 - t_case.result.a3) < tol,
+              "alfa 3 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.a3, t_case.result.a3, tol);
+  fail_unless(fabs(i.b0 - t_case.result.b0) < tol,
+              "beta 0 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.b0, t_case.result.b0, tol);
+  fail_unless(fabs(i.b1 - t_case.result.b1) < tol,
+              "beta 1 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.b1, t_case.result.b1, tol);
+  fail_unless(fabs(i.b2 - t_case.result.b2) < tol,
+              "beta 2 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.b2, t_case.result.b2, tol);
+  fail_unless(fabs(i.b3 - t_case.result.b3) < tol,
+              "beta 3 == %30.20f, expected %30.20f, tolerance = %30.20f",
+              i.b3, t_case.result.b3, tol);
+
+}
+END_TEST
+
 Suite* ionosphere_suite(void)
 {
   Suite *s = suite_create("Ionosphere");
 
   TCase *tc_core = tcase_create("Core");
   tcase_add_test(tc_core, test_calc_ionosphere);
+  tcase_add_test(tc_core, test_decode_iono_parameters);
   suite_add_tcase(s, tc_core);
 
   return s;


### PR DESCRIPTION
This adds decoder for L1C/A iono parameters.
The PR is copy for https://github.com/swift-nav/libswiftnav-private/pull/8
Can be merged.