### PR TITLE
EX-549: enable clang-tidy and fix warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,7 @@
 # See: http://releases.llvm.org/6.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
 
-Checks: "*,-cert-msc30-c,-cert-msc50-cpp,-misc-static-assert,-hicpp-static-assert,-cert-dcl03-c,-hicpp-signed-bitwise,-hicpp-no-assembler,-bugprone-integer-division,-llvm-header-guard"
+Checks: "*,
+         -cert-dcl03-c,-misc-static-assert,-hicpp-static-assert,
+         -hicpp-signed-bitwise,
+         -bugprone-integer-division,
+         -llvm-header-guard"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+# See: http://releases.llvm.org/6.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/list.html
+
+Checks: "*,-cert-msc30-c,-cert-msc50-cpp,-misc-static-assert,-hicpp-static-assert,-cert-dcl03-c,-hicpp-signed-bitwise,-hicpp-no-assembler,-bugprone-integer-division,-llvm-header-guard"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 include/swiftnav/config.h
+/fixes.yaml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,13 +95,13 @@ pipeline {
                             fi
                             '''
 
-                        //                        sh '''#!/bin/bash -ex
-                        //                            (cd build && make clang-tidy-all)
-                        //                            if [ -e "fixes.yaml" ]; then
-                        //                                echo "clang-tidy warning found"
-                        //                                exit 1
-                        //                            fi
-                        //                            '''
+                        sh '''#!/bin/bash -ex
+                            (cd build && make clang-tidy-all)
+                            if [ -e "fixes.yaml" ]; then
+                                echo "clang-tidy warning found"
+                                exit 1
+                            fi
+                            '''
                     }
                     post {
                         always {

--- a/cmake/ClangTools.cmake
+++ b/cmake/ClangTools.cmake
@@ -70,15 +70,15 @@ endif()
 
 if (EXISTS ${CLANG_TIDY_PATH})
   if (NOT TARGET clang-tidy-all)
-    # Tidy all files .cc files (and their headers) in project
+    # Tidy all .c files (and their headers) in project
     # Second stage of pipeline makes an absolute path for each file. Note that
     # git ls-files and diff-tree behave differently in prepending the file path.
     add_custom_target(clang-tidy-all
-      COMMAND git ls-files -- '../src/*.c'
+      COMMAND git ls-files -- '../src/*.[ch]'
       | sed 's/^...//' | sed 's\#\^\#${CMAKE_SOURCE_DIR}/\#'
       | xargs -P 2 -I file "${CLANG_TIDY_PATH}"
-      -export-fixes="${CMAKE_SOURCE_DIR}/fixes.yaml" file --
-      "-I${CMAKE_SOURCE_DIR}/include/"
+      -export-fixes="${CMAKE_SOURCE_DIR}/fixes.yaml" -quiet file --
+      "-I${CMAKE_SOURCE_DIR}/include/" "-I${CMAKE_SOURCE_DIR}/build/"
       )
   endif()
 endif()

--- a/include/swiftnav/almanac.h
+++ b/include/swiftnav/almanac.h
@@ -178,7 +178,7 @@ s8 calc_sat_doppler_almanac(const almanac_t *a,
                             double *doppler);
 
 u8 almanac_valid(const almanac_t *a, const gps_time_t *t);
-u8 almanac_healthy(const almanac_t *a);
+u8 almanac_healthy(const almanac_t *alm);
 
 bool almanac_equal(const almanac_t *a, const almanac_t *b);
 bool almanac_decode_week(const u32 words[8], almanac_ref_week_t *ref_week);

--- a/include/swiftnav/glo_map.h
+++ b/include/swiftnav/glo_map.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-void glo_map_init(void (*lock)(void), void (*unlock)(void));
+void glo_map_init(void (*lock_cb)(void), void (*unlock_cb)(void));
 bool glo_map_valid(const gnss_signal_t sid);
 void glo_map_set_slot_id(u16 fcn, u16 glo_slot_id);
 u16 glo_map_get_fcn(gnss_signal_t sid);

--- a/include/swiftnav/gnss_time.h
+++ b/include/swiftnav/gnss_time.h
@@ -253,15 +253,15 @@ bool gps_time_valid(const gps_time_t *t);
 
 bool gps_current_time_valid(const gps_time_t *t);
 
-void normalize_gps_time(gps_time_t *t_gps);
-void unsafe_normalize_gps_time(gps_time_t *t_gps);
+void normalize_gps_time(gps_time_t *t);
+void unsafe_normalize_gps_time(gps_time_t *t);
 
 time_t gps2time(const gps_time_t *t_gps);
 gps_time_t time2gps_t(const time_t t_unix);
 void gps2utc(const gps_time_t *t, utc_tm *u, const utc_params_t *p);
 void make_utc_tm(const gps_time_t *t, utc_tm *u);
 
-bool gpstime_in_range(const gps_time_t *begin,
+bool gpstime_in_range(const gps_time_t *bgn,
                       const gps_time_t *end,
                       const gps_time_t *t);
 double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning);

--- a/include/swiftnav/set.h
+++ b/include/swiftnav/set.h
@@ -40,7 +40,7 @@ typedef int (*cmp_fn)(const void *a, const void *b);
 int cmp_s32_s32(const void *a, const void *b);
 
 bool is_set(u8 n, size_t sz, const void *set, cmp_fn cmp);
-bool is_sid_set(u8 len, const gnss_signal_t *sids);
+bool is_sid_set(u8 n, const gnss_signal_t *sids);
 
 s32 intersection_map(
     u32 na,

--- a/include/swiftnav/signal.h
+++ b/include/swiftnav/signal.h
@@ -490,7 +490,7 @@ int sat_code_to_string(
 int sid_to_string(char *s, int n, const gnss_signal_t sid);
 bool sid_valid(gnss_signal_t sid);
 bool constellation_valid(constellation_t constellation);
-gnss_signal_t sid_from_code_index(code_t code, u16 code_index);
+gnss_signal_t sid_from_code_index(code_t code, u16 sat_index);
 u16 sid_to_code_index(gnss_signal_t sid);
 constellation_t code_to_constellation(code_t code);
 double sid_to_carr_freq(gnss_signal_t sid);

--- a/src/almanac.c
+++ b/src/almanac.c
@@ -294,7 +294,7 @@ u8 almanac_valid(const almanac_t *a, const gps_time_t *t) {
    * better. */
   /* If dt is greater than fit_interval / 2 seconds our ephemeris isn't valid.
    */
-  if (fabs(dt) > ((u32)a->fit_interval / 2)) {
+  if (fabs(dt) > (a->fit_interval / 2)) {
     return 0;
   }
 
@@ -350,8 +350,9 @@ bool almanac_equal(const almanac_t *a, const almanac_t *b) {
   if (!sid_is_equal(a->sid, b->sid) || (a->ura != b->ura) ||
       (a->fit_interval != b->fit_interval) || (a->valid != b->valid) ||
       (a->health_bits != b->health_bits) || (a->toa.wn != b->toa.wn) ||
-      (a->toa.tow != b->toa.tow))
+      (a->toa.tow != b->toa.tow)) {
     return false;
+  }
 
   switch (sid_to_constellation(a->sid)) {
     case CONSTELLATION_GPS:

--- a/src/bits.c
+++ b/src/bits.c
@@ -90,13 +90,16 @@ s32 getbits(const u8 *buff, u32 pos, u8 len) {
 void setbitu(u8 *buff, u32 pos, u32 len, u32 data) {
   u32 mask = 1u << (len - 1);
 
-  if (len <= 0 || 32 < len) return;
+  if (len <= 0 || 32 < len) {
+    return;
+  }
 
   for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
-    if (data & mask)
+    if (data & mask) {
       buff[i / 8] |= 1u << (7 - i % 8);
-    else
+    } else {
       buff[i / 8] &= ~(1u << (7 - i % 8));
+    }
   }
 }
 
@@ -200,7 +203,9 @@ void bitcopy(
  */
 u8 count_bits_u64(u64 v, u8 bv) {
   u8 r = 0;
-  for (int i = 0; i < 16; i++) r += bitn[(v >> (i * 4)) & 0xf];
+  for (int i = 0; i < 16; i++) {
+    r += bitn[(v >> (i * 4)) & 0xf];
+  }
   return bv == 1 ? r : 64 - r;
 }
 
@@ -214,7 +219,9 @@ u8 count_bits_u64(u64 v, u8 bv) {
  */
 u8 count_bits_u32(u32 v, u8 bv) {
   u8 r = 0;
-  for (int i = 0; i < 8; i++) r += bitn[(v >> (i * 4)) & 0xf];
+  for (int i = 0; i < 8; i++) {
+    r += bitn[(v >> (i * 4)) & 0xf];
+  }
   return bv == 1 ? r : 32 - r;
 }
 
@@ -228,7 +235,9 @@ u8 count_bits_u32(u32 v, u8 bv) {
  */
 u8 count_bits_u16(u16 v, u8 bv) {
   u8 r = 0;
-  for (int i = 0; i < 4; i++) r += bitn[(v >> (i * 4)) & 0xf];
+  for (int i = 0; i < 4; i++) {
+    r += bitn[(v >> (i * 4)) & 0xf];
+  }
   return bv == 1 ? r : 16 - r;
 }
 
@@ -242,7 +251,9 @@ u8 count_bits_u16(u16 v, u8 bv) {
  */
 u8 count_bits_u8(u8 v, u8 bv) {
   u8 r = 0;
-  for (int i = 0; i < 2; i++) r += bitn[(v >> (i * 4)) & 0xf];
+  for (int i = 0; i < 2; i++) {
+    r += bitn[(v >> (i * 4)) & 0xf];
+  }
   return bv == 1 ? r : 8 - r;
 }
 

--- a/src/coord_system.c
+++ b/src/coord_system.c
@@ -60,10 +60,10 @@ void llhrad2deg(const double llh_rad[3], double llh_deg[3]) {
  *  llhdeg2rad(arr1, arr1);
  */
 
-void llhdeg2rad(const double llg_deg[3], double llh_rad[3]) {
-  llh_rad[0] = llg_deg[0] * D2R;
-  llh_rad[1] = llg_deg[1] * D2R;
-  llh_rad[2] = llg_deg[2];
+void llhdeg2rad(const double llh_deg[3], double llh_rad[3]) {
+  llh_rad[0] = llh_deg[0] * D2R;
+  llh_rad[1] = llh_deg[1] * D2R;
+  llh_rad[2] = llh_deg[2];
 }
 
 /** Converts from WGS84 geodetic coordinates (latitude, longitude and height)
@@ -130,10 +130,11 @@ void wgsecef2llh(const double ecef[3], double llh[3]) {
   const double p = sqrt(ecef[0] * ecef[0] + ecef[1] * ecef[1]);
 
   /* Compute longitude first, this can be done exactly. */
-  if (p != 0)
+  if (p != 0) {
     llh[1] = atan2(ecef[1], ecef[0]);
-  else
+  } else {
     llh[1] = 0;
+  }
 
   /* If we are close to the pole then convergence is very slow, treat this is a
    * special case. */
@@ -205,10 +206,9 @@ void wgsecef2llh(const double ecef[3], double llh[3]) {
     /* Check for convergence and exit early if we have converged. */
     if (fabs(S - prev_S) < 1e-16 && fabs(C - prev_C) < 1e-16) {
       break;
-    } else {
-      prev_S = S;
-      prev_C = C;
     }
+    prev_S = S;
+    prev_C = C;
   }
 
   A_n = sqrt(S * S + C * C);
@@ -379,7 +379,9 @@ void wgsecef2azel(const double ecef[3],
   *azimuth = atan2(ned[1], ned[0]);
   /* atan2 returns angle in range [-pi, pi], usually azimuth is defined in the
    * range [0, 2pi]. */
-  if (*azimuth < 0) *azimuth += 2 * M_PI;
+  if (*azimuth < 0) {
+    *azimuth += 2 * M_PI;
+  }
 
   *elevation = asin(-ned[2] / vector_norm(3, ned));
 }

--- a/src/edc.c
+++ b/src/edc.c
@@ -75,8 +75,9 @@ static const u32 crc24qtab[256] = {
  * \return CRC-24Q value
  */
 u32 crc24q(const u8 *buf, u32 len, u32 crc) {
-  for (u32 i = 0; i < len; i++)
+  for (u32 i = 0; i < len; i++) {
     crc = ((crc << 8) & 0xFFFFFF) ^ crc24qtab[((crc >> 16) ^ buf[i]) & 0xff];
+  }
   return crc;
 }
 

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -234,20 +234,27 @@ static s8 calc_sat_state_glo(const ephemeris_t *e,
 
       memcpy(k1, ecef_vel_acc, sizeof(k1));
 
-      for (j = 0; j < 6; j++) y_tmp[j] = y[j] + h / 2 * k1[j];
+      for (j = 0; j < 6; j++) {
+        y_tmp[j] = y[j] + h / 2 * k1[j];
+      }
 
       calc_ecef_vel_acc(k2, &y_tmp[0], &y_tmp[3], e->glo.acc);
 
-      for (j = 0; j < 6; j++) y_tmp[j] = y[j] + h / 2 * k2[j];
+      for (j = 0; j < 6; j++) {
+        y_tmp[j] = y[j] + h / 2 * k2[j];
+      }
 
       calc_ecef_vel_acc(k3, &y_tmp[0], &y_tmp[3], e->glo.acc);
 
-      for (j = 0; j < 6; j++) y_tmp[j] = y[j] + h * k3[j];
+      for (j = 0; j < 6; j++) {
+        y_tmp[j] = y[j] + h * k3[j];
+      }
 
       calc_ecef_vel_acc(k4, &y_tmp[0], &y_tmp[3], e->glo.acc);
 
-      for (j = 0; j < 6; j++)
+      for (j = 0; j < 6; j++) {
         y[j] += h / 6 * (k1[j] + 2 * k2[j] + 2 * k3[j] + k4[j]);
+      }
 
       calc_ecef_vel_acc(ecef_vel_acc, &y[0], &y[3], e->glo.acc);
     }
@@ -368,7 +375,9 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
     temp = 1.0 - ecc * cos(ea_old);
     ea = ea + (ma - ea_old + ecc * sin(ea_old)) / temp;
     count++;
-    if (count > 5) break;
+    if (count > 5) {
+      break;
+    }
   } while (fabs(ea - ea_old) > 1.0E-14);
 
   double ea_dot = ma_dot / temp;
@@ -618,7 +627,7 @@ s8 calc_sat_az_el(const ephemeris_t *e,
   u8 iode;
   double clock_err, clock_rate_err;
   s8 ret;
-  if (check_e)
+  if (check_e) {
     ret = calc_sat_state(e,
                          t,
                          sat_pos,
@@ -628,7 +637,7 @@ s8 calc_sat_az_el(const ephemeris_t *e,
                          &clock_rate_err,
                          &iodc,
                          &iode);
-  else
+  } else {
     ret = calc_sat_state_n(e,
                            t,
                            sat_pos,
@@ -638,6 +647,7 @@ s8 calc_sat_az_el(const ephemeris_t *e,
                            &clock_rate_err,
                            &iodc,
                            &iode);
+  }
   if (ret != 0) {
     return ret;
   }
@@ -987,7 +997,9 @@ static const float gps_ura_values[URA_VALUE_TABLE_LEN] = {
  */
 float decode_ura_index(const u8 index) {
   /* Invalid index */
-  if (URA_VALUE_TABLE_LEN < index) return INVALID_URA_VALUE;
+  if (URA_VALUE_TABLE_LEN < index) {
+    return INVALID_URA_VALUE;
+  }
 
   return gps_ura_values[index];
 }
@@ -999,10 +1011,14 @@ float decode_ura_index(const u8 index) {
  */
 u8 encode_ura(float ura) {
   /* Negative URA */
-  if (0 > ura) return INVALID_GPS_URA_INDEX;
+  if (0 > ura) {
+    return INVALID_GPS_URA_INDEX;
+  }
 
   for (u8 i = 0; i < URA_VALUE_TABLE_LEN; i++) {
-    if (gps_ura_values[i] >= ura) return i;
+    if (gps_ura_values[i] >= ura) {
+      return i;
+    }
   }
 
   /* No valid URA index found */
@@ -1258,8 +1274,9 @@ bool ephemeris_equal(const ephemeris_t *a, const ephemeris_t *b) {
   if (!sid_is_equal(a->sid, b->sid) || (a->ura != b->ura) ||
       (a->fit_interval != b->fit_interval) || (a->valid != b->valid) ||
       (a->health_bits != b->health_bits) || (a->toe.wn != b->toe.wn) ||
-      (a->toe.tow != b->toe.tow))
+      (a->toe.tow != b->toe.tow)) {
     return false;
+  }
 
   switch (sid_to_constellation(a->sid)) {
     case CONSTELLATION_GPS:
@@ -1535,16 +1552,17 @@ s8 get_tgd_correction(const ephemeris_t *eph,
         /* The first TGD correction is for the (E1,E5a) combination */
         *tgd = (float)(gamma * eph->kepler.tgd.gal_s[0]);
         return 0;
-      } else if (CODE_GAL_E1B == sid->code || CODE_GAL_E1C == sid->code ||
-                 CODE_GAL_E1X == sid->code || CODE_GAL_E7I == sid->code ||
-                 CODE_GAL_E7Q == sid->code || CODE_GAL_E7X == sid->code) {
+      }
+      if (CODE_GAL_E1B == sid->code || CODE_GAL_E1C == sid->code ||
+          CODE_GAL_E1X == sid->code || CODE_GAL_E7I == sid->code ||
+          CODE_GAL_E7Q == sid->code || CODE_GAL_E7X == sid->code) {
         /* The clock corrections from INAV are for the (E1,E5b) combination, so
          * use the matching group delay correction for all the other signals */
         *tgd = (float)(gamma * eph->kepler.tgd.gal_s[1]);
         return 0;
-      } else {
-        log_debug_sid(*sid, "TGD not applied for the signal");
       }
+      log_debug_sid(*sid, "TGD not applied for the signal");
+
       return -1;
     case CONSTELLATION_INVALID:
     case CONSTELLATION_SBAS:

--- a/src/gnss_time.c
+++ b/src/gnss_time.c
@@ -284,8 +284,12 @@ double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning) {
   if (end->wn == WN_UNKNOWN || beginning->wn == WN_UNKNOWN) {
     /* One or both of the week numbers is unspecified.  Assume times
        are within +/- 0.5 weeks of each other. */
-    if (dt > WEEK_SECS / 2) dt -= WEEK_SECS;
-    if (dt < -WEEK_SECS / 2) dt += WEEK_SECS;
+    if (dt > WEEK_SECS / 2) {
+      dt -= WEEK_SECS;
+    }
+    if (dt < -WEEK_SECS / 2) {
+      dt += WEEK_SECS;
+    }
   } else {
     /* Week numbers were provided - use them. */
     dt += (end->wn - beginning->wn) * WEEK_SECS;
@@ -300,7 +304,6 @@ double gpsdifftime(const gps_time_t *end, const gps_time_t *beginning) {
 void add_secs(gps_time_t *time, double secs) {
   time->tow += secs;
   unsafe_normalize_gps_time(time);
-  return;
 }
 
 /** Given an unknown week number in t, fill in the week number from ref
@@ -315,10 +318,11 @@ void gps_time_match_weeks(gps_time_t *t, const gps_time_t *ref) {
   }
   t->wn = ref->wn;
   double dt = t->tow - ref->tow;
-  if (dt > WEEK_SECS / 2)
+  if (dt > WEEK_SECS / 2) {
     t->wn--;
-  else if (dt < -WEEK_SECS / 2)
+  } else if (dt < -WEEK_SECS / 2) {
     t->wn++;
+  }
 
   if (!gps_time_valid(t)) {
     log_info(
@@ -392,7 +396,8 @@ gps_time_t glo2gps(const glo_time_t *glo_t, const utc_params_t *utc_params) {
 
   if (glo_t->nt < GLO_NT_0_FLOOR) {
     return GPS_TIME_UNKNOWN;
-  } else if (glo_t->nt <= GLO_NT_0_CEILING) {
+  }
+  if (glo_t->nt <= GLO_NT_0_CEILING) {
     year_of_cycle = 1;
     day_of_year = glo_t->nt;
   } else if (glo_t->nt <= GLO_NT_1_CEILING) {
@@ -782,9 +787,8 @@ u8 days_in_month(u16 year, u8 month) {
       0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   if (month == 2 && is_leap_year(year)) {
     return 29;
-  } else {
-    return days_in_month_lookup[month];
   }
+  return days_in_month_lookup[month];
 }
 
 /** Difference between GPS and UTC time. Use UTC params struct if given,
@@ -883,9 +887,8 @@ bool is_leap_second_event(const gps_time_t *t, const utc_params_t *p) {
     if (dt >= 0.0 && dt < 1.0) {
       /* time is during the leap second event */
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   /* iterate through the leap second table, starting from latest */
@@ -897,7 +900,8 @@ bool is_leap_second_event(const gps_time_t *t, const utc_params_t *p) {
     if (dt > 1.0) {
       /* time is past the last known leap second event */
       return false;
-    } else if (dt >= 0.0 && dt < 1.0) {
+    }
+    if (dt >= 0.0 && dt < 1.0) {
       /* time is during the leap second event */
       return true;
     }

--- a/src/linear_algebra.c
+++ b/src/linear_algebra.c
@@ -121,44 +121,63 @@ s32 qrdecomp_square(const double *a, u32 rows, double *qt, double *r) {
 
   for (k = 0; k < rows - 1; k++) {
     scale = 0.0;
-    for (i = k; i < rows; i++) scale = fmax(scale, fabs(r[i * rows + k]));
+    for (i = k; i < rows; i++) {
+      scale = fmax(scale, fabs(r[i * rows + k]));
+    }
     if (scale == 0.0) {
       sing = -11;
       c[k] = d[k] = 0.0;
     } else {
-      for (i = k; i < rows; i++) r[i * rows + k] /= scale;
-      for (sum = 0.0, i = k; i < rows; i++)
+      for (i = k; i < rows; i++) {
+        r[i * rows + k] /= scale;
+      }
+      for (sum = 0.0, i = k; i < rows; i++) {
         sum += r[i * rows + k] * r[i * rows + k];
+      }
       sigma = copysign(sqrt(sum), r[k * rows + k]);
       r[k * rows + k] += sigma;
       c[k] = sigma * r[k * rows + k];
       d[k] = -scale * sigma;
       for (j = k + 1; j < rows; j++) {
-        for (sum = 0.0, i = k; i < rows; i++)
+        for (sum = 0.0, i = k; i < rows; i++) {
           sum += r[i * rows + k] * r[i * rows + j];
+        }
         tau = sum / c[k];
-        for (i = k; i < rows; i++) r[i * rows + j] -= tau * r[i * rows + k];
+        for (i = k; i < rows; i++) {
+          r[i * rows + j] -= tau * r[i * rows + k];
+        }
       }
     }
   }
   d[rows - 1] = r[(rows - 1) * rows + rows - 1];
-  if (d[rows - 1] == 0.0) sing = -11;
+  if (d[rows - 1] == 0.0) {
+    sing = -11;
+  }
   for (i = 0; i < rows; i++) {
-    for (j = 0; j < rows; j++) qt[i * rows + j] = 0.0;
+    for (j = 0; j < rows; j++) {
+      qt[i * rows + j] = 0.0;
+    }
     qt[i * rows + i] = 1.0;
   }
   for (k = 0; k < rows - 1; k++) {
-    if (c[k] != 0.0)
+    if (c[k] != 0.0) {
       for (j = 0; j < rows; j++) {
         sum = 0.0;
-        for (i = k; i < rows; i++) sum += r[i * rows + k] * qt[i * rows + j];
+        for (i = k; i < rows; i++) {
+          sum += r[i * rows + k] * qt[i * rows + j];
+        }
         sum /= c[k];
-        for (i = k; i < rows; i++) qt[i * rows + j] -= sum * r[i * rows + k];
+        for (i = k; i < rows; i++) {
+          qt[i * rows + j] -= sum * r[i * rows + k];
+        }
       }
+    }
   }
   for (i = 0; i < rows; i++) {
     r[i * rows + i] = d[i];
-    for (j = 0; j < i; j++) r[i * rows + j] = 0.0;
+    for (j = 0; j < i; j++) {
+      r[i * rows + j] = 0.0;
+    }
   }
 
   LSN_FREE(c);
@@ -182,7 +201,9 @@ void qtmult(const double *qt, u32 n, const double *b, double *x) {
   double sum;
   for (i = 0; i < n; i++) {
     sum = 0.0;
-    for (j = 0; j < n; j++) sum += qt[i * n + j] * b[j];
+    for (j = 0; j < n; j++) {
+      sum += qt[i * n + j] * b[j];
+    }
     x[i] = sum;
   }
 }
@@ -206,7 +227,9 @@ void rsolve(const double *r, u32 rows, u32 cols, const double *b, double *x) {
   double sum;
   for (i = rows - 1; i >= 0; i--) {
     sum = b[i];
-    for (j = i + 1; j < (int)rows; j++) sum -= r[i * cols + j] * x[j];
+    for (j = i + 1; j < (int)rows; j++) {
+      sum -= r[i * cols + j] * x[j];
+    }
     x[i] = sum / r[i * cols + i];
   }
 }
@@ -254,7 +277,9 @@ s32 qrsolve(const double *a, u32 rows, u32 cols, const double *b, double *x) {
  */
 static inline int inv2(const double *a, double *b) {
   double det = a[0] * a[3] - a[1] * a[2];
-  if (fabs(det) < MATRIX_EPSILON) return -1;
+  if (fabs(det) < MATRIX_EPSILON) {
+    return -1;
+  }
   b[0] = a[3] / det;
   b[1] = -a[1] / det;
   b[2] = -a[2] / det;
@@ -279,7 +304,9 @@ static inline int inv3(const double *a, double *b) {
        a[3 * 1 + 2] *
            -(a[3 * 0 + 0] * a[3 * 2 + 1] - a[3 * 0 + 1] * a[3 * 2 + 0]));
 
-  if (fabs(det) < MATRIX_EPSILON) return -1;
+  if (fabs(det) < MATRIX_EPSILON) {
+    return -1;
+  }
 
   b[3 * 0 + 0] =
       (a[3 * 1 + 1] * a[3 * 2 + 2] - a[3 * 1 + 2] * a[3 * 2 + 1]) / det;
@@ -340,7 +367,9 @@ static inline int inv4(const double *a, double *b) {
                        a[4 * 2 + 2] * -(a[4 * 0 + 0] * a[4 * 3 + 1] -
                                         a[4 * 0 + 1] * a[4 * 3 + 0])));
 
-  if (fabs(det) < MATRIX_EPSILON) return -1;
+  if (fabs(det) < MATRIX_EPSILON) {
+    return -1;
+  }
 
   b[4 * 0 + 0] =
       ((a[4 * 2 + 1] *
@@ -501,7 +530,9 @@ static int rref(u32 order, u32 cols, double *m) {
     maxrow = i;
     for (j = i + 1; j < (int)order; j++) {
       /* Find the maximum pivot */
-      if (fabs(m[j * cols + i]) > fabs(m[maxrow * cols + i])) maxrow = j;
+      if (fabs(m[j * cols + i]) > fabs(m[maxrow * cols + i])) {
+        maxrow = j;
+      }
     }
     row_swap(&m[i * cols], &m[maxrow * cols], cols);
     if (fabs(m[i * cols + i]) <= MATRIX_EPSILON) {
@@ -640,10 +671,15 @@ inline int matrix_inverse(u32 n, const double *const a, double *b) {
  *  \return     -1 if a is singular; 0 otherwise.
  */
 int matrix_pseudoinverse(u32 n, u32 m, const double *a, double *b) {
-  if (n == m) return matrix_inverse(n, a, b);
-  if (n > m) return matrix_ataiat(n, m, a, b);
-  if (n < m) /* n < m */
+  if (n == m) {
+    return matrix_inverse(n, a, b);
+  }
+  if (n > m) {
+    return matrix_ataiat(n, m, a, b);
+  }
+  if (n < m) { /* n < m */
     return matrix_ataati(n, m, a, b);
+  }
   return -1;
 }
 
@@ -685,12 +721,14 @@ inline int matrix_atwaiat(
       if (i == j) {
         /* If this is a diagonal element, just sum the squares of the
          * column of A weighted by the weighting vector. */
-        for (k = 0; k < n; k++)
+        for (k = 0; k < n; k++) {
           c[m * i + j] += w[k] * a[m * k + j] * a[m * k + j];
+        }
       } else {
         /* Otherwise, assign both off-diagonal elements at once. */
-        for (k = 0; k < n; k++)
+        for (k = 0; k < n; k++) {
           c[m * i + j] = c[m * j + i] = w[k] * a[m * k + j] * a[m * k + i];
+        }
         c[m * j + i] = c[m * i + j];
       }
     }
@@ -702,7 +740,9 @@ inline int matrix_atwaiat(
     for (i = 0; i < m; i++) {
       for (j = 0; j < n; j++) {
         b[n * i + j] = 0;
-        for (k = 0; k < m; k++) b[n * i + j] += inv[n * i + k] * a[m * j + k];
+        for (k = 0; k < m; k++) {
+          b[n * i + j] += inv[n * i + k] * a[m * j + k];
+        }
       }
     }
   }
@@ -751,12 +791,14 @@ inline int matrix_atawati(
       if (i == j) {
         /* If this is a diagonal element, just sum the squares of the
          * column of A weighted by the weighting vector. */
-        for (k = 0; k < n; k++)
+        for (k = 0; k < n; k++) {
           c[m * i + j] += w[k] * a[m * k + j] * a[m * k + j];
+        }
       } else {
         /* Otherwise, assign both off-diagonal elements at once. */
-        for (k = 0; k < n; k++)
+        for (k = 0; k < n; k++) {
           c[m * i + j] = c[m * j + i] = w[k] * a[m * k + j] * a[m * k + i];
+        }
         c[m * j + i] = c[m * i + j];
       }
     }
@@ -768,7 +810,9 @@ inline int matrix_atawati(
     for (i = 0; i < m; i++) {
       for (j = 0; j < n; j++) {
         b[n * i + j] = 0;
-        for (k = 0; k < m; k++) b[n * i + j] += inv[n * i + k] * a[m * j + k];
+        for (k = 0; k < m; k++) {
+          b[n * i + j] += inv[n * i + k] * a[m * j + k];
+        }
       }
     }
   }
@@ -795,7 +839,9 @@ inline int matrix_ataiat(u32 n, u32 m, const double *a, double *b) {
   int res;
   double *w = LSN_ALLOCATE(n * sizeof(double));
   assert(w != NULL);
-  for (i = 0; i < n; i++) w[i] = 1;
+  for (i = 0; i < n; i++) {
+    w[i] = 1;
+  }
   res = matrix_atwaiat(n, m, a, w, b);
   LSN_FREE(w);
   return res;
@@ -818,7 +864,9 @@ inline int matrix_ataati(u32 n, u32 m, const double *a, double *b) {
   int res;
   double *w = LSN_ALLOCATE(n * sizeof(double));
   assert(w != NULL);
-  for (i = 0; i < n; i++) w[i] = 1;
+  for (i = 0; i < n; i++) {
+    w[i] = 1;
+  }
   res = matrix_atawati(n, m, a, w, b);
   LSN_FREE(w);
   return res;
@@ -840,31 +888,40 @@ inline int matrix_ataati(u32 n, u32 m, const double *a, double *b) {
 inline void matrix_multiply(
     u32 n, u32 m, u32 p, const double *a, const double *b, double *c) {
   u32 i, j, k;
-  for (i = 0; i < n; i++)
+  for (i = 0; i < n; i++) {
     for (j = 0; j < p; j++) {
       c[p * i + j] = 0;
-      for (k = 0; k < m; k++) c[p * i + j] += a[m * i + k] * b[p * k + j];
+      for (k = 0; k < m; k++) {
+        c[p * i + j] += a[m * i + k] * b[p * k + j];
+      }
     }
+  }
 }
 
 inline void matrix_multiply_i(
     u32 n, u32 m, u32 p, const s32 *a, const s32 *b, s32 *c) {
   u32 i, j, k;
-  for (i = 0; i < n; i++)
+  for (i = 0; i < n; i++) {
     for (j = 0; j < p; j++) {
       c[p * i + j] = 0;
-      for (k = 0; k < m; k++) c[p * i + j] += a[m * i + k] * b[p * k + j];
+      for (k = 0; k < m; k++) {
+        c[p * i + j] += a[m * i + k] * b[p * k + j];
+      }
     }
+  }
 }
 
 inline void matrix_multiply_s64(
     u32 n, u32 m, u32 p, const s64 *a, const s64 *b, s64 *c) {
   u32 i, j, k;
-  for (i = 0; i < n; i++)
+  for (i = 0; i < n; i++) {
     for (j = 0; j < p; j++) {
       c[p * i + j] = 0;
-      for (k = 0; k < m; k++) c[p * i + j] += a[m * i + k] * b[p * k + j];
+      for (k = 0; k < m; k++) {
+        c[p * i + j] += a[m * i + k] * b[p * k + j];
+      }
     }
+  }
 }
 
 /** In-place multiplication of a matrix from right with a diagonal matrix.
@@ -944,26 +1001,26 @@ int matrix_wlsq_solve(u32 n,
   }
 
   /* AtW := A^{T} */
-  matrix_transpose(n, m, A, (double *)AtW);
+  matrix_transpose(n, m, A, AtW);
   /* multiply in the weight matrix if it is given */
   if (NULL != w) {
     /* AtW := A^{T} W */
-    matrix_multiply_diag_right(m, n, (double *)AtW, (double *)w);
+    matrix_multiply_diag_right(m, n, AtW, w);
   }
   /* AtWA := A^{T} W A */
-  matrix_multiply(m, n, m, (double *)AtW, (double *)A, (double *)AtWA);
+  matrix_multiply(m, n, m, AtW, A, AtWA);
 
   /* V  := AtWA^{-1} */
-  int res = matrix_inverse(m, (double *)AtWA, V);
+  int res = matrix_inverse(m, AtWA, V);
 
   /* produce solution only if a pointer for it is given */
   if ((0 == res) && (NULL != x)) {
     /* P is the weighted Moore-Penrose pseudoinverse of A */
     /* P := V * A^{T} * W */
-    matrix_multiply(m, m, n, V, (double *)AtW, (double *)P);
+    matrix_multiply(m, m, n, V, AtW, P);
 
     /* The wlsq solution is then P * b */
-    matrix_multiply(m, n, 1, (double *)P, (double *)b, (double *)x);
+    matrix_multiply(m, n, 1, P, b, x);
   }
 
   LSN_FREE(P);
@@ -1110,8 +1167,11 @@ void matrix_reconstruct_udu(const u32 n,
 void matrix_add_sc(
     u32 n, u32 m, const double *a, const double *b, double gamma, double *c) {
   u32 i, j;
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++) c[m * i + j] = a[m * i + j] + gamma * b[m * i + j];
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < m; j++) {
+      c[m * i + j] = a[m * i + j] + gamma * b[m * i + j];
+    }
+  }
 }
 
 /** Transpose a matrix.
@@ -1126,8 +1186,11 @@ void matrix_add_sc(
  */
 void matrix_transpose(u32 n, u32 m, const double *a, double *b) {
   u32 i, j;
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++) b[n * j + i] = a[m * i + j];
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < m; j++) {
+      b[n * j + i] = a[m * i + j];
+    }
+  }
 }
 
 /** Copy a matrix.
@@ -1141,8 +1204,11 @@ void matrix_transpose(u32 n, u32 m, const double *a, double *b) {
  */
 void matrix_copy(u32 n, u32 m, const double *a, double *b) {
   u32 i, j;
-  for (i = 0; i < n; i++)
-    for (j = 0; j < m; j++) b[m * i + j] = a[m * i + j];
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < m; j++) {
+      b[m * i + j] = a[m * i + j];
+    }
+  }
 }
 
 /* \} */
@@ -1165,7 +1231,9 @@ void matrix_copy(u32 n, u32 m, const double *a, double *b) {
 double vector_dot(u32 n, const double *a, const double *b) {
   u32 i;
   double out = 0;
-  for (i = 0; i < n; i++) out += a[i] * b[i];
+  for (i = 0; i < n; i++) {
+    out += a[i] * b[i];
+  }
   return out;
 }
 
@@ -1181,7 +1249,9 @@ double vector_dot(u32 n, const double *a, const double *b) {
 double vector_norm(u32 n, const double *a) {
   u32 i;
   double out = 0;
-  for (i = 0; i < n; i++) out += a[i] * a[i];
+  for (i = 0; i < n; i++) {
+    out += a[i] * a[i];
+  }
   return sqrt(out);
 }
 
@@ -1196,7 +1266,9 @@ double vector_norm(u32 n, const double *a) {
 double vector_mean(u32 n, const double *a) {
   u32 i;
   double out = 0;
-  for (i = 0; i < n; i++) out += a[i];
+  for (i = 0; i < n; i++) {
+    out += a[i];
+  }
   return out / n;
 }
 
@@ -1210,7 +1282,9 @@ double vector_mean(u32 n, const double *a) {
 void vector_normalize(u32 n, double *a) {
   u32 i;
   double norm = vector_norm(n, a);
-  for (i = 0; i < n; i++) a[i] /= norm;
+  for (i = 0; i < n; i++) {
+    a[i] /= norm;
+  }
 }
 
 /** Add a vector with a scaled vector.
@@ -1227,7 +1301,9 @@ void vector_normalize(u32 n, double *a) {
 void vector_add_sc(
     u32 n, const double *a, const double *b, double gamma, double *c) {
   u32 i;
-  for (i = 0; i < n; i++) c[i] = a[i] + gamma * b[i];
+  for (i = 0; i < n; i++) {
+    c[i] = a[i] + gamma * b[i];
+  }
 }
 
 /** Add two vectors.

--- a/src/linear_algebra.c
+++ b/src/linear_algebra.c
@@ -523,6 +523,7 @@ static void row_swap(double *a, double *b, u32 size) {
 /* rref is "reduced row echelon form" -- a helper function for the
  * gaussian elimination code. */
 static int rref(u32 order, u32 cols, double *m) {
+  assert(cols > 0);
   int i, j, k, maxrow;
   double tmp;
 
@@ -586,6 +587,7 @@ inline int matrix_inverse(u32 n, const double *const a, double *b) {
    * least-squares fit.  (This may apply also to a least-norm fit if
    * we have too few satellites.)  The Cholesky decomposition becomes
    * even more important for unscented filters. */
+  assert(n > 0);
   int res;
   u32 i, j, k, cols = n * 2;
   double *m = LSN_ALLOCATE(n * cols * sizeof(double));
@@ -702,6 +704,8 @@ inline int matrix_atwaiat(
     u32 n, u32 m, const double *a, const double *w, double *b) {
   u32 i, j, k;
 
+  assert(n > 0 && m > 0);
+
   /* Check to make sure we're doing the right operation */
   if (n <= m) {
     return -1;
@@ -770,6 +774,8 @@ inline int matrix_atwaiat(
 inline int matrix_atawati(
     u32 n, u32 m, const double *a, const double *w, double *b) {
   u32 i, j, k;
+
+  assert(n > 0 && m > 0);
 
   /* Check to make sure we're doing the right operation */
   if (n <= m) {

--- a/src/logging_common.c
+++ b/src/logging_common.c
@@ -36,15 +36,21 @@ const char *truncate_path_(char *path) {
   assert(NULL != path);
   int i;
 
-  if (path[0] == '\0') return "";
-  for (i = strlen(path) - 1; i >= 0 && path[i] == '/'; i--)
+  if (path[0] == '\0') {
+    return "";
+  }
+  for (i = strlen(path) - 1; i >= 0 && path[i] == '/'; i--) {
     ;
-  if (i == -1) return "/";
-  // set the trailing character to null in case it was '/'
-  // e.g. /dev/null/
+  }
+  if (i == -1) {
+    return "/";
+  }
+  /* set the trailing character to null in case it was '/' e.g. /dev/null/ */
   path[i + 1] = '\0';
-  // Go backwards until the prior '/'
-  while (i >= 0 && path[i] != '/') i--;
-  // Return a pointer to the remainder
+  /* Go backwards until the prior '/' */
+  while (i >= 0 && path[i] != '/') {
+    i--;
+  }
+  /* Return a pointer to the remainder */
   return &path[i + 1];
 }

--- a/src/nav_meas.c
+++ b/src/nav_meas.c
@@ -58,16 +58,14 @@ u8 encode_lock_time(double nm_lock_time) {
 
   if (ms_lock_time < 32) {
     return 0;
-  } else {
-    for (u8 i = 0; i < 16; i++) {
-      if (ms_lock_time > (1u << (i + 5))) {
-        continue;
-      } else {
-        return i;
-      }
-    }
-    return 15;
   }
+  for (u8 i = 0; i < 16; i++) {
+    if (ms_lock_time > (1u << (i + 5))) {
+      continue;
+    }
+    return i;
+  }
+  return 15;
 }
 
 /** Convert SBP lock time into navigation_measurement_t.lock_time.

--- a/src/set.c
+++ b/src/set.c
@@ -204,8 +204,9 @@ s32 intersection(u32 na,
 u32 insertion_index(u32 na, size_t sa, const void *as, void *b, cmp_fn cmp) {
   u32 index;
   for (index = 0; index < na && cmp((const char *)as + index * sa, b) < 0;
-       index++)
+       index++) {
     ;
+  }
   return index;
 }
 

--- a/src/signal.c
+++ b/src/signal.c
@@ -21,7 +21,7 @@
  * \{ */
 
 /** Element in the code data table. */
-typedef struct {
+typedef struct { /* NOLINT(clang-analyzer-optin.performance.Padding) */
   constellation_t constellation;
   u16 sat_count;
   u16 sig_count;
@@ -1241,7 +1241,7 @@ const u8 *get_sbas_prn_list(sbas_system_t sbas_system) {
 sbas_system_t get_sbas_system(const gnss_signal_t sid) {
   assert(IS_SBAS(sid));
   for (sbas_system_t sbas_system = (sbas_system_t)0; sbas_system < SBAS_COUNT;
-       sbas_system = (sbas_system_t)(sbas_system + 1)) {
+       sbas_system = sbas_system + 1) {
     if (is_value_in_array(sbas_prn_table[sbas_system].prn_list,
                           MAX_SBAS_SATS_PER_SYSTEM,
                           sid.sat)) {

--- a/src/signal.c
+++ b/src/signal.c
@@ -291,7 +291,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GLO_CA_CHIPPING_RATE,
                        true,
                        GLO_PRN_PERIOD_MS,
-                       (float)GLO_L1_DOPPLER_MAX_HZ,
+                       GLO_L1_DOPPLER_MAX_HZ,
                        0.f, /* reference signal (see L1C in [1]) */
                        true},
     [CODE_GLO_L2OF] = {CONSTELLATION_GLO,
@@ -317,7 +317,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                       0,
                       false,
                       0,
-                      (float)GLO_L1_DOPPLER_MAX_HZ,
+                      GLO_L1_DOPPLER_MAX_HZ,
                       0.25f, /* see L1P in [1] */
                       false},
     [CODE_GLO_L2P] = {CONSTELLATION_GLO,
@@ -594,7 +594,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         BDS3_B1C_CHIPPING_RATE,
                         false,
                         BDS3_B1C_PRN_PERIOD_MS,
-                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
+                        BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B1CQ] = {CONSTELLATION_BDS,
@@ -607,7 +607,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         0,
                         false,
                         0,
-                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
+                        BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B1CX] = {CONSTELLATION_BDS,
@@ -620,7 +620,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                         0,
                         false,
                         0,
-                        (float)BDS3_B1C_DOPPLER_MAX_HZ,
+                        BDS3_B1C_DOPPLER_MAX_HZ,
                         0.f, /* not used (interoperable with SBAS) */
                         false},
     [CODE_BDS3_B3I] = {CONSTELLATION_BDS,
@@ -778,7 +778,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        GPS_CA_CHIPPING_RATE,
                        false,
                        GPS_L1C_PRN_PERIOD_MS,
-                       (float)GPS_L1_DOPPLER_MAX_HZ,
+                       GPS_L1_DOPPLER_MAX_HZ,
                        0.f, /* see L1S in [1] */
                        false},
     [CODE_QZS_L1CQ] = {CONSTELLATION_QZS,
@@ -791,7 +791,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       (float)GPS_L1_DOPPLER_MAX_HZ,
+                       GPS_L1_DOPPLER_MAX_HZ,
                        0.25f, /* see L1L in [1] */
                        false},
     [CODE_QZS_L1CX] = {CONSTELLATION_QZS,
@@ -804,7 +804,7 @@ static const code_table_element_t code_table[CODE_COUNT] = {
                        0,
                        false,
                        0,
-                       (float)GPS_L1_DOPPLER_MAX_HZ,
+                       GPS_L1_DOPPLER_MAX_HZ,
                        0.25f, /* see L1X in [1] */
                        false},
     [CODE_QZS_L2CM] = {CONSTELLATION_QZS,
@@ -1050,7 +1050,7 @@ bool constellation_valid(constellation_t constellation) {
 /** Convert a code-specific signal index to a gnss_signal_t.
  *
  * \param code          Code to use.
- * \param code_index    Code-specific signal index in
+ * \param sat_index    Code-specific signal index in
  *                      [0, SIGNAL_COUNT_\<code\>).
  *
  * \return gnss_signal_t corresponding to code and sat_index.
@@ -1106,7 +1106,8 @@ double sid_to_carr_freq(gnss_signal_t sid) {
     assert(glo_map_valid(sid));
     return GLO_L1_HZ +
            (glo_map_get_fcn(sid) - GLO_FCN_OFFSET) * GLO_L1_DELTA_HZ;
-  } else if (CODE_GLO_L2OF == sid.code) {
+  }
+  if (CODE_GLO_L2OF == sid.code) {
     assert(glo_map_valid(sid));
     return GLO_L2_HZ +
            (glo_map_get_fcn(sid) - GLO_FCN_OFFSET) * GLO_L2_DELTA_HZ;
@@ -1128,7 +1129,8 @@ double sid_to_lambda(gnss_signal_t sid) {
     assert(glo_map_valid(sid));
     return GPS_C / (GLO_L1_HZ +
                     (glo_map_get_fcn(sid) - GLO_FCN_OFFSET) * GLO_L1_DELTA_HZ);
-  } else if (CODE_GLO_L2OF == sid.code) {
+  }
+  if (CODE_GLO_L2OF == sid.code) {
     assert(glo_map_valid(sid));
     return GPS_C / (GLO_L2_HZ +
                     (glo_map_get_fcn(sid) - GLO_FCN_OFFSET) * GLO_L2_DELTA_HZ);

--- a/src/signal.c
+++ b/src/signal.c
@@ -21,7 +21,7 @@
  * \{ */
 
 /** Element in the code data table. */
-typedef struct { /* NOLINT(clang-analyzer-optin.performance.Padding) */
+typedef struct {
   constellation_t constellation;
   u16 sat_count;
   u16 sig_count;

--- a/src/signal.c
+++ b/src/signal.c
@@ -21,7 +21,7 @@
  * \{ */
 
 /** Element in the code data table. */
-typedef struct {
+typedef struct { /* NOLINT(clang-analyzer-optin.performance.Padding) */
   constellation_t constellation;
   u16 sat_count;
   u16 sig_count;

--- a/src/single_epoch_solver.c
+++ b/src/single_epoch_solver.c
@@ -761,6 +761,7 @@ static s8 pvt_iter(const u8 n_used,
                    const bool disable_velocity,
                    const navigation_measurement_t **nav_meas,
                    lsq_data_t *lsq_data) {
+  assert(n_used > 0);
   /* Reset state to zero */
   memset(lsq_data->rx_state, 0, 8 * sizeof(double));
 

--- a/src/single_epoch_solver.c
+++ b/src/single_epoch_solver.c
@@ -505,10 +505,10 @@ static s8 pvt_solve(const u8 n_used,
   /* Solve the state update and its covariance matrix */
   int ret = matrix_wlsq_solve(n_used,
                               N_STATE,
-                              (double *)G,
+                              G,
                               (double *)lsq_data->omp_range,
-                              (double *)w,
-                              (double *)correction,
+                              w,
+                              correction,
                               (double *)lsq_data->V);
   if (ret < 0) {
     log_warn("Under-determined system, n_used = %u", n_used);
@@ -547,7 +547,7 @@ static s8 pvt_solve(const u8 n_used,
      move to get a better solution) in terms of the receiver state. */
   if (matrix_wlsq_solve(n_used,
                         N_STATE,
-                        (double *)G,
+                        G,
                         (double *)lsq_data->omp_range,
                         NULL,
                         NULL,

--- a/src/troposphere.c
+++ b/src/troposphere.c
@@ -96,14 +96,14 @@ static double lookup_param(double lat, const double *lut) {
   if (lat <= 15.0) {
     return lut[0];
     /* Below/above +/- 75 degrees latitude */
-  } else if (lat >= 75.0) {
-    return lut[4];
-  } else {
-    /* Otherwise interpolate the value */
-    u8 i = (u8)((lat - 15.0) / 15.0);
-    double lat_i = i * 15.0 + 15.0;
-    return lut[i] + (lut[i + 1] - lut[i]) / 15.0 * (lat - lat_i);
   }
+  if (lat >= 75.0) {
+    return lut[4];
+  }
+  /* Otherwise interpolate the value */
+  u8 i = (u8)((lat - 15.0) / 15.0);
+  double lat_i = i * 15.0 + 15.0;
+  return lut[i] + (lut[i + 1] - lut[i]) / 15.0 * (lat - lat_i);
 }
 
 static double calc_param(double lat,


### PR DESCRIPTION
Enabled most warnings on clang-tidy, resulting in mostly trivial fixes.

Checked that a warning produced by clang-tidy fails the Jenkins build and displays the warning in the artifacts.