### PR TITLE
[SO-32] Update num of msgs in group_meta in fuzed wagon

### DIFF
--- a/include/swiftnav/pvt_result.h
+++ b/include/swiftnav/pvt_result.h
@@ -63,7 +63,7 @@ extern "C" {
 #define GROUP_META_ID_UNKNOWN 0
 #define GROUP_META_ID_FUSION_BESTPOS 1
 #define GROUP_META_ID_GNSS 2
-#define GROUP_META_N_GROUP_MSGS 15
+#define GROUP_META_N_GROUP_MSGS 14
 /* max number of elements in msg_group_soln_meta.sol_in array */
 #define SOLN_META_MAX_N_SOL_IN 20
 


### PR DESCRIPTION
SBP_MSG_GROUP_META is part of Fuzed Wagon output and contains a field, .group_msgs, which is an array that stores the list of all msg_ids in the Fuzed Wagon, except the msg_id of SBP_MSG_GROUP_META itself, that we have now removed from this list, hence the decrement from 15 to 14.