### PR TITLE
Tao bds

### DIFF
--- a/include/swiftnav/ephemeris.h
+++ b/include/swiftnav/ephemeris.h
@@ -126,6 +126,10 @@ typedef enum {
   EPH_VALID
 } ephemeris_status_t;
 
+/* BDS satellites can be either geostationary (GEO), geosynchronous (IGSO) or
+ medium earth orbit (MEO) */
+typedef enum { GEO, IGSO, MEO } satellite_orbit_type_t;
+
 /** Structure containing the GPS ephemeris for one satellite. */
 typedef struct {
   union {
@@ -206,6 +210,7 @@ typedef struct {
     ephemeris_xyz_t xyz;       /**< Parameters specific to SBAS. */
     ephemeris_glo_t glo;       /**< Parameters specific to GLONASS. */
   };
+  satellite_orbit_type_t orb_type; /**< orbit type. */
 } ephemeris_t;
 
 #define GLO_NAV_STR_BITS 85 /**< Length of GLO navigation string */
@@ -222,10 +227,6 @@ typedef gps_time_t (*glo2gps_with_utc_params_t)(const glo_time_t *glo_t);
 /** \} */
 
 extern const float g_bds_ura_table[16];
-
-/* BDS satellites can be either geostationary (GEO), geosynchronous (IGSO) or
- medium earth orbit (MEO) */
-typedef enum { GEO, IGSO, MEO } satellite_orbit_type_t;
 
 s8 calc_sat_state(const ephemeris_t *e,
                   const gps_time_t *t,

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -493,8 +493,6 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
       om = k->omega0 + dt * om_dot - GPS_OMEGAE_DOT * e->toe.tow;
       break;
     case CONSTELLATION_BDS:
-      /* note that the condition is to be refined in near future to consider
-       * GEOs in BDS3 */
       if (e->orb_type == GEO) {
         om_dot = k->omegadot;
       }

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -522,7 +522,7 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
 
   /* transform GEO user-defined inertial system to BDCS, similar applies to
    * velocity and acceleration */
-  if (sid_to_constellation(e->sid)==CONSTELLATION_BDS && e->sid.sat<=5) {
+  if (e->orb_type == GEO) {
     double pos_bds[3];
     double sin_ome = sin(BDS2_OMEGAE_DOT*dt);
     double cos_ome = cos(BDS2_OMEGAE_DOT*dt);

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -37,6 +37,9 @@
  * based on modeling https://github.com/swift-nav/exafore_planning/issues/681 */
 #define GLO_MAX_STEP_NUM 30
 
+#define SIN_5 -0.0871557427476582
+#define COS_5  0.9961946980917456
+
 #define EPHEMERIS_INVALID_LOG_MESSAGE \
   "%s ephemeris (v:%d, fi:%d, [%d, %f]), [%d, %f]"
 
@@ -490,7 +493,14 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
       om = k->omega0 + dt * om_dot - GPS_OMEGAE_DOT * e->toe.tow;
       break;
     case CONSTELLATION_BDS:
-      om_dot = k->omegadot - BDS2_OMEGAE_DOT;
+      /* note that the condition is to be refined in near future to consider
+       * GEOs in BDS3 */
+      if (e->orb_type == GEO) {
+        om_dot = k->omegadot;
+      }
+      else {
+        om_dot = k->omegadot - BDS2_OMEGAE_DOT;
+      }
       om = k->omega0 + dt * om_dot -
            BDS2_OMEGAE_DOT * (e->toe.tow - BDS_SECOND_TO_GPS_SECOND);
       break;
@@ -509,6 +519,21 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
   pos[0] = x * cos(om) - y * cos(inc) * sin(om);
   pos[1] = x * sin(om) + y * cos(inc) * cos(om);
   pos[2] = y * sin(inc);
+
+  /* transform GEO user-defined inertial system to BDCS, similar applies to
+   * velocity and acceleration */
+  if (sid_to_constellation(e->sid)==CONSTELLATION_BDS && e->sid.sat<=5) {
+    double pos_bds[3];
+    double sin_ome = sin(BDS2_OMEGAE_DOT*dt);
+    double cos_ome = cos(BDS2_OMEGAE_DOT*dt);
+    pos_bds[0] =  pos[0]*cos_ome+pos[1]*sin_ome*COS_5+pos[2]*sin_ome*SIN_5;
+    pos_bds[1] = -pos[0]*sin_ome+pos[1]*cos_ome*COS_5+pos[2]*cos_ome*SIN_5;
+    pos_bds[2] = -pos[1]*SIN_5+pos[2]*COS_5;
+
+    pos[0] = pos_bds[0];
+    pos[1] = pos_bds[1];
+    pos[2] = pos_bds[2];
+  }
 
   /* Compute the satellite's velocity in Earth-Centered Earth-Fixed
    * coordiates. */


### PR DESCRIPTION
In the current code base, when we process BDS with GEO satellites, large residuals are found in the residuals which results in a failure in the PPP filter. The GEO satellites are all flagged as outliers because the broadcast orbit calculation is incorrect.

To solve this problem, basically in `calc_sat_state_kepler`, we need to introduce an identifier to tell whether is it a GEO satellite or not, and then use the corresponding algorithm for broadcast orbit calculation.

Seems two approaches to do this. The first one is to introduce a new parameter in the function input, which means there are several associated functions need to be modified as well. The second one is to introduce a new member `satellite_orbit_type_t` in the `ephemeris_t` structure and then assign the orbit type before the orbit calculation functions are called.

I implemented the second approach (have no problem of implementing the first one) with the intention to minimise code change, but i am not sure whether it consumes too much memory or not for other purposes, what do you guys think (only need to see if it is appropriate to add a member in `ephemeris_t` structure in `ephemeris.h` file)?