### PR TITLE
Fix non-dll build [ESD-1153]

### DIFF
--- a/include/swiftnav/common.h
+++ b/include/swiftnav/common.h
@@ -47,8 +47,8 @@ extern "C" {
 #endif /* _MSC_VER */
 
 #if defined(_MSC_VER)
-#if defined(swiftnav_EXTENSION)
-/* If building Python C extension -> leave empty */
+#if !defined(_WINDLL)
+/* Leave empty when doing non-dll build */
 #define LIBSWIFTNAV_DECLSPEC
 #elif defined(swiftnav_EXPORTS) /* swiftnav_EXTENSION */
 #define LIBSWIFTNAV_DECLSPEC __declspec(dllexport)


### PR DESCRIPTION
`swiftnav_EXTENSION` is manually defined switch. It's better to use MSVC originated and more generic switch `_WINDLL`.

https://github.com/swift-nav/libsettings/pull/30