### PR TITLE
I107: Python bindings for GLONASS correlator

### DIFF
--- a/include/libswiftnav/correlate.h
+++ b/include/libswiftnav/correlate.h
@@ -34,4 +34,15 @@ void l2c_cm_track_correlate(const s8* samples, size_t samples_len,
                             double* I_P, double* Q_P,
                             double* I_L, double* Q_L, u32* num_samples);
 
+void glo_ca_track_correlate(const s8* samples, size_t samples_len,
+                            const s8* code,
+                            double* init_code_phase,
+                            double code_step,
+                            double* init_carr_phase,
+                            double carr_step,
+                            double* I_E, double* Q_E,
+                            double* I_P, double* Q_P,
+                            double* I_L, double* Q_L,
+                            u32* num_samples);
+
 #endif /* LIBSWIFTNAV_CORRELATE_H */

--- a/include/libswiftnav/track.h
+++ b/include/libswiftnav/track.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Swift Navigation Inc.
+ * Copyright (C) 2012,2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -211,6 +211,7 @@ void aided_tl_retune(aided_tl_state_t *s, float loop_freq,
                      float carr_freq_b1);
 
 void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3]);
+void aided_tl_adjust(aided_tl_state_t *s, float err);
 
 void comp_tl_init(comp_tl_state_t *s, float loop_freq,
                     float code_freq, float code_bw,

--- a/python/swiftnav/correlate.pxd
+++ b/python/swiftnav/correlate.pxd
@@ -28,3 +28,12 @@ cdef extern from "libswiftnav/correlate.h":
                        double* I_P, double* Q_P,
                        double* I_L, double* Q_L,
                        u32* num_samples)
+
+  void glo_ca_track_correlate(s8* samples, size_t samples_len, s8* code,
+                       double* init_code_phase, double code_step,
+                       double* init_carr_phase, double carr_step,
+                       double* I_E, double* Q_E,
+                       double* I_P, double* Q_P,
+                       double* I_L, double* Q_L,
+                       u32* num_samples);
+

--- a/python/swiftnav/correlate.pyx
+++ b/python/swiftnav/correlate.pyx
@@ -45,6 +45,11 @@ def track_correlate(np.ndarray[char, ndim=1, mode="c"] samples,
                   &init_code_phase, code_freq / sampling_freq,
                   &init_carr_phase, carr_freq * 2.0 * M_PI / sampling_freq,
                   &I_E, &Q_E, &I_P, &Q_P, &I_L, &Q_L, &blksize)
+  elif signal == "gloca":
+    glo_ca_track_correlate(<s8*>&samples[0], len(samples), <s8*>&code[0],
+                  &init_code_phase, code_freq / sampling_freq,
+                  &init_carr_phase, carr_freq * 2.0 * M_PI / sampling_freq,
+                  &I_E, &Q_E, &I_P, &Q_P, &I_L, &Q_L, &blksize)
   else:
     l2c_cm_track_correlate(<s8*>&samples[0], len(samples), <s8*>&code[0],
                   chips_to_correlate,

--- a/python/swiftnav/correlate.pyx
+++ b/python/swiftnav/correlate.pyx
@@ -45,7 +45,7 @@ def track_correlate(np.ndarray[char, ndim=1, mode="c"] samples,
                   &init_code_phase, code_freq / sampling_freq,
                   &init_carr_phase, carr_freq * 2.0 * M_PI / sampling_freq,
                   &I_E, &Q_E, &I_P, &Q_P, &I_L, &Q_L, &blksize)
-  elif signal == "gloca":
+  elif signal == "glo_l1" or signal == "glo_l2":
     glo_ca_track_correlate(<s8*>&samples[0], len(samples), <s8*>&code[0],
                   &init_code_phase, code_freq / sampling_freq,
                   &init_carr_phase, carr_freq * 2.0 * M_PI / sampling_freq,

--- a/python/swiftnav/track.pxd
+++ b/python/swiftnav/track.pxd
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Swift Navigation Inc.
+# Copyright (C) 2015,2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -91,6 +91,7 @@ cdef extern from "libswiftnav/track.h":
                        float carr_bw, float carr_zeta, float carr_k,
                        float carr_freq_b1)
   void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3])
+  void aided_tl_adjust(aided_tl_state_t *s, float err)
 
   # Tracking loop: Comp
   ctypedef struct comp_tl_state_t:

--- a/python/swiftnav/track.pyx
+++ b/python/swiftnav/track.pyx
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Swift Navigation Inc.
+# Copyright (C) 2015,2016 Swift Navigation Inc.
 #
 # This source is subject to the license found in the file 'LICENSE' which must
 # be be distributed together with this source. All other rights reserved.
@@ -311,6 +311,9 @@ cdef class AidedTrackingLoop:
     cs_[2].Q = imag(L)
     aided_tl_update(&self._thisptr, cs_)
     return (self._thisptr.code_freq, self._thisptr.carr_freq)
+
+  def adjust_freq(self, corr):
+    aided_tl_adjust(&self._thisptr, corr)
 
   def to_dict(self):
     return self._thisptr

--- a/src/correlate.c
+++ b/src/correlate.c
@@ -26,11 +26,13 @@
 
 enum correlator_type {
   L1CA_CORRELATOR,
-  L2C_CORRELATOR
+  L2C_CORRELATOR,
+  GLOCA_CORRELATOR
 };
 
-#define L1_CA_CHIPS_PER_PRN_CODE   1023
-#define L2C_CM_CHIPS_PER_PRN_CODE  10230
+#define L1_CA_CHIPS_PER_PRN_CODE    1023
+#define L2C_CM_CHIPS_PER_PRN_CODE   10230
+#define GLO_CA_CHIPS_PER_PRN_CODE   511
 
 static void track_correlate(enum correlator_type correlator_type,
                             const s8* restrict samples,
@@ -144,6 +146,59 @@ void l2c_cm_track_correlate(const s8* samples, size_t samples_len,
                   I_E, Q_E, I_P, Q_P, I_L, Q_L, *num_samples);
 }
 
+/** Perform GLO CA correlation.
+ *
+ * \param samples          Samples array. One byte per sample.
+ * \param samples_len      Samples array size.
+ * \param code             L2C CM PRN code. One byte per chip: 10230 bytes long.
+ * \param[in,out] init_code_phase  Initial code phase [chips].
+ *                         The function returns the
+ *                         the last unprocessed code phase here.
+ * \param code_step        Code phase increment step [chips].
+ * \param[in,out] init_carr_phase  Initial carrier phase [radians].
+ *                         The function returns the the last unprocessed carrier
+ *                         phase here.
+ * \param carr_step        Carrier phase increment step [radians].
+ * \param[out] I_E         Early replica in-phase correlation component.
+ * \param[out] Q_E         Early replica quadrature correlation component.
+ * \param[out] I_P         Prompt replica in-phase correlation component.
+ * \param[out] Q_P         Prompt replica quadrature correlation component.
+ * \param[out] I_L         Late replica in-phase correlation component.
+ * \param[out] Q_L         Late replica quadrature correlation component.
+ * \param[out] num_samples The number of processed samples from \e samples array.
+ */
+void glo_ca_track_correlate(const s8* samples, size_t samples_len,
+                            const s8* code,
+                            double* init_code_phase,
+                            double code_step,
+                            double* init_carr_phase,
+                            double carr_step,
+                            double* I_E, double* Q_E,
+                            double* I_P, double* Q_P,
+                            double* I_L, double* Q_L,
+                            u32* num_samples)
+{
+  *num_samples = (int)ceil((2 * GLO_CA_CHIPS_PER_PRN_CODE -
+                   * init_code_phase) / code_step);
+
+  if (0 == *num_samples) {
+    *num_samples =
+      (int)ceil(2 * GLO_CA_CHIPS_PER_PRN_CODE / code_step);
+  }
+
+  if (*num_samples > samples_len) {
+    *num_samples = samples_len;
+  }
+
+  if (0 == *num_samples) {
+    return;
+  }
+
+  track_correlate(GLOCA_CORRELATOR, samples, code, init_code_phase,
+                  code_step, init_carr_phase, carr_step, I_E, Q_E, I_P,
+                  Q_P, I_L, Q_L, *num_samples);
+}
+
 /** Produce L1 C/A chip for the given code phase
  *
  * \param code       L1 C/A PRN code array. One byte per sample: 1023 bytes long.
@@ -213,6 +268,43 @@ static inline double l2c_cm_get_code_phase(double code_phase, double code_step)
   return code_phase;
 }
 
+/** Produce GLO C/A chip for the given code phase
+ *
+ * \param code       GLO C/A PRN code array.
+ *                   One byte per sample: 511 bytes long.
+ * \param code_phase Code phase of the chip to return.
+ * \return Code chip.
+ */
+static inline s8 glo_ca_get_chip(const s8 *code, double code_phase)
+{
+  int i;
+  if (code_phase < 0) {
+    i = (int)(code_phase + GLO_CA_CHIPS_PER_PRN_CODE);
+  } else if (code_phase >= GLO_CA_CHIPS_PER_PRN_CODE) {
+    i = (int)(code_phase - GLO_CA_CHIPS_PER_PRN_CODE);
+  } else {
+    i = (int)code_phase;
+  }
+  return code[i];
+}
+
+/** Produce a new GLO C/A code phase given current code phase
+ *  and the step.
+ *
+ * \param code_phase Current code phase [chips].
+ * \param code_step  Code phase update step [chips].
+ * \return New code phase.
+ */
+static inline double glo_ca_get_code_phase(double code_phase,
+                                           double code_step)
+{
+  code_phase += code_step;
+  if (code_phase >= GLO_CA_CHIPS_PER_PRN_CODE) {
+    code_phase -= GLO_CA_CHIPS_PER_PRN_CODE;
+  }
+  return code_phase;
+}
+
 #ifndef __SSSE3__
 
 /** Perform correlation.
@@ -237,6 +329,7 @@ static inline double l2c_cm_get_code_phase(double code_phase, double code_step)
  * \param num_samples      The number of samples to correlate from \e samples
  *                         array.
  */
+
 static void track_correlate(enum correlator_type correlator_type,
                             const s8* restrict samples,
                             const s8* restrict code,
@@ -279,6 +372,12 @@ static void track_correlate(enum correlator_type correlator_type,
       code_L         = l2c_cm_get_chip(code, code_phase + 0.5);
       code_phase_new = l2c_cm_get_code_phase(code_phase, code_step);
       break;
+    case GLOCA_CORRELATOR:
+      code_E         = glo_ca_get_chip(code, code_phase - 0.5);
+      code_P         = glo_ca_get_chip(code, code_phase);
+      code_L         = glo_ca_get_chip(code, code_phase + 0.5);
+      code_phase_new = glo_ca_get_code_phase(code_phase, code_step);
+      break;
     default:
       break;
     }
@@ -290,7 +389,8 @@ static void track_correlate(enum correlator_type correlator_type,
        rotation matrix */
     double carr_sin_ = carr_sin*cos_delta + carr_cos*sin_delta;
     double carr_cos_ = carr_cos*cos_delta - carr_sin*sin_delta;
-    double i_mag = (3.0 - carr_sin_*carr_sin_ - carr_cos_*carr_cos_) / 2.0;
+    double i_mag =
+      (3.0 - carr_sin_*carr_sin_ - carr_cos_*carr_cos_) / 2.0;
     carr_sin = carr_sin_ * i_mag;
     carr_cos = carr_cos_ * i_mag;
 
@@ -304,7 +404,8 @@ static void track_correlate(enum correlator_type correlator_type,
     code_phase = code_phase_new;
   }
   *init_code_phase = code_phase;
-  *init_carr_phase = fmod(*init_carr_phase + num_samples * carr_step, 2*M_PI);
+  *init_carr_phase =
+    fmod(*init_carr_phase + num_samples * carr_step, 2*M_PI);
 }
 
 #else
@@ -363,6 +464,12 @@ static void track_correlate(enum correlator_type correlator_type,
       code_P         = l2c_cm_get_chip(code, code_phase);
       code_L         = l2c_cm_get_chip(code, code_phase + 0.5);
       code_phase_new = l2c_cm_get_code_phase(code_phase, code_step);
+      break;
+    case GLOCA_CORRELATOR:
+      code_E         = glo_ca_get_chip(code, code_phase - 0.5);
+      code_P         = glo_ca_get_chip(code, code_phase);
+      code_L         = glo_ca_get_chip(code, code_phase + 0.5);
+      code_phase_new = glo_ca_get_code_phase(code_phase, code_step);
       break;
     default:
       break;

--- a/src/correlate.c
+++ b/src/correlate.c
@@ -75,8 +75,8 @@ void l1_ca_track_correlate(const s8* samples, size_t samples_len,
                            double* I_P, double* Q_P,
                            double* I_L, double* Q_L, u32* num_samples)
 {
-  *num_samples = (int)ceil((chips_to_correlate - *init_code_phase) /
-                 code_step);
+  *num_samples = (u32)ceil((chips_to_correlate - *init_code_phase) /
+                           code_step);
 
   if (0 == *num_samples) {
     *num_samples = (int)ceil(chips_to_correlate / code_step);
@@ -126,8 +126,8 @@ void l2c_cm_track_correlate(const s8* samples, size_t samples_len,
                             double* I_P, double* Q_P,
                             double* I_L, double* Q_L, u32* num_samples)
 {
-  *num_samples = (int)ceil((chips_to_correlate - *init_code_phase) /
-                 code_step);
+  *num_samples = (u32)ceil((chips_to_correlate - *init_code_phase) /
+                           code_step);
 
   if (0 == *num_samples) {
     *num_samples = (int)ceil(chips_to_correlate / code_step);
@@ -150,7 +150,7 @@ void l2c_cm_track_correlate(const s8* samples, size_t samples_len,
  *
  * \param samples          Samples array. One byte per sample.
  * \param samples_len      Samples array size.
- * \param code             L2C CM PRN code. One byte per chip: 10230 bytes long.
+ * \param code             GLO CA PRN code. One byte per chip: 511 bytes long.
  * \param[in,out] init_code_phase  Initial code phase [chips].
  *                         The function returns the
  *                         the last unprocessed code phase here.
@@ -178,8 +178,8 @@ void glo_ca_track_correlate(const s8* samples, size_t samples_len,
                             double* I_L, double* Q_L,
                             u32* num_samples)
 {
-  *num_samples = (int)ceil((2 * GLO_CA_CHIPS_PER_PRN_CODE -
-                   * init_code_phase) / code_step);
+  *num_samples = (u32)ceil((2 * GLO_CA_CHIPS_PER_PRN_CODE - *init_code_phase) /
+                           code_step);
 
   if (0 == *num_samples) {
     *num_samples =

--- a/src/track.c
+++ b/src/track.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 Swift Navigation Inc.
+ * Copyright (C) 2012,2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -372,6 +372,19 @@ void aided_tl_update(aided_tl_state_t *s, correlation_t cs[3])
   s->code_freq = simple_lf_update(&(s->code_filt), -code_error);
   if (s->carr_to_code) /* Optional carrier aiding of code loop */
     s->code_freq += s->carr_freq / s->carr_to_code;
+}
+
+/** Adjust carrier frequency.
+ *
+ * Applies the given correction to the internal state of the tracking loop.
+ *
+ * \param s The tracking loop state struct.
+ * \param err The correction in [Herz]
+ */
+void aided_tl_adjust(aided_tl_state_t *s, float err)
+{
+  s->carr_freq += err;
+  s->carr_filt.y = s->carr_freq;
 }
 
 /** Initialise a simple tracking loop.

--- a/tests/check_track.c
+++ b/tests/check_track.c
@@ -60,12 +60,31 @@ START_TEST(test_costas_discriminator)
 }
 END_TEST
 
+START_TEST(test_aided_tl_adjustment)
+{
+  aided_tl_state_t s;
+  aided_tl_init(&s, 50,    /* loop_freq [Hz] */
+                0,         /* Doppler on code_freq [Hz] */
+                1 /*code_bw*/, 0.7 /*code_zeta*/, 1 /*code_k*/,
+                1200 /*carr_to_code*/,
+                0 /* Doppler on carr_freq [Hz]*/,
+                13 /*carr_bw*/, 0.7 /*carr_zeta*/, 1 /*carr_k*/,
+                5 /*carr_freq_b1*/);
+  float carr_freq_prev = s.carr_freq;
+  float err = 15;
+  aided_tl_adjust(&s, err);
+  fail_unless((carr_freq_prev + err) == s.carr_freq,
+               "incorrect adjusment result");
+}
+END_TEST
+
 Suite* track_test_suite(void)
 {
   Suite *s = suite_create("Track");
 
   TCase *tc_core = tcase_create("Core");
   tcase_add_test(tc_core, test_costas_discriminator);
+  tcase_add_test(tc_core, test_aided_tl_adjustment);
   suite_add_tcase(s, tc_core);
 
   return s;


### PR DESCRIPTION
Part of I107 task. Required for GLONASS support in Peregrine.