### PR TITLE
[ME-168] Some changes associated to enabling L5 (wip)

### DIFF
--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -1490,12 +1490,10 @@ s8 get_tgd_correction(const ephemeris_t *eph,
     case CONSTELLATION_BDS:
       if (CODE_BDS2_B1 == sid->code) {
         *tgd = eph->kepler.tgd.bds_s[0];
-        return 0;
       } else {
         *tgd = eph->kepler.tgd.bds_s[1];
-        return 0;
       }
-      return -1;
+      return 0;
     case CONSTELLATION_GLO:
       /* As per GLO ICD v5.1 2008:
          d_tau = t_f2 - t_f1 -> t_f1 = t_f2 - d_tau.

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -1491,11 +1491,9 @@ s8 get_tgd_correction(const ephemeris_t *eph,
       if (CODE_BDS2_B1 == sid->code) {
         *tgd = eph->kepler.tgd.bds_s[0];
         return 0;
-      } else if (CODE_BDS2_B2 == sid->code) {
+      } else {
         *tgd = eph->kepler.tgd.bds_s[1];
         return 0;
-      } else {
-        log_debug_sid(*sid, "TGD not applied for the signal");
       }
       return -1;
     case CONSTELLATION_GLO:


### PR DESCRIPTION
Quick fix for B2a.. so that no error is raised when L5 comes through.