### PR TITLE
Add iono and tropo correction usage

### DIFF
--- a/include/libswiftnav/pvt.h
+++ b/include/libswiftnav/pvt.h
@@ -16,6 +16,8 @@
 
 #include <libswiftnav/common.h>
 #include <libswiftnav/track.h>
+#include <libswiftnav/ionosphere.h>
+#include <libswiftnav/troposphere.h>
 
 #define PVT_MAX_ITERATIONS 10
 
@@ -84,5 +86,11 @@ s8 calc_PVT(const u8 n_used,
             bool disable_raim,
             gnss_solution *soln,
             dops_t *dops);
+
+void calc_iono_tropo(const u8 n_ready_tdcp,
+                     navigation_measurement_t *nav_meas_tdcp,
+                     const double *pos_ecef,
+                     const double *pos_llh,
+                     const ionosphere_t *iono_params);
 
 #endif /* LIBSWIFTNAV_PVT_H */


### PR DESCRIPTION
This PR is created based on review here https://github.com/swift-nav/piksi_firmware/pull/686#discussion_r66972864
The idea is to move iono and tropo correction from FW to libswiftnav.
Since this is a public repository the function does not take into account L2C.