### PR TITLE
[SCB-102] Assert on invalid tow.

### DIFF
--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -338,6 +338,8 @@ static s8 calc_sat_state_kepler(const ephemeris_t *e,
                                 double acc[3],
                                 double *clock_err,
                                 double *clock_rate_err) {
+  assert(e->toe.tow < WEEK_SECS);
+  assert(t->tow < WEEK_SECS);
   const ephemeris_kepler_t *k = &e->kepler;
 
   /* Calculate satellite clock terms */


### PR DESCRIPTION
In SCB-102 we encountered an issue in which the times encoded in BDS ephemeris messages were not normalized which caused very large outliers do to erroneous computations inside `calc_sat_state` which assume that all times are normalized.  This is actually the second time we've tracked down this same bug and both times required a large amount of man hours.

In order to prevent future issues like this I've added an assertion which will cause a hard failure if an ephemeris has an invalid time.  One alternative would be to normalize all unnormalized times.