### PR TITLE
Added the macro_overload.h to the install list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(HDRS
     include/swiftnav/ionosphere.h
     include/swiftnav/linear_algebra.h
     include/swiftnav/logging.h
+    include/swiftnav/macro_overload.h
     include/swiftnav/memcpy_s.h
     include/swiftnav/nav_meas.h
     include/swiftnav/pvt_result.h


### PR DESCRIPTION
Fix for a bug found in https://github.com/swift-nav/swiftnav-rs/pull/57, preventing the submodule update to proceed.