### PR TITLE
EX-438: Use only the integer part of UTC offset in GLO time conversion

### DIFF
--- a/src/gnss_time.c
+++ b/src/gnss_time.c
@@ -450,8 +450,9 @@ gps_time_t glo2gps(const glo_time_t *glo_t, const utc_params_t *utc_params) {
     gps_t.tow += 1;
   }
 
-  /* convert to GPS time */
-  gps_t.tow -= d_utc;
+  /* use just the integer part of the time difference to convert GLO time to
+   * GPS time (see GLO ICD, Section 4.5)*/
+  gps_t.tow -= round(d_utc);
   normalize_gps_time(&gps_t);
   return gps_t;
 }

--- a/tests/check_gnss_time.c
+++ b/tests/check_gnss_time.c
@@ -597,7 +597,7 @@ START_TEST(test_utc_params) {
     glo_time_t glo_time = gps2glo(&testcases[i].t, testcases[i].p);
     gps_time_t converted = glo2gps(&glo_time, testcases[i].p);
     fail_unless(
-        fabs(gpsdifftime(&testcases[i].t, &converted)) < 1e-5,
+        fabs(gpsdifftime(&testcases[i].t, &converted)) < 0.2,
         "utc_params_testcase %d gps2glo2gps failed for (%u/%u %u:%u:%.16f), "
         "expected (%d, %f), got (%d, %f)",
         i,


### PR DESCRIPTION
Currently, GLO to GPS time conversion uses the UTC to GPS conversion parameters from GPS navigation message, which includes the integer leap second offset as well as polynomial fine offset.

GLO ICD however asks to use only the integer part of the offset from the GPS data, and instead collect the fine offset from GLO navigation data:
![image](https://user-images.githubusercontent.com/18000866/50836040-ea49bd00-1360-11e9-9b49-da2e3ae08c07.png)

This PR amends `glo2gps` computation to include only the integer part.

Note: The fine tau_gps offset will be implemented on FW side in https://github.com/swift-nav/piksi_firmware_private/pull/2608. `glo2gps` is not used anywhere else that I can find.

Note 2: Merging this PR without the FW one only removes the <0.5ns ~15cm common offset from all GLO ranges that should not have been there in the first place.