### PR TITLE
Increase number of BDS sats

### DIFF
--- a/include/swiftnav/signal.h
+++ b/include/swiftnav/signal.h
@@ -33,7 +33,7 @@ extern "C" {
  * refer to https://igscb.jpl.nasa.gov/pipermail/igsmail/2012/007771.html and
  * https://igscb.jpl.nasa.gov/pipermail/igsmail/2015/008391.html */
 #define NUM_SATS_GLO 28
-#define NUM_SATS_BDS 61
+#define NUM_SATS_BDS 64
 #define NUM_SATS_GAL 36
 #define NUM_SATS_QZS 10
 

--- a/include/swiftnav/signal.h
+++ b/include/swiftnav/signal.h
@@ -33,7 +33,7 @@ extern "C" {
  * refer to https://igscb.jpl.nasa.gov/pipermail/igsmail/2012/007771.html and
  * https://igscb.jpl.nasa.gov/pipermail/igsmail/2015/008391.html */
 #define NUM_SATS_GLO 28
-#define NUM_SATS_BDS 37
+#define NUM_SATS_BDS 61
 #define NUM_SATS_GAL 36
 #define NUM_SATS_QZS 10
 

--- a/tests/check_signal.c
+++ b/tests/check_signal.c
@@ -224,6 +224,14 @@ START_TEST(test_signal_properties) {
       {.sid = {.code = CODE_GPS_L2P, .sat = 24},
        .valid = true,
        .str = "GPS L2P 24"},
+      {.sid = {.code = CODE_BDS2_B1, .sat = 0}, .valid = false},
+      {.sid = {.code = CODE_BDS2_B1, .sat = 1},
+       .valid = true,
+       .str = "BDS B1 1"},
+      {.sid = {.code = CODE_BDS2_B1, .sat = 41},
+       .valid = true,
+       .str = "BDS B1 41"},
+      {.sid = {.code = CODE_BDS2_B1, .sat = 65}, .valid = false},
   };
 
   for (u32 i = 0; i < sizeof(test_cases) / sizeof(test_cases[0]); i++) {


### PR DESCRIPTION
Increases `NUM_SATS_BDS` to allow for highest GNSS launched PRN of 61.
There are only 49 BDS2/3 satellites.

https://www.glonass-iac.ru/en/BEIDOU/
https://en.wikipedia.org/wiki/List_of_BeiDou_satellites

Does this have negative impact to limited static allocations?
Should these be renamed to `BDS_LAST_PRN` if they are not actually used as the number of satellites?
Example 1:
https://github.com/swift-nav/gnss-converters/blob/4d993bfe8e56984a977468050130134d82dd141a/c/src/gnss_converters/ubx_ephemeris/bds.c#L73
Example 2:
https://github.com/swift-nav/libswiftnav/blob/a7eb7d8dd947962b082f80df8403034e0f384d32/src/signal.c#L1043

How much work is it to allocate for non-consecutive PRNs, being more space efficient and accurate to the name `NUM_SATS_BDS`?

Should we be changing the Num Signals variables to reflect BDS2/3 sats and GPS L5 sats not all emitting every signal? ... or does that create more complications? Are entries filled by indexing on PRN, or first come first served?
Does being more efficient risk being too inflexible to constellation changes?