### PR TITLE
Use function pointers instead of weak symbols.

### DIFF
--- a/include/swiftnav/logging.h
+++ b/include/swiftnav/logging.h
@@ -43,25 +43,22 @@ extern "C" {
  *
  * \{ */
 
-typedef void (*PFN_log)(int level, 
-                        const char *msg, 
-                        ...)
-                        __attribute__((format(printf, 2, 3)));
+typedef void (*PFN_log)(int level, const char *msg, ...)
+    __attribute__((format(printf, 2, 3)));
 
-typedef void (*PFN_detailed_log)(int level, 
+typedef void (*PFN_detailed_log)(int level,
                                  const char *file_path,
                                  const int line_number,
-                                 const char *msg, 
-                                 ...)
-                                 __attribute__((format(printf, 4, 5)));
+                                 const char *msg,
+                                 ...) __attribute__((format(printf, 4, 5)));
 
-extern PFN_log          log_;
+extern PFN_log log_;
 extern PFN_detailed_log detailed_log_;
 
 /**
  * Provide custom implementation for the underlying log functions.
  */
-void logging_set_implementation(PFN_log impl_log, 
+void logging_set_implementation(PFN_log impl_log,
                                 PFN_detailed_log impl_detailed_log);
 
 const char *truncate_path_(char *path);

--- a/include/swiftnav/logging.h
+++ b/include/swiftnav/logging.h
@@ -43,23 +43,23 @@ extern "C" {
  *
  * \{ */
 
-typedef void (*PFN_log)(int level, const char *msg, ...)
+typedef void (*pfn_log)(int level, const char *msg, ...)
     __attribute__((format(printf, 2, 3)));
 
-typedef void (*PFN_detailed_log)(int level,
+typedef void (*pfn_detailed_log)(int level,
                                  const char *file_path,
                                  const int line_number,
                                  const char *msg,
                                  ...) __attribute__((format(printf, 4, 5)));
 
-extern PFN_log log_;
-extern PFN_detailed_log detailed_log_;
+extern pfn_log log_;
+extern pfn_detailed_log detailed_log_;
 
 /**
  * Provide custom implementation for the underlying log functions.
  */
-void logging_set_implementation(PFN_log impl_log,
-                                PFN_detailed_log impl_detailed_log);
+void logging_set_implementation(pfn_log impl_log,
+                                pfn_detailed_log impl_detailed_log);
 
 const char *truncate_path_(char *path);
 

--- a/include/swiftnav/logging.h
+++ b/include/swiftnav/logging.h
@@ -43,18 +43,28 @@ extern "C" {
  *
  * \{ */
 
-void log_(int level, const char *msg, ...)
-    __attribute__((format(printf, 2, 3)));
+typedef void (*PFN_log)(int level, 
+                        const char *msg, 
+                        ...)
+                        __attribute__((format(printf, 2, 3)));
 
-void detailed_log_(int level,
-                   const char *file_path,
-                   const int line_number,
-                   const char *msg,
-                   ...) __attribute__((format(printf, 4, 5)));
+typedef void (*PFN_detailed_log)(int level, 
+                                 const char *file_path,
+                                 const int line_number,
+                                 const char *msg, 
+                                 ...)
+                                 __attribute__((format(printf, 4, 5)));
+
+extern PFN_log          log_;
+extern PFN_detailed_log detailed_log_;
+
+/**
+ * Provide custom implementation for the underlying log functions.
+ */
+void logging_set_implementation(PFN_log impl_log, 
+                                PFN_detailed_log impl_detailed_log);
 
 const char *truncate_path_(char *path);
-
-void event_(int fd, const char *msg, ...) __attribute__((format(printf, 2, 3)));
 
 extern const char *level_string[];
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -25,11 +25,10 @@
  * \param level Log level
  * \param msg Log contents
  */
-__attribute__((format(printf, 2, 3))) 
-static void default_log_(int level, const char *msg, ...) {
-
+__attribute__((format(printf, 2, 3))) static void default_log_(int level,
+                                                               const char *msg,
+                                                               ...) {
   va_list ap;
-
   fprintf(stderr, "%s: ", level_string[level]);
   va_start(ap, msg);
   vfprintf(stderr, msg, ap);
@@ -44,13 +43,12 @@ static void default_log_(int level, const char *msg, ...) {
  * \param line_number line number where this function was called
  * \param msg Log contents
  */
-__attribute__((format(printf, 4, 5))) 
-static void default_detailed_log_(int level,
-                                  const char *file_path,
-                                  const int line_number,
-                                  const char *msg,
-                                  ...) {
-
+__attribute__((format(printf, 4, 5))) static void default_detailed_log_(
+    int level,
+    const char *file_path,
+    const int line_number,
+    const char *msg,
+    ...) {
   va_list ap;
   fprintf(stderr, "(lsn::%s:%d) ", file_path, line_number);
   fprintf(stderr, "%s: ", level_string[level]);
@@ -63,7 +61,7 @@ static void default_detailed_log_(int level,
 PFN_log log_ = default_log_;
 PFN_detailed_log detailed_log_ = default_detailed_log_;
 
-void logging_set_implementation(PFN_log impl_log, 
+void logging_set_implementation(PFN_log impl_log,
                                 PFN_detailed_log impl_detailed_log) {
   assert(impl_log != NULL);
   assert(impl_detailed_log != NULL);

--- a/src/logging.c
+++ b/src/logging.c
@@ -58,11 +58,11 @@ __attribute__((format(printf, 4, 5))) static void default_detailed_log_(
   fprintf(stderr, "\n");
 }
 
-PFN_log log_ = default_log_;
-PFN_detailed_log detailed_log_ = default_detailed_log_;
+pfn_log log_ = default_log_;
+pfn_detailed_log detailed_log_ = default_detailed_log_;
 
-void logging_set_implementation(PFN_log impl_log,
-                                PFN_detailed_log impl_detailed_log) {
+void logging_set_implementation(pfn_log impl_log,
+                                pfn_detailed_log impl_detailed_log) {
   assert(impl_log != NULL);
   assert(impl_detailed_log != NULL);
   log_ = impl_log;

--- a/src/logging.c
+++ b/src/logging.c
@@ -25,7 +25,7 @@
  * \param level Log level
  * \param msg Log contents
  */
-__attribute__((weak)) void log_(int level, const char *msg, ...) {
+static void default_log_(int level, const char *msg, ...) {
   va_list ap;
 
   fprintf(stderr, "%s: ", level_string[level]);
@@ -42,11 +42,11 @@ __attribute__((weak)) void log_(int level, const char *msg, ...) {
  * \param line_number line number where this function was called
  * \param msg Log contents
  */
-__attribute__((weak)) void detailed_log_(int level,
-                                         const char *file_path,
-                                         const int line_number,
-                                         const char *msg,
-                                         ...) {
+static void default_detailed_log_(int level,
+                                  const char *file_path,
+                                  const int line_number,
+                                  const char *msg,
+                                  ...) {
   va_list ap;
   fprintf(stderr, "(lsn::%s:%d) ", file_path, line_number);
   fprintf(stderr, "%s: ", level_string[level]);
@@ -56,20 +56,15 @@ __attribute__((weak)) void detailed_log_(int level,
   fprintf(stderr, "\n");
 }
 
-/** Log an event.
- *
- *  By default, this will log to stderr on x86, but is intended for logging to a
- *  file on Piksi.
- *
- * \param fd Bogus file descriptor
- * \param msg Log string contents
- */
-__attribute__((weak)) void event_(int fd, const char *msg, ...) {
-  va_list ap;
-  fprintf(stderr, "fd: %d: ", fd);
-  va_start(ap, msg);
-  vfprintf(stderr, msg, ap);
-  va_end(ap);
+PFN_log log_ = default_log_;
+PFN_detailed_log detailed_log_ = default_detailed_log_;
+
+void logging_set_implementation(PFN_log impl_log, 
+                                PFN_detailed_log impl_detailed_log) {
+  assert(impl_log != NULL);
+  assert(impl_detailed_log != NULL);
+  log_ = impl_log;
+  detailed_log_ = impl_detailed_log;
 }
 
 /* \} */

--- a/src/logging.c
+++ b/src/logging.c
@@ -25,7 +25,9 @@
  * \param level Log level
  * \param msg Log contents
  */
+__attribute__((format(printf, 2, 3))) 
 static void default_log_(int level, const char *msg, ...) {
+
   va_list ap;
 
   fprintf(stderr, "%s: ", level_string[level]);
@@ -42,11 +44,13 @@ static void default_log_(int level, const char *msg, ...) {
  * \param line_number line number where this function was called
  * \param msg Log contents
  */
+__attribute__((format(printf, 4, 5))) 
 static void default_detailed_log_(int level,
                                   const char *file_path,
                                   const int line_number,
                                   const char *msg,
                                   ...) {
+
   va_list ap;
   fprintf(stderr, "(lsn::%s:%d) ", file_path, line_number);
   fprintf(stderr, "%s: ", level_string[level]);


### PR DESCRIPTION
Also remove unused event_ function.

This is a change that helps us in build setups where the weak symbol approach proves difficult. It is presumed that the additional overhead of a pointer dereference is negligible in any scenario where printf style logs are being invoked.

@pmiettinen Do you think this is misguided?