### PR TITLE
EX-516: Fix -Wfloat-conversion warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ target_compile_options(swiftnav PRIVATE "-Wformat=2")
 target_compile_options(swiftnav PRIVATE "-Wimplicit-function-declaration")
 target_compile_options(swiftnav PRIVATE "-Wredundant-decls")
 target_compile_options(swiftnav PRIVATE "-Wformat-security")
+target_compile_options(swiftnav PRIVATE "-Wfloat-conversion")
 
 # unit tests
 if(NOT CMAKE_CROSSCOMPILING AND NOT PIKSI_MULTI_UNIT_TEST)

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -214,7 +214,7 @@ static s8 calc_sat_state_glo(const ephemeris_t *e,
 
   dt -= *clock_err;
 
-  u32 num_steps = ceil(fabs(dt) / GLO_MAX_STEP_LENGTH);
+  u32 num_steps = (u32)ceil(fabs(dt) / GLO_MAX_STEP_LENGTH);
   num_steps = MIN(num_steps, GLO_MAX_STEP_NUM);
 
   double ecef_vel_acc[6];
@@ -1109,8 +1109,8 @@ void decode_ephemeris(const u32 frame_words[3][8],
   log_debug_sid(e->sid, "Health bits = 0x%02" PRIx8, e->health_bits);
 
   /* t_gd: Word 7, bits 17-24 */
-  k->tgd.gps_s[0] =
-      (s8)(frame_words[0][7 - 3] >> (30 - 24) & 0xFF) * GPS_LNAV_EPH_SF_TGD;
+  k->tgd.gps_s[0] = (float)((s8)(frame_words[0][7 - 3] >> (30 - 24) & 0xFF) *
+                            GPS_LNAV_EPH_SF_TGD);
   /* L1-L5 TGD has to be filled up with C-NAV as combination of L1-L2 TGD and
    * ISC_L5 */
   k->tgd.gps_s[1] = 0.0;
@@ -1350,84 +1350,87 @@ static u32 get_iodcrc(const ephemeris_t *eph) {
   setbits(buffer,
           numbits,
           14,
-          eph->kepler.inc_dot / M_PI * (double)(1 << 30) * (double)(1 << 13));
+          (s32)(eph->kepler.inc_dot / M_PI * (double)(1 << 30) *
+                (double)(1 << 13)));
   numbits += 14;
   setbits(buffer,
           numbits,
           11,
-          eph->kepler.af2 * (double)(1 << 30) * (double)(1 << 30) *
-              (double)(1 << 6));
+          (s32)(eph->kepler.af2 * (double)(1 << 30) * (double)(1 << 30) *
+                (double)(1 << 6)));
   numbits += 11;
   setbits(buffer,
           numbits,
           22,
-          eph->kepler.af1 * (double)(1 << 30) * (double)(1 << 20));
+          (s32)(eph->kepler.af1 * (double)(1 << 30) * (double)(1 << 20)));
   numbits += 22;
   setbits(buffer,
           numbits,
           24,
-          eph->kepler.af0 * (double)(1 << 30) * (double)(1 << 3));
+          (s32)(eph->kepler.af0 * (double)(1 << 30) * (double)(1 << 3)));
   numbits += 24;
-  setbits(buffer, numbits, 18, eph->kepler.crs * (double)(1 << 6));
+  setbits(buffer, numbits, 18, (s32)(eph->kepler.crs * (double)(1 << 6)));
   numbits += 18;
   setbits(buffer,
           numbits,
           16,
-          eph->kepler.dn / M_PI * (double)(1 << 30) * (double)(1 << 13));
+          (s32)(eph->kepler.dn / M_PI * (double)(1 << 30) * (double)(1 << 13)));
   numbits += 16;
   setbits(buffer,
           numbits,
           32,
-          eph->kepler.m0 / M_PI * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.m0 / M_PI * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 32;
   setbits(buffer,
           numbits,
           18,
-          eph->kepler.cuc * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.cuc * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 18;
   setbitu(buffer,
           numbits,
           32,
-          eph->kepler.ecc * (double)(1 << 30) * (double)(1 << 3));
+          (u32)(eph->kepler.ecc * (double)(1 << 30) * (double)(1 << 3)));
   numbits += 32;
   setbits(buffer,
           numbits,
           18,
-          eph->kepler.cus * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.cus * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 18;
-  setbitu(buffer, numbits, 32, eph->kepler.sqrta * (double)(1 << 19));
+  setbitu(buffer, numbits, 32, (u32)(eph->kepler.sqrta * (double)(1 << 19)));
   numbits += 32;
   setbits(buffer,
           numbits,
           18,
-          eph->kepler.cic * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.cic * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 18;
-  setbits(buffer,
-          numbits,
-          32,
-          eph->kepler.omega0 / M_PI * (double)(1 << 30) * (double)(1 << 1));
+  setbits(
+      buffer,
+      numbits,
+      32,
+      (s32)(eph->kepler.omega0 / M_PI * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 32;
   setbits(buffer,
           numbits,
           18,
-          eph->kepler.cis * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.cis * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 18;
   setbits(buffer,
           numbits,
           32,
-          eph->kepler.inc / M_PI * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.inc / M_PI * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 32;
-  setbits(buffer, numbits, 18, eph->kepler.crc * (double)(1 << 6));
+  setbits(buffer, numbits, 18, (s32)(eph->kepler.crc * (double)(1 << 6)));
   numbits += 18;
   setbits(buffer,
           numbits,
           32,
-          eph->kepler.w / M_PI * (double)(1 << 30) * (double)(1 << 1));
+          (s32)(eph->kepler.w / M_PI * (double)(1 << 30) * (double)(1 << 1)));
   numbits += 32;
   setbits(buffer,
           numbits,
           24,
-          eph->kepler.omegadot / M_PI * (double)(1 << 30) * (double)(1 << 13));
+          (s32)(eph->kepler.omegadot / M_PI * (double)(1 << 30) *
+                (double)(1 << 13)));
   numbits += 24;
   setbits(buffer, numbits, 5, 0);
   numbits += 5;
@@ -1479,9 +1482,9 @@ s8 get_tgd_correction(const ephemeris_t *eph,
       gamma = GPS_L1_HZ * GPS_L1_HZ / (frequency * frequency);
       if (CODE_GPS_L5I == sid->code || CODE_GPS_L5Q == sid->code ||
           CODE_GPS_L5X == sid->code) {
-        *tgd = eph->kepler.tgd.gps_s[1] * gamma;
+        *tgd = (float)(eph->kepler.tgd.gps_s[1] * gamma);
       } else {
-        *tgd = eph->kepler.tgd.gps_s[0] * gamma;
+        *tgd = (float)(eph->kepler.tgd.gps_s[0] * gamma);
       }
       return 0;
     case CONSTELLATION_BDS:
@@ -1504,7 +1507,7 @@ s8 get_tgd_correction(const ephemeris_t *eph,
         *tgd = 0.0;
         return 0;
       } else if (CODE_GLO_L2OF == sid->code || CODE_GLO_L2P == sid->code) {
-        *tgd = eph->glo.d_tau;
+        *tgd = (float)eph->glo.d_tau;
         return 0;
       } else {
         log_debug_sid(*sid, "TGD not applied for the signal");
@@ -1518,9 +1521,9 @@ s8 get_tgd_correction(const ephemeris_t *eph,
       gamma = QZS_L1_HZ * QZS_L1_HZ / (frequency * frequency);
       if (CODE_QZS_L5I == sid->code || CODE_QZS_L5Q == sid->code ||
           CODE_QZS_L5X == sid->code) {
-        *tgd = eph->kepler.tgd.gps_s[1] * gamma;
+        *tgd = (float)(eph->kepler.tgd.gps_s[1] * gamma);
       } else {
-        *tgd = eph->kepler.tgd.gps_s[0] * gamma;
+        *tgd = (float)(eph->kepler.tgd.gps_s[0] * gamma);
       }
       return 0;
     case CONSTELLATION_GAL:
@@ -1530,14 +1533,14 @@ s8 get_tgd_correction(const ephemeris_t *eph,
       if (CODE_GAL_E5I == sid->code || CODE_GAL_E5Q == sid->code ||
           CODE_GAL_E5X == sid->code) {
         /* The first TGD correction is for the (E1,E5a) combination */
-        *tgd = gamma * eph->kepler.tgd.gal_s[0];
+        *tgd = (float)(gamma * eph->kepler.tgd.gal_s[0]);
         return 0;
       } else if (CODE_GAL_E1B == sid->code || CODE_GAL_E1C == sid->code ||
                  CODE_GAL_E1X == sid->code || CODE_GAL_E7I == sid->code ||
                  CODE_GAL_E7Q == sid->code || CODE_GAL_E7X == sid->code) {
         /* The clock corrections from INAV are for the (E1,E5b) combination, so
          * use the matching group delay correction for all the other signals */
-        *tgd = gamma * eph->kepler.tgd.gal_s[1];
+        *tgd = (float)(gamma * eph->kepler.tgd.gal_s[1]);
         return 0;
       } else {
         log_debug_sid(*sid, "TGD not applied for the signal");

--- a/src/signal.c
+++ b/src/signal.c
@@ -118,7 +118,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GPS_CA_CHIPPING_RATE,
                        false,
                        GPS_L2CM_PRN_PERIOD_MS,
-                       GPS_L2_DOPPLER_MAX_HZ,
+                       (float)GPS_L2_DOPPLER_MAX_HZ,
                        -0.25f, /* see L2S in [1] */
                        true},
     [CODE_GPS_L2CL] = {CONSTELLATION_GPS,
@@ -131,7 +131,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GPS_CA_CHIPPING_RATE,
                        false,
                        GPS_L2CL_PRN_PERIOD_MS,
-                       GPS_L2_DOPPLER_MAX_HZ,
+                       (float)GPS_L2_DOPPLER_MAX_HZ,
                        -0.25f, /* see L2L in [1] */
                        false},
     [CODE_GPS_L2CX] = {CONSTELLATION_GPS,
@@ -144,7 +144,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       GPS_L2_DOPPLER_MAX_HZ,
+                       (float)GPS_L2_DOPPLER_MAX_HZ,
                        -0.25f, /* see L2X [1] */
                        false},
     [CODE_GPS_L5I] = {CONSTELLATION_GPS,
@@ -157,7 +157,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       GPS_L5_CHIPPING_RATE,
                       false,
                       GPS_L5_PRN_PERIOD_MS,
-                      GPS_L5_DOPPLER_MAX_HZ,
+                      (float)GPS_L5_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L5I in [1]) */
                       false},
     [CODE_GPS_L5Q] = {CONSTELLATION_GPS,
@@ -170,7 +170,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GPS_L5_DOPPLER_MAX_HZ,
+                      (float)GPS_L5_DOPPLER_MAX_HZ,
                       -0.25f, /* see L5Q in [1] */
                       false},
     [CODE_GPS_L5X] = {CONSTELLATION_GPS,
@@ -183,7 +183,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GPS_L5_DOPPLER_MAX_HZ,
+                      (float)GPS_L5_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_GPS_L5I (see L5X in [1])*/
                       false},
     [CODE_GPS_L1P] = {CONSTELLATION_GPS,
@@ -209,7 +209,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GPS_L2_DOPPLER_MAX_HZ,
+                      (float)GPS_L2_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L2P in [1]) */
                       false},
 
@@ -250,7 +250,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        SBAS_L5_CHIPPING_RATE,
                        false,
                        SBAS_L5_PRN_PERIOD_MS,
-                       SBAS_L5_DOPPLER_MAX_HZ,
+                       (float)SBAS_L5_DOPPLER_MAX_HZ,
                        0.f, /* reference signal */
                        true},
     [CODE_SBAS_L5Q] = {CONSTELLATION_SBAS,
@@ -263,7 +263,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        SBAS_L5_CHIPPING_RATE,
                        false,
                        SBAS_L5_PRN_PERIOD_MS,
-                       SBAS_L5_DOPPLER_MAX_HZ,
+                       (float)SBAS_L5_DOPPLER_MAX_HZ,
                        -0.25f, /* not used */
                        false},
     [CODE_SBAS_L5X] = {CONSTELLATION_SBAS,
@@ -276,7 +276,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        SBAS_L5_CHIPPING_RATE,
                        false,
                        SBAS_L5_PRN_PERIOD_MS,
-                       SBAS_L5_DOPPLER_MAX_HZ,
+                       (float)SBAS_L5_DOPPLER_MAX_HZ,
                        0.f, /* must be aligned with CODE_SBAS_L5I */
                        false},
 
@@ -291,7 +291,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GLO_CA_CHIPPING_RATE,
                        true,
                        GLO_PRN_PERIOD_MS,
-                       GLO_L1_DOPPLER_MAX_HZ,
+                       (float)GLO_L1_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L1C in [1]) */
                        true},
     [CODE_GLO_L2OF] = {CONSTELLATION_GLO,
@@ -304,7 +304,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GLO_CA_CHIPPING_RATE,
                        false,
                        GLO_PRN_PERIOD_MS,
-                       GLO_L2_DOPPLER_MAX_HZ,
+                       (float)GLO_L2_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L2C in [1]) */
                        true},
     [CODE_GLO_L1P] = {CONSTELLATION_GLO,
@@ -317,7 +317,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GLO_L1_DOPPLER_MAX_HZ,
+                      (float)GLO_L1_DOPPLER_MAX_HZ,
                       0.25f, /* see L1P in [1] */
                       false},
     [CODE_GLO_L2P] = {CONSTELLATION_GLO,
@@ -330,7 +330,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GLO_L2_DOPPLER_MAX_HZ,
+                      (float)GLO_L2_DOPPLER_MAX_HZ,
                       0.25f, /* see L2P in [1] */
                       false},
 
@@ -397,7 +397,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       GAL_E6_CHIPPING_RATE,
                       false,
                       GAL_E6B_PRN_PERIOD_MS,
-                      GAL_E6_DOPPLER_MAX_HZ,
+                      (float)GAL_E6_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L6B in [1]) */
                       true},
     [CODE_GAL_E6C] = {CONSTELLATION_GAL,
@@ -410,7 +410,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E6_DOPPLER_MAX_HZ,
+                      (float)GAL_E6_DOPPLER_MAX_HZ,
                       -0.5f, /* see L6C in [1] */
                       false},
     [CODE_GAL_E6X] = {CONSTELLATION_GAL,
@@ -423,7 +423,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E6_DOPPLER_MAX_HZ,
+                      (float)GAL_E6_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_GAL_E6B (see L6X in [1])*/
                       false},
     [CODE_GAL_E7I] = {CONSTELLATION_GAL,
@@ -436,7 +436,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       GAL_E7_CHIPPING_RATE,
                       false,
                       GAL_E7I_PRN_PERIOD_MS,
-                      GAL_E7_DOPPLER_MAX_HZ,
+                      (float)GAL_E7_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L7I in [1]) */
                       true},
     [CODE_GAL_E7Q] = {CONSTELLATION_GAL,
@@ -449,7 +449,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E7_DOPPLER_MAX_HZ,
+                      (float)GAL_E7_DOPPLER_MAX_HZ,
                       -0.25f, /* see L7Q in [1] */
                       false},
     [CODE_GAL_E7X] = {CONSTELLATION_GAL,
@@ -462,7 +462,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E7_DOPPLER_MAX_HZ,
+                      (float)GAL_E7_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_GAL_E7I (see L7X in [1])*/
                       false},
     [CODE_GAL_E8I] = {CONSTELLATION_GAL,
@@ -475,7 +475,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E8_DOPPLER_MAX_HZ,
+                      (float)GAL_E8_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L8I in [1]) */
                       false},
     [CODE_GAL_E8Q] = {CONSTELLATION_GAL,
@@ -488,7 +488,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E8_DOPPLER_MAX_HZ,
+                      (float)GAL_E8_DOPPLER_MAX_HZ,
                       -0.25f, /* see L8Q in [1] */
                       false},
     [CODE_GAL_E8X] = {CONSTELLATION_GAL,
@@ -501,7 +501,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E8_DOPPLER_MAX_HZ,
+                      (float)GAL_E8_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_GAL_E8Q (see L8X in [1])*/
                       false},
     [CODE_GAL_E5I] = {CONSTELLATION_GAL,
@@ -514,7 +514,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       GAL_E5_CHIPPING_RATE,
                       false,
                       GAL_E5I_PRN_PERIOD_MS,
-                      GAL_E5_DOPPLER_MAX_HZ,
+                      (float)GAL_E5_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L5I in [1]) */
                       true},
     [CODE_GAL_E5Q] = {CONSTELLATION_GAL,
@@ -527,7 +527,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E5_DOPPLER_MAX_HZ,
+                      (float)GAL_E5_DOPPLER_MAX_HZ,
                       -0.25f, /* see L5Q in [1] */
                       false},
     [CODE_GAL_E5X] = {CONSTELLATION_GAL,
@@ -540,7 +540,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      GAL_E5_DOPPLER_MAX_HZ,
+                      (float)GAL_E5_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_GAL_E5I (see L5X in [1])*/
                       false},
 
@@ -581,7 +581,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       BDS2_B2_CHIPPING_RATE,
                       false,
                       BDS2_B2_PRN_PERIOD_MS,
-                      BDS2_B2_DOPPLER_MAX_HZ,
+                      (float)BDS2_B2_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L7I in [1]) */
                       true},
     [CODE_BDS3_B1CI] = {CONSTELLATION_BDS,
@@ -594,7 +594,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         BDS3_B1C_CHIPPING_RATE,
                         false,
                         BDS3_B1C_PRN_PERIOD_MS,
-                        BDS3_B1C_DOPPLER_MAX_HZ,
+                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B1CQ] = {CONSTELLATION_BDS,
@@ -607,7 +607,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         0,
                         false,
                         0,
-                        BDS3_B1C_DOPPLER_MAX_HZ,
+                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B1CX] = {CONSTELLATION_BDS,
@@ -620,7 +620,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         0,
                         false,
                         0,
-                        BDS3_B1C_DOPPLER_MAX_HZ,
+                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B3I] = {CONSTELLATION_BDS,
@@ -633,7 +633,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        BDS3_B3_CHIPPING_RATE,
                        false,
                        BDS3_B3_PRN_PERIOD_MS,
-                       BDS3_B3_DOPPLER_MAX_HZ,
+                       (float)BDS3_B3_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L6I in [1]) */
                        false},
     [CODE_BDS3_B3Q] = {CONSTELLATION_BDS,
@@ -646,7 +646,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       BDS3_B3_DOPPLER_MAX_HZ,
+                       (float)BDS3_B3_DOPPLER_MAX_HZ,
                        -0.25f, /* see L6Q in [1] */
                        false},
     [CODE_BDS3_B3X] = {CONSTELLATION_BDS,
@@ -659,7 +659,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       BDS3_B3_DOPPLER_MAX_HZ,
+                       (float)BDS3_B3_DOPPLER_MAX_HZ,
                        0.f, /*must be aligned to CODE_BDS3_B3I (L6X in [1]) */
                        false},
     [CODE_BDS3_B7I] = {CONSTELLATION_BDS,
@@ -672,7 +672,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        BDS3_B7_CHIPPING_RATE,
                        false,
                        BDS3_B7_PRN_PERIOD_MS,
-                       BDS3_B7_DOPPLER_MAX_HZ,
+                       (float)BDS3_B7_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L7I in [1]) */
                        false},
     [CODE_BDS3_B7Q] = {CONSTELLATION_BDS,
@@ -685,7 +685,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       BDS3_B7_DOPPLER_MAX_HZ,
+                       (float)BDS3_B7_DOPPLER_MAX_HZ,
                        -0.25f, /* see L7Q in [1] */
                        false},
     [CODE_BDS3_B7X] = {CONSTELLATION_BDS,
@@ -698,7 +698,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        BDS3_B7_CHIPPING_RATE,
                        false,
                        BDS3_B7_PRN_PERIOD_MS,
-                       BDS3_B7_DOPPLER_MAX_HZ,
+                       (float)BDS3_B7_DOPPLER_MAX_HZ,
                        0.f, /* must be aligned to CODE_BDS3_B7I (L7X in [1]) */
                        false},
     [CODE_BDS3_B5I] = {CONSTELLATION_BDS,
@@ -711,7 +711,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        BDS3_B5_CHIPPING_RATE,
                        false,
                        BDS3_B5_PRN_PERIOD_MS,
-                       BDS3_B5_DOPPLER_MAX_HZ,
+                       (float)BDS3_B5_DOPPLER_MAX_HZ,
                        0.f, /* not used (interoperable with SBAS) */
                        false},
     [CODE_BDS3_B5Q] = {CONSTELLATION_BDS,
@@ -724,7 +724,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       BDS3_B5_DOPPLER_MAX_HZ,
+                       (float)BDS3_B5_DOPPLER_MAX_HZ,
                        0.f, /* not used (interoperable with SBAS) */
                        false},
     [CODE_BDS3_B5X] = {CONSTELLATION_BDS,
@@ -737,7 +737,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       BDS3_B5_DOPPLER_MAX_HZ,
+                       (float)BDS3_B5_DOPPLER_MAX_HZ,
                        0.f, /* not used (interoperable with SBAS) */
                        false},
 
@@ -778,7 +778,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GPS_CA_CHIPPING_RATE,
                        false,
                        GPS_L1C_PRN_PERIOD_MS,
-                       GPS_L1_DOPPLER_MAX_HZ,
+                       (float)GPS_L1_DOPPLER_MAX_HZ,
                        0.f, /* see L1S in [1] */
                        false},
     [CODE_QZS_L1CQ] = {CONSTELLATION_QZS,
@@ -791,7 +791,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       GPS_L1_DOPPLER_MAX_HZ,
+                       (float)GPS_L1_DOPPLER_MAX_HZ,
                        0.25f, /* see L1L in [1] */
                        false},
     [CODE_QZS_L1CX] = {CONSTELLATION_QZS,
@@ -804,7 +804,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       GPS_L1_DOPPLER_MAX_HZ,
+                       (float)GPS_L1_DOPPLER_MAX_HZ,
                        0.25f, /* see L1X in [1] */
                        false},
     [CODE_QZS_L2CM] = {CONSTELLATION_QZS,
@@ -817,7 +817,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        QZS_L1CA_CHIPPING_RATE,
                        false,
                        GPS_L2CM_PRN_PERIOD_MS,
-                       QZS_L2_DOPPLER_MAX_HZ,
+                       (float)QZS_L2_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L2S in [1]) */
                        true},
     [CODE_QZS_L2CL] = {CONSTELLATION_QZS,
@@ -830,7 +830,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        QZS_L1CA_CHIPPING_RATE,
                        false,
                        GPS_L2CL_PRN_PERIOD_MS,
-                       QZS_L2_DOPPLER_MAX_HZ,
+                       (float)QZS_L2_DOPPLER_MAX_HZ,
                        0.f, /* see L2L in [1] */
                        false},
     [CODE_QZS_L2CX] = {CONSTELLATION_QZS,
@@ -843,7 +843,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       QZS_L2_DOPPLER_MAX_HZ,
+                       (float)QZS_L2_DOPPLER_MAX_HZ,
                        0.f, /* see L2X in [1] */
                        false},
     [CODE_QZS_L5I] = {CONSTELLATION_QZS,
@@ -856,7 +856,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      QZS_L5_DOPPLER_MAX_HZ,
+                      (float)QZS_L5_DOPPLER_MAX_HZ,
                       0.f, /* reference signal (see L5I in [1]) */
                       false},
     [CODE_QZS_L5Q] = {CONSTELLATION_QZS,
@@ -869,7 +869,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      QZS_L5_DOPPLER_MAX_HZ,
+                      (float)QZS_L5_DOPPLER_MAX_HZ,
                       -0.25f, /* see L5Q in [1] */
                       false},
     [CODE_QZS_L5X] = {CONSTELLATION_QZS,
@@ -882,7 +882,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      QZS_L5_DOPPLER_MAX_HZ,
+                      (float)QZS_L5_DOPPLER_MAX_HZ,
                       0.f, /* must be aligned to CODE_QZS_L5I (see L5X in [1])*/
                       false},
 };

--- a/src/troposphere.c
+++ b/src/troposphere.c
@@ -100,7 +100,7 @@ static double lookup_param(double lat, const double *lut) {
     return lut[4];
   } else {
     /* Otherwise interpolate the value */
-    u8 i = (lat - 15.0) / 15.0;
+    u8 i = (u8)((lat - 15.0) / 15.0);
     double lat_i = i * 15.0 + 15.0;
     return lut[i] + (lut[i + 1] - lut[i]) / 15.0 * (lat - lat_i);
   }
@@ -209,9 +209,9 @@ double calc_troposphere(const gps_time_t *t_gps,
 
   /* Scale surface values to required height */
   double t = t_0 - b * h;
-  double p = p_0 * powf(t / t_0, e_p);
+  double p = p_0 * powf((float)(t / t_0), (float)e_p);
   double dl = l + 1.0;
-  double e = e_0 * powf(t / t_0, e_p * dl);
+  double e = e_0 * powf((float)(t / t_0), (float)(e_p * dl));
 
   /* Compute the acceleration at the mass center
      of a vertical column of the atmosphere */

--- a/tests/check_gnss_time.c
+++ b/tests/check_gnss_time.c
@@ -391,7 +391,7 @@ START_TEST(test_utc_offset) {
   for (size_t i = 0; i < sizeof(testcases) / sizeof(struct utc_offset_testcase);
        i++) {
     double dUTC = get_gps_utc_offset(&testcases[i].t, NULL);
-    double is_lse = is_leap_second_event(&testcases[i].t, NULL);
+    bool is_lse = is_leap_second_event(&testcases[i].t, NULL);
 
     fail_unless(dUTC == testcases[i].dUTC && is_lse == testcases[i].is_lse,
                 "utc_leap_testcase %d failed, expected (%f,%d) got (%f,%d)",

--- a/tests/check_signal.c
+++ b/tests/check_signal.c
@@ -470,7 +470,7 @@ END_TEST
 START_TEST(test_signal_code_requires_direct_acq) {
   bool requires;
 
-  requires = code_to_chip_rate(CODE_GPS_L1CA);
+  requires = code_requires_direct_acq(CODE_GPS_L1CA);
   fail_unless(true == requires, "CODE_GPS_L1CA requires code_to_chip_rate");
 
   requires = code_requires_direct_acq(CODE_GPS_L2CM);


### PR DESCRIPTION
Add `-Wfloat-conversion` flag and fix all the resulting warnings. This is needed so that the same flag can be set e.g. in `gnss-converters` where recently several bugs were found that would have been caught by this (https://github.com/swift-nav/gnss-converters/pull/168).

The changes in `libswiftnav` boil down mostly to adding explicit casting to highlight where truncation happens. No obvious bugs found.

The `-Wfloat-equal` flag and the resulting float comparison fixes were left for later date as they will affect e.g. SBP ephemeris comparisons.

## Testing of downstream uses

- [x] Starling compiles and the integration tests pass (https://github.com/swift-nav/starling/pull/2117)
- [x] piksi_firmware unit tests pass
- [x] piksi_firmware compiles and runs on a device without issues
- [x] gnss_converters unit tests pass
