### PR TITLE
GPS+Gal clock solve

### DIFF
--- a/include/swiftnav/single_epoch_solver.h
+++ b/include/swiftnav/single_epoch_solver.h
@@ -49,7 +49,8 @@ extern const char *pvt_err_msg[7];
 enum processing_strategy_t {
   GPS_ONLY,
   ALL_CONSTELLATIONS,
-  GPS_L1CA_WHEN_POSSIBLE
+  GPS_L1CA_WHEN_POSSIBLE,
+  L1_ONLY
 };
 
 typedef struct __attribute__((packed)) {

--- a/src/single_epoch_solver.c
+++ b/src/single_epoch_solver.c
@@ -1192,6 +1192,11 @@ s8 calc_PVT(const u8 n_used,
         use_this = (CODE_GPS_L1CA == nav_meas[i].sid.code) ||
                    (sats_used <= N_STATE + RAIM_MAX_EXCLUSIONS);
         break;
+      case L1_ONLY:
+        /* use all the available 1575.4 2MHz codes */
+        use_this = (CODE_GPS_L1CA == nav_meas[i].sid.code) ||
+                   (CODE_GAL_E1B == nav_meas[i].sid.code);
+        break;
       default:
         break;
     }

--- a/src/single_epoch_solver.c
+++ b/src/single_epoch_solver.c
@@ -1193,7 +1193,7 @@ s8 calc_PVT(const u8 n_used,
                    (sats_used <= N_STATE + RAIM_MAX_EXCLUSIONS);
         break;
       case L1_ONLY:
-        /* use all the available 1575.4 2MHz codes */
+        /* use all the available 1575.42 MHz codes */
         use_this = (CODE_GPS_L1CA == nav_meas[i].sid.code) ||
                    (CODE_GAL_E1B == nav_meas[i].sid.code);
         break;


### PR DESCRIPTION
Use all available GPS and Galileo L1 measurements for the clock solve. This should improve GPS-only poor DOP situations not mitigated by using L2 measurements.