### PR TITLE
[ORI-344] Add functions to lookup/reverse lookup codes and constellations.

### DIFF
--- a/include/swiftnav/signal.h
+++ b/include/swiftnav/signal.h
@@ -195,6 +195,10 @@ static inline char constellation_to_char(constellation_t cons) {
   }
 }
 
+const char *constellation_to_string(const constellation_t cons);
+
+constellation_t constellation_string_to_enum(const char *constellation_string);
+
 /** Code identifier. */
 typedef enum code_e {
   CODE_INVALID = -1,
@@ -264,6 +268,8 @@ typedef enum code_e {
   CODE_AUX_BDS = 63,
   CODE_COUNT
 } code_t;
+
+code_t code_string_to_enum(const char *code_label);
 
 /** GNSS signal identifier. */
 typedef struct {

--- a/src/signal.c
+++ b/src/signal.c
@@ -11,7 +11,7 @@
  */
 
 #include <assert.h>
-
+#include <string.h>
 #include <swiftnav/array_tools.h>
 #include <swiftnav/constants.h>
 #include <swiftnav/glo_map.h>
@@ -886,6 +886,36 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0.f, /* must be aligned to CODE_QZS_L5I (see L5X in [1])*/
                       false},
 };
+
+static const char *constellation_table[CONSTELLATION_COUNT] = {
+    [CONSTELLATION_GPS] = "GPS",
+    [CONSTELLATION_SBAS] = "SBAS",
+    [CONSTELLATION_GLO] = "GLO",
+    [CONSTELLATION_BDS] = "BDS",
+    [CONSTELLATION_QZS] = "QZS",
+    [CONSTELLATION_GAL] = "GAL"};
+
+const char *constellation_to_string(const constellation_t cons) {
+  return constellation_table[cons];
+}
+
+constellation_t constellation_string_to_enum(const char *constellation_string) {
+  for (s32 i = 0; i < (s32)CONSTELLATION_COUNT; ++i) {
+    if (strcmp(constellation_string, constellation_table[i]) == 0) {
+      return (constellation_t)i;
+    }
+  }
+  return CONSTELLATION_INVALID;
+}
+
+code_t code_string_to_enum(const char *code_label) {
+  for (s32 i = 0; i < (s32)CODE_COUNT; ++i) {
+    if (strcmp(code_label, code_table[i].str) == 0) {
+      return (code_t)i;
+    }
+  }
+  return CODE_INVALID;
+}
 
 typedef struct {
   u8 prn_list[MAX_SBAS_SATS_PER_SYSTEM];


### PR DESCRIPTION
It's helpful to have some utilities that convert between string and enum for constellation_t and code_t. These utilities will be used for reading in various configuration.