### PR TITLE
Added Makefile with bazel wrappers [BUILD-360]

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+build:clang-format-check --aspects @rules_swiftnav//clang_format:clang_format_check.bzl%clang_format_check_aspect
+build:clang-format-check --@rules_swiftnav//clang_format:clang_format_config=//:clang_format_config
+build:clang-format-check --output_groups=report
+
+build:clang-tidy --aspects @rules_swiftnav//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(":bazel/configure_file.bzl", "configure_file")
 load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_test")
 
 refresh_compile_commands(
     name = "refresh_compile_commands",
@@ -99,8 +100,9 @@ cc_library(
     deps = ["//:swiftnav"],
 )
 
-cc_test(
+swift_cc_test(
     name = "swiftnav-test",
+    type = UNIT,
     srcs = [
         "tests/check_almanac.c",
         "tests/check_bits.c",
@@ -131,4 +133,10 @@ cc_test(
         "//:swiftnav",
         "@my-check//:check",
     ],
+)
+
+filegroup(
+    name = "clang_format_config",
+    srcs = [".clang-format"],
+    visibility = ["//visibility:public"],
 )

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,24 @@ docker-build: docker-image
 docker-lint: docker-image
 	mkdir -p build
 	docker-compose run -T libswiftnav /bin/bash -c "cd build && cmake .. && make -j4 clang-format-all"
+
+do-all-unit-tests:
+	bazel test --test_tag_filters=unit --test_output=all //...
+
+do-all-integration-tests:
+	bazel test --test_tag_filters=integration --test_output=all //...
+
+clang-format-all-check:
+	bazel build //... --config=clang-format-check
+
+clang-format-all:
+	bazel run @rules_swiftnav//clang_format
+
+clang-tidy-all-check:
+	bazel build //... --config=clang-tidy
+
+do-code-coverage:
+	bazel coverage --test_tag_filters=unit --collect_code_coverage --combined_report=lcov //...
+
+do-generate-coverage-report: do-code-coverage
+	genhtml bazel-out/_coverage/_coverage_report.dat -o coverage

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,18 @@
 workspace(name = "root")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_swiftnav",
+    strip_prefix = "rules_swiftnav-e59de2d94814156ab50b467f562c8bb29beffc3c",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/e59de2d94814156ab50b467f562c8bb29beffc3c.tar.gz"
+)
+
 new_local_repository(
     name = "my-check",
     build_file = "bazel/check.BUILD",
     path = "third_party/check",
 )
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_foreign_cc",


### PR DESCRIPTION
Adding Makefile wrappers for commonly used bazel commands to make it easier for developers to start using bazel.

Added targets:
* do-all-unit-tests
* do-all-integration-tests
* clang-format-all-check
* clang-format-all
* clang-tidy-all-check
* do-code-coverage
* do-generate-coverage-report

# Design Notes
* I'm using aspects to run `clang-format` and `clang-tidy` on each file. You can see the setup in `.bazelrc`
* I'm loading `.clang-format` configuration in `.bazelrc`
* Replaced `cc_test` with `swift_cc_test` so that at leas one tests runs with `do-all-unit-tests`

# Jira
https://swift-nav.atlassian.net/browse/BUILD-360