### PR TITLE
ci: don't generate clang-tidy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,4 +128,4 @@ if(libswiftnav_BUILD_TESTS OR libswiftnav_BUILD_TEST_LIBS)
 endif()
 
 swift_validate_targets()
-swift_create_clang_tidy_targets()
+swift_create_clang_tidy_targets(DONT_GENERATE_CLANG_TIDY_CONFIG)


### PR DESCRIPTION
This prevents clang-tidy targets from generating a `.clang-tidy` in the source dir.  This is a temporary fix, long term fix is here: https://github.com/swift-nav/cmake/pull/109.  This is necessary for `swiftnav-rs` build since the release and publish process (validated by `cargo release minor`) wants to make sure that the build doesn't modify things outside of the build dir.